### PR TITLE
Includes code to bootstrap tfstate managing resources for a staging env

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -30,6 +30,10 @@ cd bootstrap/dev
 AWS_PROFILE=dev_profile_name tofu init
 AWS_PROFILE=dev_profile_name tofu apply
 
+cd ../staging
+AWS_PROFILE=staging_profile_name tofu init
+AWS_PROFILE=staging_profile_name tofu apply
+
 cd ../prod
 AWS_PROFILE=prod_profile_name tofu init
 AWS_PROFILE=prod_profile_name tofu apply
@@ -37,7 +41,7 @@ AWS_PROFILE=prod_profile_name tofu apply
 
 ## Regular operation
 
-In the top-level dir, any time you're switching between the `dev` or `prod` envs, you'll have to reconfigure the state. For example, if you've been building to `prod` but want to switch to building to `dev`, you'd have to run this command.
+In the top-level dir, any time you're switching between the `dev`, `staging`, or `prod` envs, you'll have to reconfigure the state. For example, if you've been building to `prod` but want to switch to building to `dev`, you'd have to run this command.
 
 ```console
 $ AWS_PROFILE=dev_profile_name tofu init -var-file=dev.tfvars -reconfigure

--- a/infra/bootstrap/staging/.terraform.lock.hcl
+++ b/infra/bootstrap/staging/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.28.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:tcau98fkhZ2RhbPHo8LdiiUk2RGpZUgT/t06sdMLids=",
+    "zh:38d58305206953783c150fb96d5c4f3ea5fe0b9e0987d927c884a6b0f2adf7a9",
+    "zh:43fd483251165f98b7a44360b41b437d309b007ef2bfff818eedcf3730e3f5cb",
+    "zh:4753decc5a718cb74b08244a02d00c150f0ddd6ebf2e1227f6a985c647c03ce9",
+    "zh:5956525650554bd3fbc4b695eb5250193f0ebf94c45862a7730457ab6a315069",
+    "zh:76d98fa1146750c01f607bae4421952ee9cd14ed3a4a59deb7136749adb9e0ae",
+    "zh:792c29e5ec91356baddb6219ac7f6f1df09c251cbe4ab6e089fc25d64270b22a",
+    "zh:856424380caa7c1536dc00515d12beac2693db1a8425da654eed5530abeb17d9",
+    "zh:e8982ec2bc692efa7236e3565e7094a09f52c5b71d8860a570a36fb31a40f27f",
+    "zh:f5e7ff825dc3f7356fb80936bfe7bb1b54a728ccf429cb753cfe590932f0403b",
+  ]
+}

--- a/infra/bootstrap/staging/main.tf
+++ b/infra/bootstrap/staging/main.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = "us-east-2"
+}
+
+module "state" {
+  source  = "../../modules/state"
+
+  basename = "loci-infra"
+  environment = "staging"
+}


### PR DESCRIPTION
Facilitates easy bootstrapping of a bucket and DynamoDB locking table to store and lock tfstate for a `staging` env in a separate AWS account from the Dev and Prod AWS accounts.

Closes #5 