### PR TITLE
Adds pre-collection schema check to Socrata API collection and drops computed_field columns

### DIFF
--- a/platform/airflow/plugins/sources/update_configs.py
+++ b/platform/airflow/plugins/sources/update_configs.py
@@ -30,7 +30,7 @@ CHICAGO_FOOD_INSPECTIONS = DatasetUpdateConfig(
 )
 
 CHICAGO_SIDEWALK_CAFE_PERMITS = DatasetUpdateConfig(
-    dataset_id="4ijn-s7e5",
+    dataset_id="nxj5-ix6z",
     dataset_name="chicago_sidewalk_cafe_permits",
     full_update_cron="5 5 1-7 * 0",
     update_cron="5 5 * * *",
@@ -124,8 +124,7 @@ CHICAGO_ADDITIONAL_DWELLING_UNIT_PREAPPROVAL_APPLICATIONS = DatasetUpdateConfig(
 COOK_COUNTY_RESIDENTIAL_CONDOMINIUM_UNIT_CHARACTERISTICS = DatasetUpdateConfig(
     dataset_id="3r7i-mrz4",
     dataset_name="cook_county_residential_condominium_unit_characteristics",
-    # full_update_cron="10 5 1-7 * 6",
-    full_update_cron="* * * * *",
+    full_update_cron="10 5 1-7 * 6",
     update_cron="10 5 * * *",
     entity_key=["row_id"],
     full_update_mode="file_download",

--- a/platform/migrations/postgres/V16__drop_computed_region_socrata_cols.sql
+++ b/platform/migrations/postgres/V16__drop_computed_region_socrata_cols.sql
@@ -1,0 +1,137 @@
+alter table raw_data.chicago_building_permits
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu",
+  drop column if exists ":@computed_region_awaf_s7ux";
+
+alter table raw_data.chicago_park_district_activities
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_8hcu_yrd4";
+
+alter table raw_data.chicago_311_service_requests
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu",
+  drop column if exists ":@computed_region_du4m_ji7t";
+
+alter table raw_data.chicago_relocated_vehicles
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu",
+  drop column if exists ":@computed_region_awaf_s7ux";
+
+alter table raw_data.open_air_chicago_individual_measurements
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_8hcu_yrd4";
+
+alter table raw_data.chicago_homicide_and_non_fatal_shooting_victimizations
+  drop column if exists ":@computed_region_d3ds_rm58",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_43wa_7qmu",
+  drop column if exists ":@computed_region_d9mm_jgwp";
+
+alter table raw_data.chicago_arrests
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu";
+
+alter table raw_data.chicago_crimes
+  drop column if exists ":@computed_region_awaf_s7ux",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu",
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_d9mm_jgwp",
+  drop column if exists ":@computed_region_d3ds_rm58",
+  drop column if exists ":@computed_region_8hcu_yrd4";
+
+alter table raw_data.chicago_divvy_bicycle_stations
+  drop column if exists ":@computed_region_awaf_s7ux",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu",
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_8hcu_yrd4";
+
+alter table raw_data.chicago_speed_camera_locations
+  drop column if exists ":@computed_region_awaf_s7ux",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu";
+
+alter table raw_data.chicago_red_light_camera_locations
+  drop column if exists ":@computed_region_awaf_s7ux",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu";
+
+alter table raw_data.chicago_red_light_camera_violations
+  drop column if exists ":@computed_region_awaf_s7ux",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu";
+
+alter table raw_data.chicago_speed_camera_violations
+  drop column if exists ":@computed_region_awaf_s7ux",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu";
+
+alter table raw_data.chicago_potholes_patched
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu";
+
+alter table raw_data.chicago_business_licenses
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_awaf_s7ux",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu";
+
+alter table raw_data.chicago_sidewalk_cafe_permits
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu";
+
+alter table raw_data.chicago_food_inspections
+  drop column if exists ":@computed_region_awaf_s7ux",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu";
+
+alter table raw_data.chicago_additional_dwelling_unit_preapproval_applications
+  drop column if exists ":@computed_region_rpca_8um6",
+  drop column if exists ":@computed_region_vrxf_vc4k",
+  drop column if exists ":@computed_region_6mkv_f3dw",
+  drop column if exists ":@computed_region_bdys_3d7i",
+  drop column if exists ":@computed_region_43wa_7qmu";
+
+alter table raw_data.chicago_traffic_crashes_crashes
+  drop column if exists ":@computed_region_rpca_8um6";


### PR DESCRIPTION
The logic for the main purpose of this PR (fixing a specific schema drift instance) is well documented in Issue #36.

Changes:
* Updates the `SocrataTableMetadata` class's `generate_ddl` method to add system Socrata columns as well as optionally add fields needed to implement SCD2.
* Adds a "pre-flight check" to the Socrata incremental update collection mode which compares the columns in the API-call responses against the schema of the `target_table` and then short-circuits the collection if new columns have appeared in the source. This notifies the maintainer (by way of a failed Airflow DAG run) that one+ new columns must be added to the `target_table` via a migration script.
* Adds a method to filter out `:@computed_regiojn_...` columns before attempting to ingest them.
* Updates SocrataTests.