### PR TITLE
Adds staging and marts models for bike crashes.

### DIFF
--- a/platform/airflow/dags/dag_files/dbt_build_dag.py
+++ b/platform/airflow/dags/dag_files/dbt_build_dag.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import subprocess
+from datetime import datetime
 
 from airflow.sdk import dag, task
 
@@ -21,7 +21,7 @@ def dbt_build_dag():
                 "--project-dir",
                 "/opt/airflow/dbt",
                 "--select",
-                "chicago_homicide_and_non_fatal_shooting_victimizations",
+                "+stg__bike_involved_crashes+",
             ],
             capture_output=True,
             text=True,

--- a/platform/airflow/dags/loci/sources/update_configs.py
+++ b/platform/airflow/dags/loci/sources/update_configs.py
@@ -358,7 +358,8 @@ CHICAGO_311_SERVICE_REQUESTS = DatasetUpdateConfig(
     spec=specs.CHICAGO_311_SERVICE_REQUESTS_SPEC,
     full_update_cron="0 0 1-7 1,4,7,10 0",
     update_cron="30 4 * * 1,4",
-    full_update_mode="file_download",
+    full_update_mode="api",
+    # full_update_mode="file_download",
 )
 
 CHICAGO_TOWED_VEHICLES = DatasetUpdateConfig(
@@ -464,7 +465,7 @@ CHICAGO_ARRESTS = DatasetUpdateConfig(
 CHICAGO_CRIMES = DatasetUpdateConfig(
     spec=specs.CHICAGO_CRIMES_SPEC,
     full_update_cron="0 1 1-7 * 1",
-    update_cron="10 1 * * *",
+    update_cron="10 1 * * 1",
     full_update_mode="file_download",
 )
 

--- a/platform/dbt/dbt_project.yml
+++ b/platform/dbt/dbt_project.yml
@@ -24,12 +24,11 @@ clean-targets:         # directories to be removed by `dbt clean`
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
-
-# In this example config, we tell dbt to build all models in the example/
-# directory as views. These settings can be overridden in the individual model
-# files using the `{{ config(...) }}` macro.
 models:
   loci:
     staging:
       +materialized: table
       +schema: staging
+    marts:
+      +materialized: table
+      +schema: marts

--- a/platform/dbt/models/marts/cycling/bike_crash_hotspots.sql
+++ b/platform/dbt/models/marts/cycling/bike_crash_hotspots.sql
@@ -1,0 +1,66 @@
+-- bike_commuter__crash_hotspots.sql
+-- Bike crash data aggregated for heatmap display.
+--
+-- Two output modes in one model:
+--   1. Individual crash points with a severity score (for zoomed-in view)
+--   2. Grid-cell aggregation (for zoomed-out heatmap view)
+--
+-- For the grid aggregation we use a simple lat/lon grid rather than H3
+-- to avoid the PostGIS H3 extension dependency. Each cell is roughly
+-- 200m x 200m (~0.002 degrees at Chicago's latitude).
+with crashes_with_severity as (
+    select
+        crash_record_id,
+        geom,
+        crash_date,
+        local_crash_date
+        local_crash_time,
+        local_crash_day_of_week,
+        first_crash_type,
+        most_severe_injury,
+        hit_and_run_i,
+        dooring_i,
+        weather_condition,
+        lighting_condition,
+        street_name,
+        street_direction,
+        prim_contributory_cause,
+        injuries_total,
+        injuries_fatal,
+        injuries_incapacitating,
+        case
+            when injuries_fatal > 0 then 5
+            when injuries_incapacitating > 0 then 4
+            when injuries_non_incapacitating > 0 then 3
+            when injuries_reported_not_evident > 0 then 2
+            else 1
+        end as severity_score,
+        extract(year from crash_date) as crash_year
+    from {{ ref('stg__bike_involved_crashes') }}
+)
+-- ,grid_agg as (
+--     select
+--         -- Snap to grid: round lat/lon to nearest 0.002 degrees
+--         round(ST_Y(geom)::numeric / 0.002) * 0.002 as grid_lat,
+--         round(ST_X(geom)::numeric / 0.002) * 0.002 as grid_lon,
+--         count(*) as crash_count,
+--         avg(severity_score) as avg_severity,
+--         max(severity_score) as max_severity,
+--         sum(case when dooring_i = 'Y' then 1 else 0 end) as dooring_count,
+--         sum(case when hit_and_run_i = 'Y' then 1 else 0 end) as hit_and_run_count,
+--         sum(injuries_fatal) as total_fatal,
+--         sum(injuries_incapacitating) as total_incapacitating,
+--         min(crash_date) as earliest_crash,
+--         max(crash_date) as latest_crash
+--     from crashes_with_severity
+--     group by grid_lat, grid_lon
+-- )
+
+-- Output the individual crash points (the app can aggregate client-side
+-- at different zoom levels, or use the grid_agg CTE for a pre-computed
+-- heatmap layer).
+--
+-- To use the grid aggregation instead, change the final select to:
+--   select *, ST_SetSRID(ST_MakePoint(grid_lon, grid_lat), 4326) as geom
+--   from grid_agg
+select * from crashes_with_severity

--- a/platform/dbt/models/staging/cycling/stg__bike_involved_crashes.sql
+++ b/platform/dbt/models/staging/cycling/stg__bike_involved_crashes.sql
@@ -1,0 +1,93 @@
+with bike_crash_ids as (
+    select crash_record_id
+    from {{ source('raw_data', 'chicago_traffic_crashes_vehicles') }}
+    where unit_type = 'BICYCLE' and valid_to is null
+        union
+    select crash_record_id
+    from {{ source('raw_data', 'chicago_traffic_crashes_people') }}
+    where person_type = 'BICYCLE' and valid_to is null
+        union
+    select crash_record_id
+    from {{ source('raw_data', 'chicago_traffic_crashes_crashes') }}
+    where first_crash_type = 'PEDALCYCLIST' and valid_to is null
+),
+crashes as (
+    select
+        crash_record_id,
+        crash_date,
+        crash_date at time zone 'America/Chicago' as local_crash_date,
+        to_char(crash_date at time zone 'America/Chicago', 'Day') as local_crash_day_of_week,
+        (crash_date at time zone 'America/Chicago')::time as local_crash_time,
+        -- Road context
+        posted_speed_limit,
+        traffic_control_device,
+        trafficway_type,
+        intersection_related_i,
+        roadway_surface_cond,
+        road_defect,
+        alignment,
+        lane_cnt,
+        -- Conditions
+        weather_condition,
+        lighting_condition,
+        -- Crash classification
+        first_crash_type,
+        crash_type,
+        prim_contributory_cause,
+        sec_contributory_cause,
+        most_severe_injury,
+        damage,
+        hit_and_run_i,
+        dooring_i,
+        -- Injury counts
+        injuries_total,
+        injuries_fatal,
+        injuries_incapacitating,
+        injuries_non_incapacitating,
+        injuries_reported_not_evident,
+        -- Location
+        street_no,
+        street_direction,
+        street_name,
+        beat_of_occurrence,
+        latitude,
+        longitude,
+        location as geom
+    from {{ source('raw_data', 'chicago_traffic_crashes_crashes') }}
+    inner join bike_crash_ids
+    using (crash_record_id)
+    where valid_to is null
+),
+bike_crash_people as (
+    select
+        person_id,
+        person_type,
+        crash_record_id,
+        vehicle_id,
+        pedpedal_action as cyclist_action,
+        pedpedal_visibility as cyclist_visibility,
+        pedpedal_location as cyclist_location,
+        sex,
+        age,
+        safety_equipment,
+        ejection,
+        injury_classification,
+        driver_action,
+        driver_vision,
+        physical_condition as driver_physical_condition,
+        bac_result,
+        bac_result_value,
+        cell_phone_use
+    from {{ source('raw_data', 'chicago_traffic_crashes_people') }}
+    where
+        valid_to is null
+        and person_type = 'BICYCLE'
+),
+merged as (
+    select *
+    from crashes
+    left join bike_crash_people
+    using (crash_record_id)
+)
+
+select * from merged


### PR DESCRIPTION
Changes:
* Adds staging and marts models for Chicago bike-involved crash data. (Closes #83)

The models built and contain the expected data.

<img width="1523" height="1042" alt="Screenshot from 2026-03-07 10-45-09" src="https://github.com/user-attachments/assets/4fb7bdb0-4073-4de7-8533-dc7385ab990c" />

<img width="1468" height="821" alt="Screenshot from 2026-03-07 10-50-03" src="https://github.com/user-attachments/assets/66ee85f7-24c0-4970-96a9-ddcaa3d53669" />

