### PR TITLE
Fixes logic for connecting crashes to edges

### DIFF
--- a/infra/modules/bike-map/main.tf
+++ b/infra/modules/bike-map/main.tf
@@ -389,7 +389,10 @@ resource "aws_lambda_function" "routing_api" {
     }
   }
 
-  depends_on = [aws_cloudwatch_log_group.routing_lambda]
+  depends_on = [
+    aws_cloudwatch_log_group.routing_lambda,
+    aws_iam_role_policy.routing_lambda
+  ]
 
   lifecycle {
     ignore_changes = [

--- a/platform/airflow/dags/dag_files/dbt_build_dag.py
+++ b/platform/airflow/dags/dag_files/dbt_build_dag.py
@@ -25,7 +25,7 @@ def dbt_build() -> str:
             "--project-dir",
             "/opt/airflow/dbt",
             "--select",
-            "+bike_safety_weighted_edges",
+            "bike_safety_weighted_edges",
         ],
         capture_output=True,
         text=True,

--- a/platform/airflow/dags/loci/tasks/testing/route_tests.py
+++ b/platform/airflow/dags/loci/tasks/testing/route_tests.py
@@ -92,6 +92,19 @@ TEST_CASES = [
         destination=(41.9295, -87.7080),  # Logan Square monument
         must_avoid=["Western Avenue", "North Western Avenue"],
     ),
+    RouteTestCase(
+        name="Belmont under the Kennedy should just use the cycleway",
+        origin=(41.9394, -87.7117),  # West of Kennedy
+        destination=(41.9393, -87.7051),  # East of Kennedy
+        must_use=["Belmont Avenue Bikeway"],
+        must_avoid=["North Avondale Avenue", "North Kedzie Avenue"],
+    ),
+    RouteTestCase(
+        name="Avoid the northbound underpass on Ashland above Cortland",
+        origin=(41.9157, -87.6678),  # South of the underpass
+        destination=(41.9189, -87.6682),  # North of the underpass
+        must_use=["West Cortland Street", "North Elston Avenue"],
+    ),
 ]
 
 

--- a/platform/dbt/macros/osm/road_rank.sql
+++ b/platform/dbt/macros/osm/road_rank.sql
@@ -1,0 +1,18 @@
+-- macros/road_rank.sql
+-- Maps an OSM highway type to a numeric rank for comparison.
+-- Higher rank = more dangerous / higher-traffic road.
+--
+-- Used by int_node_traffic_control to determine the worst road
+-- classification meeting at each intersection node.
+
+{% macro road_rank(highway_column) %}
+    case
+        when {{ highway_column }} in ('primary', 'primary_link')
+            or {{ highway_column }} like '%primary%'         then 4
+        when {{ highway_column }} in ('secondary', 'secondary_link')
+            or {{ highway_column }} like '%secondary%'       then 3
+        when {{ highway_column }} in ('tertiary', 'tertiary_link')
+            or {{ highway_column }} like '%tertiary%'        then 2
+        else                                                      1
+    end
+{% endmacro %}

--- a/platform/dbt/macros/testing/compare_aggregations.sql
+++ b/platform/dbt/macros/testing/compare_aggregations.sql
@@ -1,0 +1,19 @@
+{% macro _compare_aggregations(model, other_model, this_model_agg, other_model_agg, assertion) %}
+
+with this_model as (
+    select {{ this_model_agg }} as this_model_agg
+    from {{ model }}
+),
+
+other_model as (
+    select {{ other_model_agg }} as other_model_agg
+    from {{ other_model }}
+)
+
+select
+    this_model.this_model_agg,
+    other_model.other_model_agg
+from this_model, other_model
+where not ({{ assertion }})
+
+{% endmacro %}

--- a/platform/dbt/models/marts/cycling/_marts_cycling.yml
+++ b/platform/dbt/models/marts/cycling/_marts_cycling.yml
@@ -36,6 +36,11 @@ models:
           config:
             name: crash_penalty_non_negative
 
+      # Every edge from the source network must be present.
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('chicago_bike_network_edges')
+
       # safety_cost should always be >= length_m * min possible factor product
       # (0.5 * 1.0 * 1.0 * 1.0 = 0.5), so safety_cost >= length_m * 0.5.
       # We test a weaker version: safety_cost > 0 for non-zero-length edges.
@@ -114,90 +119,25 @@ models:
           - not_null
 
   # ==================================================================
-  # stg__traffic_control_nodes
+  # bike_crash_hotspots
   # ==================================================================
-  - name: stg__traffic_control_nodes
+  - name: bike_crash_hotspots
     description: >
-      Per-node traffic control classification. Enriches each node with
-      graph degree, intersection status, max road classification, and
-      a safety penalty/bonus for use in edge cost computation.
-
-    data_tests:
-      # All penalties are non-negative
-      - dbt_utils.expression_is_true:
-          arguments:
-            expression: "traffic_control_penalty >= 0"
-          config:
-            name: traffic_control_penalty_non_negative
-
-      # Uncontrolled intersections always get a positive penalty
-      - dbt_utils.expression_is_true:
-          arguments:
-            expression: "traffic_control_penalty > 0"
-          config:
-            name: uncontrolled_intersections_penalized
-            where: "traffic_control is null and is_intersection"
-
-      # Signals always cost less than uncontrolled intersections
-      # at the same road class
-      - dbt_utils.expression_is_true:
-          arguments:
-            expression: "traffic_control_penalty <= 7.0"
-          config:
-            name: signals_are_cheapest_intersection
-            where: "traffic_control = 'traffic_signals'"
-
-      # Mid-segment nodes (not intersections, no device) get zero
-      - dbt_utils.expression_is_true:
-          arguments:
-            expression: "traffic_control_penalty = 0"
-          config:
-            name: mid_segment_nodes_neutral
-            where: "traffic_control is null and not is_intersection"
-
-      # Penalty should scale with road class: for uncontrolled
-      # intersections, primary > secondary > tertiary > minor
-      - dbt_utils.expression_is_true:
-          arguments:
-            expression: >
-              traffic_control_penalty >= 2.0
-              and (
-                (max_road_class = 'primary'   and traffic_control_penalty >= 15.0)
-                or (max_road_class = 'secondary' and traffic_control_penalty >= 10.0)
-                or (max_road_class = 'tertiary'  and traffic_control_penalty >= 5.0)
-                or (max_road_class = 'minor'     and traffic_control_penalty >= 2.0)
-              )
-          config:
-            name: uncontrolled_penalty_scales_with_road_class
-            where: "traffic_control is null and is_intersection"
-
+      Bike crash data with severity scores, deduplicated to one row per crash.
     columns:
-      - name: osmid
-        data_tests:
+      - name: crash_record_id
+        tests:
           - unique
           - not_null
-      - name: degree
-        data_tests:
+      - name: severity_score
+        tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
-              arguments:
-                min_value: 1
-      - name: is_intersection
-        data_tests:
+              min_value: 1
+              max_value: 5
+      - name: geom
+        tests:
           - not_null
-      - name: max_road_rank
-        data_tests:
-          - not_null
-          - accepted_values:
-              arguments:
-                values: [1, 2, 3, 4]
-                quote: false
-      - name: max_road_class
-        data_tests:
-          - not_null
-          - accepted_values:
-              arguments:
-                values: ['minor', 'tertiary', 'secondary', 'primary']
-      - name: traffic_control_penalty
-        data_tests:
+      - name: crash_date
+        tests:
           - not_null

--- a/platform/dbt/models/marts/cycling/_marts_cycling.yml
+++ b/platform/dbt/models/marts/cycling/_marts_cycling.yml
@@ -59,6 +59,12 @@ models:
               # exceed length_m even at factor=1.0. We test the subset where
               # factors are elevated.
               severity: warn
+      - compare_aggregations:
+          arguments:
+            other_model: "ref('bike_crash_hotspots')"
+            this_model_agg: "sum(crash_count)"
+            other_model_agg: "count(distinct crash_record_id)"
+            assertion: "this_model_agg / other_model_agg::float between 0.995 and 1.0"
 
     columns:
       - name: u

--- a/platform/dbt/models/marts/cycling/bike_crash_hotspots.sql
+++ b/platform/dbt/models/marts/cycling/bike_crash_hotspots.sql
@@ -45,6 +45,12 @@ with crashes_with_severity as (
         end as severity_score,
         extract(year from crash_date) as crash_year
     from {{ ref('stg__bike_involved_crashes') }}
+    where geom is not null
+),
+deduplication as (
+    select distinct on (crash_record_id) *
+    from crashes_with_severity
+    order by crash_record_id, severity_score desc
 )
 -- ,grid_agg as (
 --     select
@@ -71,4 +77,4 @@ with crashes_with_severity as (
 -- To use the grid aggregation instead, change the final select to:
 --   select *, ST_SetSRID(ST_MakePoint(grid_lon, grid_lat), 4326) as geom
 --   from grid_agg
-select * from crashes_with_severity
+select * from deduplication

--- a/platform/dbt/models/marts/cycling/bike_safety_weighted_edges.sql
+++ b/platform/dbt/models/marts/cycling/bike_safety_weighted_edges.sql
@@ -40,42 +40,69 @@
     ]
 ) }}
 
-{% set crash_weight = 2.0 %}
+{% set crash_weight = 4.0 %}
 {% set crash_decay_lambda = 0.4 %}
-{% set crash_buffer_degrees = 0.0004 %}
+{% set crash_buffer_degrees = 0.0002 %}
 
 with edges as (
     select *
     from {{ ref('chicago_bike_network_edges') }}
 ),
-
 crashes as (
     select * from {{ ref('bike_crash_hotspots') }}
 ),
-
 -- =====================================================================
--- Crash scores: driven from small crashes table onto edge spatial index.
+-- Crash deduplication: assign each crash to exactly one edge.
+-- Priority: most dangerous highway class, then nearest by distance.
+-- This prevents a single crash near an intersection from being counted
+-- on multiple short segments.
+-- =====================================================================
+crash_nearest as (
+    select distinct on (c.crash_record_id)
+        c.crash_record_id,
+        c.severity_score,
+        c.crash_date,
+        e.u, e.v, e.key
+    from crashes c
+    inner join edges e
+        on e.geom && ST_Expand(c.geom, {{ crash_buffer_degrees }})
+        and ST_DWithin(c.geom, e.geom, {{ crash_buffer_degrees }})
+    order by c.crash_record_id,
+        case
+            when e.highway in ('primary', 'primary_link')       then 1
+            when e.highway like '%primary%'                     then 1
+            when e.highway in ('secondary', 'secondary_link')   then 2
+            when e.highway like '%secondary%'                   then 2
+            when e.highway in ('tertiary', 'tertiary_link')     then 3
+            when e.highway like '%tertiary%'                    then 3
+            when e.highway in ('unclassified')                  then 4
+            when e.highway in ('residential')                   then 5
+            when e.highway like '%residential%'                 then 5
+            when e.highway in ('service')                       then 6
+            else 7
+        end,
+        ST_Distance(c.geom, e.geom)
+),
+-- =====================================================================
+-- Crash scores: aggregate deduplicated crashes per edge.
 -- Severity is squared per crash before summing to amplify the difference
 -- between fatal and minor crashes.
 -- =====================================================================
 crash_scores as (
     select
-        e.u,
-        e.v,
-        e.key,
+        cn.u,
+        cn.v,
+        cn.key,
         count(*)                                        as crash_count,
         sum(
-            power(c.severity_score, 2) * exp(
+            power(cn.severity_score, 2) * exp(
                 -{{ crash_decay_lambda }}
-                * extract(epoch from (current_date - c.crash_date))
+                * extract(epoch from (current_date - cn.crash_date))
                 / (365.25 * 86400)
             )
         )                                               as crash_score
-    from crashes c
-    inner join edges e
-        on e.geom && ST_Expand(c.geom, {{ crash_buffer_degrees }})
-        and ST_DWithin(c.geom, e.geom, {{ crash_buffer_degrees }})
-    group by e.u, e.v, e.key
+    from crash_nearest cn
+    group by cn.u, cn.v, cn.key
 ),
 
 -- =====================================================================
@@ -162,6 +189,20 @@ factors as (
             -- 3. No bike infrastructure — neutral
             else 1.0
         end                             as infrastructure_factor,
+
+        -- Tunnel factor: penalizes tunnels without protective bike infrastructure.
+        -- infrastructure_factor <= 0.7 indicates at least a buffered lane or better.
+        case
+            when e.tunnel = 'yes'
+                and coalesce(e.osm_infra_type, '') not in (
+                    'protected_lane', 'track', 'shared_path', 'buffered_lane'
+                )
+                and coalesce(e.display_route_type, '') not in (
+                    'Protected Bike Lane', 'Neighborhood Greenway', 'Buffered Bike Lane'
+                )
+            then 2.5
+            else 1.0
+        end as tunnel_factor,
 
         -- Surface factor: affects control and crash risk.
         case
@@ -259,6 +300,7 @@ final as (
         speed_factor,
         road_type_factor,
         infrastructure_factor,
+        tunnel_factor,
         surface_factor,
         lighting_factor,
         traffic_control_penalty,
@@ -273,6 +315,7 @@ final as (
                 * speed_factor
                 * road_type_factor
                 * infrastructure_factor
+                * tunnel_factor
                 * surface_factor
                 * lighting_factor
                 + (crash_score_per_meter * length_m * {{ crash_weight }})

--- a/platform/dbt/models/marts/cycling/bike_safety_weighted_edges.sql
+++ b/platform/dbt/models/marts/cycling/bike_safety_weighted_edges.sql
@@ -40,7 +40,7 @@
     ]
 ) }}
 
-{% set crash_weight = 4.0 %}
+{% set crash_weight = 24.0 %}
 {% set crash_decay_lambda = 0.4 %}
 {% set crash_buffer_degrees = 0.0002 %}
 
@@ -68,6 +68,7 @@ crash_nearest as (
         on e.geom && ST_Expand(c.geom, {{ crash_buffer_degrees }})
         and ST_DWithin(c.geom, e.geom, {{ crash_buffer_degrees }})
     order by c.crash_record_id,
+        ST_Distance(c.geom, e.geom),
         case
             when e.highway in ('primary', 'primary_link')       then 1
             when e.highway like '%primary%'                     then 1
@@ -80,8 +81,7 @@ crash_nearest as (
             when e.highway like '%residential%'                 then 5
             when e.highway in ('service')                       then 6
             else 7
-        end,
-        ST_Distance(c.geom, e.geom)
+        end
 ),
 -- =====================================================================
 -- Crash scores: aggregate deduplicated crashes per edge.
@@ -140,13 +140,13 @@ factors as (
         -- independent of bike infrastructure. Based on highway class as
         -- a proxy for traffic volume, road design, and turning conflicts.
         case
-            when e.highway in ('cycleway')                      then 0.6
-            when e.highway like '%cycleway%'                    then 0.6
-            when e.highway in ('path', 'footway', 'bridleway')  then 0.7
-            when e.highway like '%path%'                        then 0.7
-            when e.highway in ('pedestrian')                    then 0.8
+            when e.highway in ('cycleway')                      then 0.3
+            when e.highway like '%cycleway%'                    then 0.3
+            when e.highway in ('path', 'footway', 'bridleway')  then 0.4
+            when e.highway like '%path%'                        then 0.4
+            when e.highway in ('pedestrian')                    then 0.5
             when e.highway in ('living_street')                 then 0.9
-            when e.highway = 'service' and e.service = 'alley'  then 1.3
+            when e.highway = 'service' and e.service = 'alley'  then 1.5
             when e.highway in ('service')                       then 1.0
             when e.highway in ('residential')                   then 1.1
             when e.highway like '%residential%'                 then 1.1

--- a/platform/dbt/models/staging/cycling/_staging_cycling.yml
+++ b/platform/dbt/models/staging/cycling/_staging_cycling.yml
@@ -1,0 +1,91 @@
+version: 2
+
+models:
+  # ==================================================================
+  # stg__traffic_control_nodes
+  # ==================================================================
+  - name: stg__traffic_control_nodes
+    description: >
+      Per-node traffic control classification. Enriches each node with
+      graph degree, intersection status, max road classification, and
+      a safety penalty/bonus for use in edge cost computation.
+
+    data_tests:
+      # All penalties are non-negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "traffic_control_penalty >= 0"
+          config:
+            name: traffic_control_penalty_non_negative
+
+      # Uncontrolled intersections always get a positive penalty
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "traffic_control_penalty > 0"
+          config:
+            name: uncontrolled_intersections_penalized
+            where: "traffic_control is null and is_intersection"
+
+      # Signals always cost less than uncontrolled intersections
+      # at the same road class
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "traffic_control_penalty <= 7.0"
+          config:
+            name: signals_are_cheapest_intersection
+            where: "traffic_control = 'traffic_signals'"
+
+      # Mid-segment nodes (not intersections, no device) get zero
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "traffic_control_penalty = 0"
+          config:
+            name: mid_segment_nodes_neutral
+            where: "traffic_control is null and not is_intersection"
+
+      # Penalty should scale with road class: for uncontrolled
+      # intersections, primary > secondary > tertiary > minor
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              traffic_control_penalty >= 2.0
+              and (
+                (max_road_class = 'primary'   and traffic_control_penalty >= 15.0)
+                or (max_road_class = 'secondary' and traffic_control_penalty >= 10.0)
+                or (max_road_class = 'tertiary'  and traffic_control_penalty >= 5.0)
+                or (max_road_class = 'minor'     and traffic_control_penalty >= 2.0)
+              )
+          config:
+            name: uncontrolled_penalty_scales_with_road_class
+            where: "traffic_control is null and is_intersection"
+
+    columns:
+      - name: osmid
+        data_tests:
+          - unique
+          - not_null
+      - name: degree
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 1
+      - name: is_intersection
+        data_tests:
+          - not_null
+      - name: max_road_rank
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [1, 2, 3, 4]
+                quote: false
+      - name: max_road_class
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['minor', 'tertiary', 'secondary', 'primary']
+      - name: traffic_control_penalty
+        data_tests:
+          - not_null

--- a/platform/dbt/tests/generic/compare_aggregations.sql
+++ b/platform/dbt/tests/generic/compare_aggregations.sql
@@ -1,0 +1,5 @@
+{% test compare_aggregations(model, other_model, this_model_agg, other_model_agg, assertion) %}
+
+    {{ _compare_aggregations(model, other_model, this_model_agg, other_model_agg, assertion) }}
+
+{% endtest %}

--- a/platform/dbt/tests/macros/test__compare_aggregations.sql
+++ b/platform/dbt/tests/macros/test__compare_aggregations.sql
@@ -1,0 +1,68 @@
+-- tests/macros/test__compare_aggregations.sql
+--
+-- Singular test for the_compare_aggregations generic test.
+-- Uses inline (values ...) tables to simulate models, then calls the macro
+-- and checks that it returns the expected number of rows.
+-- If this query returns any rows, the test fails.
+
+{% set passing_case %}
+    {{ _compare_aggregations(
+        model="(values (1), (2), (3)) as t(id)",
+        other_model="(values (1), (2), (3)) as t(id)",
+        this_model_agg="count(*)",
+        other_model_agg="count(*)",
+        assertion="this_model_agg = other_model_agg"
+    ) }}
+{% endset %}
+
+{% set failing_different_counts %}
+    {{_compare_aggregations(
+        model="(values (1), (2), (3)) as t(id)",
+        other_model="(values (1), (2)) as t(id)",
+        this_model_agg="count(*)",
+        other_model_agg="count(*)",
+        assertion="this_model_agg = other_model_agg"
+    ) }}
+{% endset %}
+
+{% set passing_threshold %}
+    {{_compare_aggregations(
+        model="(values (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)) as t(id)",
+        other_model="(values (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)) as t(id)",
+        this_model_agg="count(*)",
+        other_model_agg="count(*)",
+        assertion="other_model_agg::float / this_model_agg >= 0.999"
+    ) }}
+{% endset %}
+
+{% set failing_threshold %}
+    {{_compare_aggregations(
+        model="(values (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)) as t(id)",
+        other_model="(values (1), (2), (3), (4), (5)) as t(id)",
+        this_model_agg="count(*)",
+        other_model_agg="count(*)",
+        assertion="other_model_agg::float / this_model_agg >= 0.999"
+    ) }}
+{% endset %}
+
+select test_name from (
+
+    select 'passing_case: expected 0 rows but got some' as test_name
+    where (select count(*) from ({{ passing_case }}) as t) != 0
+
+    union all
+
+    select 'failing_different_counts: expected rows but got 0' as test_name
+    where (select count(*) from ({{ failing_different_counts }}) as t) = 0
+
+    union all
+
+    select 'passing_threshold: expected 0 rows but got some' as test_name
+    where (select count(*) from ({{ passing_threshold }}) as t) != 0
+
+    union all
+
+    select 'failing_threshold: expected rows but got 0' as test_name
+    where (select count(*) from ({{ failing_threshold }}) as t) = 0
+
+) as results


### PR DESCRIPTION
Changes:
* Adjusted logic for connecting crashes to edges (Closes #139)
    * Previously, it was joining crashes to all edges within ~40 meters (~130 ft) and not deduplicating. So crashes that happened on the road would also penalize adjacent protected bike lines, and could have been penalizing orthogonal routes.
    * Added a test to check against regression of the fixed segments.
* Added a penalty for tunnels without protected bike infrastructure, to capture the risk from riding in places with sudden darkness and limited maneuverability around cars. 

<img width="3344" height="1642" alt="image" src="https://github.com/user-attachments/assets/0ecef5a4-a38d-4308-bd43-9756c258ffab" />

ToDo: Adjust weights

Adjusted weights to make crashes comparably impactful again.

Also implemented a generic test to check an arbitrary comparison of aggregations, and applied that to test that nearly all crashes join to edges and are properly deduplicated.

Also added a lot of new (since Q4 2025) cycleways to OSM, and connected a lot of networks to fix strange routing.