### PR TITLE
Iss133 increase osmnx update freq

### DIFF
--- a/platform/airflow/dags/loci/collectors/osmnx/client.py
+++ b/platform/airflow/dags/loci/collectors/osmnx/client.py
@@ -39,7 +39,121 @@ import numpy as np
 from loci.collectors.utils import make_temp_dir
 from scipy.spatial import cKDTree
 
-log = logging.getLogger(__name__)
+# OSM tags to collect for edges, mapped to Postgres column names.
+# Colon-separated tags become underscore-separated columns so they
+# can be queried without double-quotes.
+#
+# Format: (osm_tag, column_name, column_type)
+# column_type is used in DDL generation; flatten always calls _to_str_or_none
+# except for the few non-text columns handled explicitly in _flatten_edges.
+EDGE_TAG_COLUMNS = [
+    # --- existing tags ---
+    ("name", "name", "text"),
+    ("highway", "highway", "text"),
+    ("oneway", "oneway", "boolean"),
+    ("reversed", "reversed", "text"),
+    ("maxspeed", "maxspeed", "text"),
+    ("surface", "surface", "text"),
+    ("lanes", "lanes", "text"),
+    ("ref", "ref", "text"),
+    ("service", "service", "text"),
+    ("width", "width", "text"),
+    ("lit", "lit", "text"),
+    ("access", "access", "text"),
+    ("bridge", "bridge", "text"),
+    ("tunnel", "tunnel", "text"),
+    # --- bicycle general ---
+    ("bicycle", "bicycle", "text"),
+    ("bicycle:lanes", "bicycle_lanes", "text"),
+    ("bicycle:lanes:backward", "bicycle_lanes_backward", "text"),
+    ("bicycle:lanes:forward", "bicycle_lanes_forward", "text"),
+    ("bicycle:right", "bicycle_right", "text"),
+    ("bicycle_road", "bicycle_road", "text"),
+    ("class:bicycle", "class_bicycle", "text"),
+    ("cyclestreet", "cyclestreet", "text"),
+    ("oneway:bicycle", "oneway_bicycle", "text"),
+    ("ramp:bicycle", "ramp_bicycle", "text"),
+    ("sidewalk:both:bicycle", "sidewalk_both_bicycle", "text"),
+    # --- cycleway general ---
+    ("cycleway", "cycleway", "text"),
+    ("cycleway:buffer", "cycleway_buffer", "text"),
+    ("cycleway:lane", "cycleway_lane", "text"),
+    ("cycleway:oneway", "cycleway_oneway", "text"),
+    ("cycleway:separation", "cycleway_separation", "text"),
+    ("cycleway:shared_lane", "cycleway_shared_lane", "text"),
+    ("cycleway:smoothness", "cycleway_smoothness", "text"),
+    ("cycleway:surface", "cycleway_surface", "text"),
+    # --- cycleway:both ---
+    ("cycleway:both", "cycleway_both", "text"),
+    ("cycleway:both:buffer", "cycleway_both_buffer", "text"),
+    ("cycleway:both:colour", "cycleway_both_colour", "text"),
+    ("cycleway:both:lane", "cycleway_both_lane", "text"),
+    ("cycleway:both:separation", "cycleway_both_separation", "text"),
+    ("cycleway:both:shared_lane", "cycleway_both_shared_lane", "text"),
+    ("cycleway:both:traffic_sign", "cycleway_both_traffic_sign", "text"),
+    # --- cycleway:left ---
+    ("cycleway:left", "cycleway_left", "text"),
+    ("cycleway:left:buffer", "cycleway_left_buffer", "text"),
+    ("cycleway:left:lane", "cycleway_left_lane", "text"),
+    ("cycleway:left:oneway", "cycleway_left_oneway", "text"),
+    ("cycleway:left:separation", "cycleway_left_separation", "text"),
+    ("cycleway:left:shared_lane", "cycleway_left_shared_lane", "text"),
+    ("cycleway:left:traffic_sign", "cycleway_left_traffic_sign", "text"),
+    # --- cycleway:right ---
+    ("cycleway:right", "cycleway_right", "text"),
+    ("cycleway:right:buffer", "cycleway_right_buffer", "text"),
+    ("cycleway:right:lane", "cycleway_right_lane", "text"),
+    ("cycleway:right:oneway", "cycleway_right_oneway", "text"),
+    ("cycleway:right:separation", "cycleway_right_separation", "text"),
+    ("cycleway:right:shared_lane", "cycleway_right_shared_lane", "text"),
+    ("cycleway:right:traffic_sign", "cycleway_right_traffic_sign", "text"),
+]
+
+# Tags that need to be added to ox.settings.useful_tags_way before fetching.
+# This is the union of all OSM tags in EDGE_TAG_COLUMNS that aren't already
+# in OSMnx's default useful_tags_way.
+EXTRA_USEFUL_TAGS_WAY = [
+    "bicycle",
+    "bicycle:lanes",
+    "bicycle:lanes:backward",
+    "bicycle:lanes:forward",
+    "bicycle:right",
+    "bicycle_road",
+    "class:bicycle",
+    "cyclestreet",
+    "cycleway",
+    "cycleway:both",
+    "cycleway:both:buffer",
+    "cycleway:both:colour",
+    "cycleway:both:lane",
+    "cycleway:both:separation",
+    "cycleway:both:shared_lane",
+    "cycleway:both:traffic_sign",
+    "cycleway:buffer",
+    "cycleway:lane",
+    "cycleway:left",
+    "cycleway:left:buffer",
+    "cycleway:left:lane",
+    "cycleway:left:oneway",
+    "cycleway:left:separation",
+    "cycleway:left:shared_lane",
+    "cycleway:left:traffic_sign",
+    "cycleway:oneway",
+    "cycleway:right",
+    "cycleway:right:buffer",
+    "cycleway:right:lane",
+    "cycleway:right:oneway",
+    "cycleway:right:separation",
+    "cycleway:right:shared_lane",
+    "cycleway:right:traffic_sign",
+    "cycleway:separation",
+    "cycleway:shared_lane",
+    "cycleway:smoothness",
+    "cycleway:surface",
+    "oneway:bicycle",
+    "ramp:bicycle",
+    "sidewalk:both:bicycle",
+]
 
 
 class OsmnxClient:
@@ -53,13 +167,23 @@ class OsmnxClient:
         '["service"!~"private"]'
     )
 
-    def __init__(self, cache_dir: str | Path | None = None):
+    EDGE_TAG_COLUMNS = EDGE_TAG_COLUMNS
+    EXTRA_USEFUL_TAGS_WAY = EXTRA_USEFUL_TAGS_WAY
+
+    def __init__(
+        self,
+        cache_dir: str | Path | None = None,
+        logger: logging.Logger | None = None,
+    ):
+        self.logger = logger or logging.getLogger(__name__)
+
         if cache_dir:
             self.cache_dir = Path(cache_dir)
             self._temp_dir_handle = None
         else:
             self.cache_dir, self._temp_dir_handle = make_temp_dir(prefix="osmnx_cache_")
         self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.logger.info("OsmnxClient initialized with cache_dir=%s", self.cache_dir)
 
     # ------------------------------------------------------------------ #
     #  Public API
@@ -71,6 +195,7 @@ class OsmnxClient:
         network_type: str = "bike",
         include_bikeable_footways: bool = True,
         merge_threshold_meters: float | None = 15,
+        simplify: bool = True,
     ) -> nx.MultiDiGraph:
         """Fetch a bike network graph, optionally including bikeable footways.
 
@@ -101,14 +226,25 @@ class OsmnxClient:
         cache_path = self._cache_path(bbox, cache_key)
 
         if cache_path and cache_path.exists():
-            log.info("Loading cached graph from %s", cache_path)
+            self.logger.info("Loading cached graph from %s", cache_path)
             import osmnx as ox
 
-            return ox.load_graphml(cache_path)
+            G = ox.load_graphml(cache_path)
+            self.logger.info(
+                "Loaded cached graph: %d nodes, %d edges",
+                G.number_of_nodes(),
+                G.number_of_edges(),
+            )
+            return G
+
+        self.logger.info(
+            "No cache found at %s, fetching from Overpass API",
+            cache_path,
+        )
 
         # --- Base bike network ---
         G = self._fetch_graph(bbox, network_type=network_type)
-        log.info(
+        self.logger.info(
             "Base bike graph: %d nodes, %d edges",
             G.number_of_nodes(),
             G.number_of_edges(),
@@ -122,8 +258,9 @@ class OsmnxClient:
                     bbox,
                     network_type=None,
                     custom_filter=self._BIKEABLE_FOOTWAY_FILTER,
+                    simplify=simplify,
                 )
-                log.info(
+                self.logger.info(
                     "Bikeable footways graph: %d nodes, %d edges",
                     G_footways.number_of_nodes(),
                     G_footways.number_of_edges(),
@@ -131,7 +268,7 @@ class OsmnxClient:
                 # Track which nodes are footway-only (not already in the base graph)
                 footway_nodes = set(G_footways.nodes) - set(G.nodes)
                 G = self._merge_graphs(G, G_footways)
-                log.info(
+                self.logger.info(
                     "Merged graph: %d nodes, %d edges (%d footway-only nodes)",
                     G.number_of_nodes(),
                     G.number_of_edges(),
@@ -139,7 +276,7 @@ class OsmnxClient:
                 )
             except Exception as e:
                 if "Found no graph nodes" in str(e) or "EmptyOverpassResponse" in str(e):
-                    log.info("No bikeable footways found in bbox %s, skipping merge", bbox)
+                    self.logger.info("No bikeable footways found in bbox %s, skipping merge", bbox)
                 else:
                     raise
 
@@ -149,12 +286,13 @@ class OsmnxClient:
                 G,
                 threshold_meters=merge_threshold_meters,
                 cross_graph_nodes=footway_nodes,
+                logger=self.logger,
             )
 
         if cache_path:
             import osmnx as ox
 
-            log.info("Caching graph to %s", cache_path)
+            self.logger.info("Caching graph to %s", cache_path)
             ox.save_graphml(G, cache_path)
 
         return G
@@ -178,13 +316,13 @@ class OsmnxClient:
         bbox: tuple[float, float, float, float],
         network_type: str | None = "bike",
         custom_filter: str | None = None,
+        simplify: bool = True,
     ) -> nx.MultiDiGraph:
         """Download a single graph from Overpass via OSMnx."""
         import osmnx as ox
-        from loci.collectors.osmnx.collector import EXTRA_USEFUL_TAGS_WAY
 
         # Ensure our cycling tags are included in the download
-        for tag in EXTRA_USEFUL_TAGS_WAY:
+        for tag in self.EXTRA_USEFUL_TAGS_WAY:
             if tag not in ox.settings.useful_tags_way:
                 ox.settings.useful_tags_way.append(tag)
 
@@ -198,6 +336,14 @@ class OsmnxClient:
             kwargs["network_type"] = None
         else:
             kwargs["network_type"] = network_type
+        kwargs["simplify"] = simplify
+
+        self.logger.info(
+            "Fetching graph from Overpass: bbox=%s, network_type=%s, custom_filter=%s",
+            bbox,
+            kwargs.get("network_type"),
+            custom_filter,
+        )
 
         return ox.graph_from_bbox(**kwargs)
 
@@ -231,6 +377,7 @@ class OsmnxClient:
         G: nx.MultiDiGraph,
         threshold_meters: float = 15,
         cross_graph_nodes: set | None = None,
+        logger: logging.Logger | None = None,
     ) -> nx.MultiDiGraph:
         """Merge nodes that are within `threshold_meters` of each other.
 
@@ -251,12 +398,16 @@ class OsmnxClient:
             Node IDs that came from the supplemental graph (e.g. footways).
             If provided, only pairs where exactly one node is in this set
             will be merged. The base-graph node is always kept.
+        logger : logging.Logger or None
+            Logger instance. Falls back to module-level logger if None.
 
         Returns
         -------
         nx.MultiDiGraph
             A copy of the graph with near-duplicate nodes contracted.
         """
+        _log = logger or logging.getLogger(__name__)
+
         nodes = list(G.nodes(data=True))
         node_ids = [n for n, _ in nodes]
 
@@ -330,7 +481,7 @@ class OsmnxClient:
         # Resolve transitive chains: if A→B and B→C, make A→C
         merge_map = {k: OsmnxClient._resolve_merge_chain(merge_map, k) for k in merge_map}
 
-        log.info(
+        _log.info(
             "connect_near_nodes: %d pairs to merge, "
             "skipped %d (same graph), %d (layer mismatch), "
             "%d (grade separation mismatch)",
@@ -343,7 +494,7 @@ class OsmnxClient:
         if not merge_map:
             return G
 
-        return OsmnxClient._apply_merges(G, merge_map)
+        return OsmnxClient._apply_merges(G, merge_map, logger=_log)
 
     # ------------------------------------------------------------------ #
     #  Vertical separation helpers
@@ -415,12 +566,15 @@ class OsmnxClient:
     def _apply_merges(
         G: nx.MultiDiGraph,
         merge_map: dict,
+        logger: logging.Logger | None = None,
     ) -> nx.MultiDiGraph:
         """Rewire edges and remove merged nodes.
 
         For each dropped node, all its edges are rewired to point to/from
         the kept node instead, then the dropped node is removed.
         """
+        _log = logger or logging.getLogger(__name__)
+
         G_new = G.copy()
 
         for drop, keep in merge_map.items():
@@ -441,7 +595,7 @@ class OsmnxClient:
 
             G_new.remove_node(drop)
 
-        log.info(
+        _log.info(
             "After merging: %d nodes, %d edges",
             G_new.number_of_nodes(),
             G_new.number_of_edges(),

--- a/platform/airflow/dags/loci/collectors/osmnx/client.py
+++ b/platform/airflow/dags/loci/collectors/osmnx/client.py
@@ -194,7 +194,7 @@ class OsmnxClient:
         bbox: tuple[float, float, float, float],
         network_type: str = "bike",
         include_bikeable_footways: bool = True,
-        merge_threshold_meters: float | None = 15,
+        merge_threshold_meters: float | None = 10,
         simplify: bool = True,
     ) -> nx.MultiDiGraph:
         """Fetch a bike network graph, optionally including bikeable footways.

--- a/platform/airflow/dags/loci/collectors/osmnx/collector.py
+++ b/platform/airflow/dags/loci/collectors/osmnx/collector.py
@@ -29,123 +29,6 @@ from loci.tracking.ingestion_tracker import IngestionTracker
 logger = logging.getLogger(__name__)
 
 
-# OSM tags to collect for edges, mapped to Postgres column names.
-# Colon-separated tags become underscore-separated columns so they
-# can be queried without double-quotes.
-#
-# Format: (osm_tag, column_name, column_type)
-# column_type is used in DDL generation; flatten always calls _to_str_or_none
-# except for the few non-text columns handled explicitly in _flatten_edges.
-EDGE_TAG_COLUMNS = [
-    # --- existing tags ---
-    ("name", "name", "text"),
-    ("highway", "highway", "text"),
-    ("oneway", "oneway", "boolean"),
-    ("reversed", "reversed", "text"),
-    ("maxspeed", "maxspeed", "text"),
-    ("surface", "surface", "text"),
-    ("lanes", "lanes", "text"),
-    ("ref", "ref", "text"),
-    ("service", "service", "text"),
-    ("width", "width", "text"),
-    ("lit", "lit", "text"),
-    ("access", "access", "text"),
-    ("bridge", "bridge", "text"),
-    ("tunnel", "tunnel", "text"),
-    # --- bicycle general ---
-    ("bicycle", "bicycle", "text"),
-    ("bicycle:lanes", "bicycle_lanes", "text"),
-    ("bicycle:lanes:backward", "bicycle_lanes_backward", "text"),
-    ("bicycle:lanes:forward", "bicycle_lanes_forward", "text"),
-    ("bicycle:right", "bicycle_right", "text"),
-    ("bicycle_road", "bicycle_road", "text"),
-    ("class:bicycle", "class_bicycle", "text"),
-    ("cyclestreet", "cyclestreet", "text"),
-    ("oneway:bicycle", "oneway_bicycle", "text"),
-    ("ramp:bicycle", "ramp_bicycle", "text"),
-    ("sidewalk:both:bicycle", "sidewalk_both_bicycle", "text"),
-    # --- cycleway general ---
-    ("cycleway", "cycleway", "text"),
-    ("cycleway:buffer", "cycleway_buffer", "text"),
-    ("cycleway:lane", "cycleway_lane", "text"),
-    ("cycleway:oneway", "cycleway_oneway", "text"),
-    ("cycleway:separation", "cycleway_separation", "text"),
-    ("cycleway:shared_lane", "cycleway_shared_lane", "text"),
-    ("cycleway:smoothness", "cycleway_smoothness", "text"),
-    ("cycleway:surface", "cycleway_surface", "text"),
-    # --- cycleway:both ---
-    ("cycleway:both", "cycleway_both", "text"),
-    ("cycleway:both:buffer", "cycleway_both_buffer", "text"),
-    ("cycleway:both:colour", "cycleway_both_colour", "text"),
-    ("cycleway:both:lane", "cycleway_both_lane", "text"),
-    ("cycleway:both:separation", "cycleway_both_separation", "text"),
-    ("cycleway:both:shared_lane", "cycleway_both_shared_lane", "text"),
-    ("cycleway:both:traffic_sign", "cycleway_both_traffic_sign", "text"),
-    # --- cycleway:left ---
-    ("cycleway:left", "cycleway_left", "text"),
-    ("cycleway:left:buffer", "cycleway_left_buffer", "text"),
-    ("cycleway:left:lane", "cycleway_left_lane", "text"),
-    ("cycleway:left:oneway", "cycleway_left_oneway", "text"),
-    ("cycleway:left:separation", "cycleway_left_separation", "text"),
-    ("cycleway:left:shared_lane", "cycleway_left_shared_lane", "text"),
-    ("cycleway:left:traffic_sign", "cycleway_left_traffic_sign", "text"),
-    # --- cycleway:right ---
-    ("cycleway:right", "cycleway_right", "text"),
-    ("cycleway:right:buffer", "cycleway_right_buffer", "text"),
-    ("cycleway:right:lane", "cycleway_right_lane", "text"),
-    ("cycleway:right:oneway", "cycleway_right_oneway", "text"),
-    ("cycleway:right:separation", "cycleway_right_separation", "text"),
-    ("cycleway:right:shared_lane", "cycleway_right_shared_lane", "text"),
-    ("cycleway:right:traffic_sign", "cycleway_right_traffic_sign", "text"),
-]
-
-# Tags that need to be added to ox.settings.useful_tags_way before fetching.
-# This is the union of all OSM tags in EDGE_TAG_COLUMNS that aren't already
-# in OSMnx's default useful_tags_way.
-EXTRA_USEFUL_TAGS_WAY = [
-    "bicycle",
-    "bicycle:lanes",
-    "bicycle:lanes:backward",
-    "bicycle:lanes:forward",
-    "bicycle:right",
-    "bicycle_road",
-    "class:bicycle",
-    "cyclestreet",
-    "cycleway",
-    "cycleway:both",
-    "cycleway:both:buffer",
-    "cycleway:both:colour",
-    "cycleway:both:lane",
-    "cycleway:both:separation",
-    "cycleway:both:shared_lane",
-    "cycleway:both:traffic_sign",
-    "cycleway:buffer",
-    "cycleway:lane",
-    "cycleway:left",
-    "cycleway:left:buffer",
-    "cycleway:left:lane",
-    "cycleway:left:oneway",
-    "cycleway:left:separation",
-    "cycleway:left:shared_lane",
-    "cycleway:left:traffic_sign",
-    "cycleway:oneway",
-    "cycleway:right",
-    "cycleway:right:buffer",
-    "cycleway:right:lane",
-    "cycleway:right:oneway",
-    "cycleway:right:separation",
-    "cycleway:right:shared_lane",
-    "cycleway:right:traffic_sign",
-    "cycleway:separation",
-    "cycleway:shared_lane",
-    "cycleway:smoothness",
-    "cycleway:surface",
-    "oneway:bicycle",
-    "ramp:bicycle",
-    "sidewalk:both:bicycle",
-]
-
-
 class OsmnxCollector:
     """Collects OSMnx bike network data and ingests into PostGIS.
 
@@ -177,9 +60,9 @@ class OsmnxCollector:
         logger: logging.Logger | None = None,
     ):
         self.engine = engine
-        self.client = client or OsmnxClient()
-        self.tracker = tracker or IngestionTracker(engine=self.engine)
         self.logger = logger or logging.getLogger("osmnx_collector")
+        self.client = client or OsmnxClient(logger=self.logger)
+        self.tracker = tracker or IngestionTracker(engine=self.engine)
 
     # ------------------------------------------------------------------
     # Collection
@@ -192,6 +75,14 @@ class OsmnxCollector:
 
         self.logger.info("Downloading %s", spec.name)
         G = self.client.get_bike_network(bbox=spec.bbox, network_type=spec.network_type)
+
+        self.logger.info(
+            "Graph for %s: %d nodes, %d edges (cache_dir=%s)",
+            spec.name,
+            G.number_of_nodes(),
+            G.number_of_edges(),
+            self.client.cache_dir,
+        )
 
         nodes_gdf = self.client.get_nodes_gdf(G)
         edges_gdf = self.client.get_edges_gdf(G)
@@ -222,20 +113,20 @@ class OsmnxCollector:
                 select 1 from {node_fqn}
                 where valid_to is null
                     and tile_id = %(tile_id)s
-                    and ingested_at >= now() - interval '%(mms)s months'
+                    and ingested_at >= now() - interval '{max_months_stale} months'
                 limit 1
                 """,
-                {"tile_id": tile_id, "mms": max_months_stale},
+                {"tile_id": tile_id},
             )
             edge_df = self.engine.query(
                 f"""
                 select 1 from {edge_fqn}
                 where valid_to is null
                     and tile_id = %(tile_id)s
-                    and ingested_at >= now() - interval '%(mms)s months'
+                    and ingested_at >= now() - interval '{max_months_stale} months'
                 limit 1
                 """,
-                {"tile_id": tile_id, "mms": max_months_stale},
+                {"tile_id": tile_id},
             )
             return (not node_df.empty) and (not edge_df.empty)
         except Exception as e:
@@ -397,7 +288,7 @@ class OsmnxCollector:
 
             # Extract all tag columns. The "oneway" tag is boolean;
             # everything else is text via _to_str_or_none.
-            for osm_tag, col_name, col_type in EDGE_TAG_COLUMNS:
+            for osm_tag, col_name, col_type in self.client.EDGE_TAG_COLUMNS:
                 if col_type == "boolean":
                     edge[col_name] = bool(row.get(osm_tag, False))
                 else:
@@ -530,8 +421,8 @@ class OsmnxCollector:
             "length_m double precision",
         ]
 
-        # Tag columns from the mapping
-        for _osm_tag, col_name, col_type in EDGE_TAG_COLUMNS:
+        # Tag columns from the client's mapping
+        for _osm_tag, col_name, col_type in self.client.EDGE_TAG_COLUMNS:
             columns.append(f"{col_name} {col_type}")
 
         # Geometry, tile, and SCD2 metadata

--- a/platform/airflow/dags/loci/sources/update_configs.py
+++ b/platform/airflow/dags/loci/sources/update_configs.py
@@ -608,9 +608,8 @@ OSM_RELATIONS_UPDATE_CONFIG = DatasetUpdateConfig(
 
 OSMNX_CHICAGO_BIKE_NETWORK_UC = DatasetUpdateConfig(
     spec=specs.OSMNX_CHICAGO_BIKE_NETWORK_SPEC,
-    update_cron="45 5 1-7 2,5,8,11 *",
+    update_cron="45 6 * * 4",
     full_update_week_of_month=1,
     full_update_day_of_week=4,
-    full_update_months=(2, 5, 8, 11),
     full_update_mode="api",
 )

--- a/platform/airflow/dags/loci/tasks/osmnx_tasks.py
+++ b/platform/airflow/dags/loci/tasks/osmnx_tasks.py
@@ -5,14 +5,14 @@ from airflow.sdk.bases.operator import chain
 from loci.collectors.osmnx.collector import OsmnxCollector
 from loci.db.af_utils import get_postgres_engine
 from loci.sources.update_configs import DatasetUpdateConfig
-from loci.tasks.task_utils import check_ingestion_log, choose_update_mode
+from loci.tasks.task_utils import check_ingestion_log
 from loci.tracking.ingestion_tracker import IngestionTracker
 
 
 def _get_collector(conn_id: str, task_logger: Logger) -> OsmnxCollector:
     pg_engine = get_postgres_engine(conn_id=conn_id, logger=task_logger)
     tracker = IngestionTracker(engine=pg_engine)
-    return OsmnxCollector(engine=pg_engine, tracker=tracker)
+    return OsmnxCollector(engine=pg_engine, logger=task_logger, tracker=tracker)
 
 
 @task
@@ -39,16 +39,16 @@ def update_osmnx_table(
     conn_id: str,
     task_logger: Logger,
 ) -> None:
-    _update_mode = choose_update_mode(update_config=update_config, task_logger=task_logger)
+    # _update_mode = choose_update_mode(update_config=update_config, task_logger=task_logger)
     _full_update = run_full_update(
         conn_id=conn_id, update_config=update_config, task_logger=task_logger
     )
-    _incremental_update = run_incremental_update(
-        conn_id=conn_id, update_config=update_config, task_logger=task_logger
-    )
+    # _incremental_update = run_incremental_update(
+    #     conn_id=conn_id, update_config=update_config, task_logger=task_logger
+    # )
     _check_ingestion_log = check_ingestion_log(
         conn_id=conn_id, update_config=update_config, task_logger=task_logger
     )
 
-    chain(_update_mode, _full_update, _check_ingestion_log)
-    chain(_update_mode, _incremental_update, _check_ingestion_log)
+    chain(_full_update, _check_ingestion_log)
+    # chain(_update_mode, _incremental_update, _check_ingestion_log)

--- a/platform/airflow/dags/loci/tasks/osmnx_tasks.py
+++ b/platform/airflow/dags/loci/tasks/osmnx_tasks.py
@@ -1,4 +1,6 @@
+import shutil
 from logging import Logger
+from pathlib import Path
 
 from airflow.sdk import task, task_group
 from airflow.sdk.bases.operator import chain
@@ -17,6 +19,12 @@ def _get_collector(conn_id: str, task_logger: Logger) -> OsmnxCollector:
 
 @task
 def run_full_update(update_config: DatasetUpdateConfig, conn_id: str, task_logger: Logger) -> bool:
+    import osmnx as ox
+
+    cache_path = Path(ox.settings.cache_folder).resolve()
+    if cache_path.is_dir():
+        task_logger.info(f"Clearing OSM cache from {cache_path}")
+        shutil.rmtree(cache_path)
     collector = _get_collector(conn_id, task_logger)
     summary_results = collector.collect(spec=update_config.spec, force=True)
     task_logger.info("Collection summary", extra={"payload": summary_results})
@@ -39,16 +47,11 @@ def update_osmnx_table(
     conn_id: str,
     task_logger: Logger,
 ) -> None:
-    # _update_mode = choose_update_mode(update_config=update_config, task_logger=task_logger)
     _full_update = run_full_update(
         conn_id=conn_id, update_config=update_config, task_logger=task_logger
     )
-    # _incremental_update = run_incremental_update(
-    #     conn_id=conn_id, update_config=update_config, task_logger=task_logger
-    # )
     _check_ingestion_log = check_ingestion_log(
         conn_id=conn_id, update_config=update_config, task_logger=task_logger
     )
 
     chain(_full_update, _check_ingestion_log)
-    # chain(_update_mode, _incremental_update, _check_ingestion_log)

--- a/platform/migrations/postgres/V34__redefine_raw_tables_for_osmnx_chicagoland_network.sql
+++ b/platform/migrations/postgres/V34__redefine_raw_tables_for_osmnx_chicagoland_network.sql
@@ -1,0 +1,111 @@
+create table raw_data.osmnx_chicago_network_nodes (
+    osmid bigint not null,
+    latitude double precision,
+    longitude double precision,
+    street_count integer,
+    highway text,
+    ref text,
+    geom geometry(Point, 4326),
+    tile_id text,
+    ingested_at timestamptz not null default (now() at time zone 'UTC'),
+    record_hash text not null,
+    valid_from timestamptz not null default (now() at time zone 'UTC'),
+    valid_to timestamptz
+);
+alter table raw_data.osmnx_chicago_network_nodes
+    add constraint uq_osmnx_chicago_network_nodes_entity_hash
+    unique (osmid, record_hash);
+create index ix_osmnx_chicago_network_nodes_current
+    on raw_data.osmnx_chicago_network_nodes (osmid)
+    where valid_to is null;
+create index ix_osmnx_chicago_network_nodes_geom
+    on raw_data.osmnx_chicago_network_nodes using gist (geom);
+create index ix_osmnx_chicago_network_nodes_tile_id
+    on raw_data.osmnx_chicago_network_nodes (tile_id)
+    where valid_to is null;
+
+
+create table raw_data.osmnx_chicago_network_edges (
+    u bigint not null,
+    v bigint not null,
+    key integer not null,
+    osmid text,
+    length_m double precision,
+    name text,
+    highway text,
+    oneway boolean,
+    reversed text,
+    maxspeed text,
+    surface text,
+    lanes text,
+    ref text,
+    service text,
+    width text,
+    lit text,
+    access text,
+    bridge text,
+    tunnel text,
+    bicycle text,
+    bicycle_lanes text,
+    bicycle_lanes_backward text,
+    bicycle_lanes_forward text,
+    bicycle_right text,
+    bicycle_road text,
+    class_bicycle text,
+    cyclestreet text,
+    oneway_bicycle text,
+    ramp_bicycle text,
+    sidewalk_both_bicycle text,
+    cycleway text,
+    cycleway_buffer text,
+    cycleway_lane text,
+    cycleway_oneway text,
+    cycleway_separation text,
+    cycleway_shared_lane text,
+    cycleway_smoothness text,
+    cycleway_surface text,
+    cycleway_both text,
+    cycleway_both_buffer text,
+    cycleway_both_colour text,
+    cycleway_both_lane text,
+    cycleway_both_separation text,
+    cycleway_both_shared_lane text,
+    cycleway_both_traffic_sign text,
+    cycleway_left text,
+    cycleway_left_buffer text,
+    cycleway_left_lane text,
+    cycleway_left_oneway text,
+    cycleway_left_separation text,
+    cycleway_left_shared_lane text,
+    cycleway_left_traffic_sign text,
+    cycleway_right text,
+    cycleway_right_buffer text,
+    cycleway_right_lane text,
+    cycleway_right_oneway text,
+    cycleway_right_separation text,
+    cycleway_right_shared_lane text,
+    cycleway_right_traffic_sign text,
+    geom geometry(LineString, 4326),
+    tile_id text,
+    ingested_at timestamptz not null default (now() at time zone 'UTC'),
+    record_hash text not null,
+    valid_from timestamptz not null default (now() at time zone 'UTC'),
+    valid_to timestamptz
+);
+alter table raw_data.osmnx_chicago_network_edges
+    add constraint uq_osmnx_chicago_network_edges_entity_hash
+    unique (u, v, key, record_hash);
+create index ix_osmnx_chicago_network_edges_current
+    on raw_data.osmnx_chicago_network_edges (u, v, key)
+    where valid_to is null;
+create index ix_osmnx_chicago_network_edges_geom
+    on raw_data.osmnx_chicago_network_edges using gist (geom);
+create index ix_osmnx_chicago_network_edges_u
+    on raw_data.osmnx_chicago_network_edges (u)
+    where valid_to is null;
+create index ix_osmnx_chicago_network_edges_v
+    on raw_data.osmnx_chicago_network_edges (v)
+    where valid_to is null;
+create index ix_osmnx_chicago_network_edges_tile_id
+    on raw_data.osmnx_chicago_network_edges (tile_id)
+    where valid_to is null;

--- a/platform/migrations/postgres/V35__clean_up_experiment.sql
+++ b/platform/migrations/postgres/V35__clean_up_experiment.sql
@@ -1,0 +1,2 @@
+drop table raw_data.osmnx_chicago_network_nodes;
+drop table raw_data.osmnx_chicago_network_edges;


### PR DESCRIPTION
Changes:
* Moves additional useful OSM tags from OSMnx `collector.py` file to `client.py`.
* Increases frequency of osmnx updates. (Closes #133)
* Eliminates incremental collection task as there isn't an incremental mode.

I ran into some issues initially that led me to try collecting all kinds of OSM ways rather than just bike-network parts (hence the migration scripts), but ultimately discovered that the `osmnx` package also implements its own caching scheme that was preventing me from retrieving updated edge and node data. After clearing that cache, updates were pulled in and the altered SCD2 scheme worked. 

From the Airflow run logs, it looks like 10105 edges were closed out (meaning they were probably split so one of the ends changed node-number) and 1561 edges were replaced (meaning their end nodes were unchanged but attributes like tags for that edge were changed).

<img width="3354" height="2088" alt="EC716177-8085-4BB8-8805-E805D2EEB570" src="https://github.com/user-attachments/assets/d28e3571-14c0-465b-97e8-0de41cf4f548" />

<img width="1450" height="1862" alt="image" src="https://github.com/user-attachments/assets/62257215-9216-4a0e-b635-7f0ff3839180" />

