### PR TITLE
Iss141 add ckan tooling

### DIFF
--- a/apps/bike-map/index.html
+++ b/apps/bike-map/index.html
@@ -434,7 +434,8 @@
     height: 14px;
   }
 
-  .about-overlay {
+  /* ── Overlay (shared by about, terms, privacy) ────────── */
+  .overlay {
     position: absolute;
     inset: 0;
     z-index: 100;
@@ -448,40 +449,65 @@
     transition: opacity 0.2s ease;
   }
 
-  .about-overlay.visible {
+  .overlay.visible {
     opacity: 1;
     pointer-events: auto;
   }
 
-  .about-card {
+  .overlay-card {
     background: rgba(18, 18, 20, 0.96);
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 14px;
     padding: 28px 28px 24px;
-    max-width: 380px;
+    max-width: 420px;
+    max-height: calc(100vh - 48px);
+    overflow-y: auto;
     width: calc(100% - 32px);
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
   }
 
-  .about-card h1 {
+  .overlay-card h1 {
     font-size: 18px;
     font-weight: 700;
     color: #e8e4df;
     margin-bottom: 14px;
   }
 
-  .about-card p {
+  .overlay-card h2 {
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: rgba(255, 255, 255, 0.5);
+    margin-top: 18px;
+    margin-bottom: 8px;
+  }
+
+  .overlay-card h2:first-of-type {
+    margin-top: 4px;
+  }
+
+  .overlay-card p {
     font-size: 14px;
     line-height: 1.65;
     color: rgba(255, 255, 255, 0.55);
-    margin-bottom: 12px;
+    margin-bottom: 10px;
   }
 
-  .about-card p:last-of-type {
+  .overlay-card p:last-of-type {
     margin-bottom: 0;
   }
 
-  .about-close {
+  .overlay-card a {
+    color: #6366f1;
+    text-decoration: none;
+  }
+
+  .overlay-card a:hover {
+    color: #818cf8;
+  }
+
+  .overlay-close {
     display: block;
     width: 100%;
     margin-top: 20px;
@@ -497,7 +523,25 @@
     transition: background 0.15s, color 0.15s;
   }
 
-  .about-close:hover { background: rgba(255, 255, 255, 0.14); color: #fff; }
+  .overlay-close:hover { background: rgba(255, 255, 255, 0.14); color: #fff; }
+
+  .overlay-links {
+    display: flex;
+    gap: 16px;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .overlay-links a {
+    font-size: 12px;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.35);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+
+  .overlay-links a:hover { color: rgba(255, 255, 255, 0.7); }
 
   /* ── Mobile layout ───────────────────────────────────── */
   #panel-container {
@@ -512,7 +556,7 @@
       position: absolute;
       top: 8px;
       left: 8px;
-      right: 8px;
+      right: 52px;
       z-index: 10;
       pointer-events: none;
     }
@@ -712,7 +756,7 @@
   <div class="panel-header" data-panel="route-panel">
     <div>
       <h2>Route</h2>
-      <p class="panel-subtitle">Safety-weighted cycling routes</p>
+      <p class="panel-subtitle">Low-stress cycling routes</p>
     </div>
     <svg class="panel-chevron" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="4 6 8 10 12 6"/></svg>
   </div>
@@ -741,7 +785,7 @@
           Why this route?
         </button>
         <div class="route-why-text" id="route-why-text">
-          This route favors streets with a less severe recent crash history, lower max speed limits, better bike lane infrastructure, safer surface material, and lighting, even if that means a slightly longer ride. It may differ from the shortest path to help you avoid higher-risk areas.
+          This route prefers streets with better bike infrastructure, lower speed limits, lighting, and less severe recent crash history, even if that means a slightly longer ride. It may differ from the shortest path based on these preferences. Conditions change — always use your own judgment.
         </div>
       </div>
     </div>
@@ -750,13 +794,85 @@
   </div>
 </div>
 
-<!-- About overlay -->
-<div class="about-overlay" id="about-overlay">
-  <div class="about-card">
+<!-- ── About overlay ──────────────────────────────────── -->
+<div class="overlay" id="about-overlay">
+  <div class="overlay-card">
     <h1>Chicago Bike Map</h1>
-    <p>Chicago Bike Map helps you ride smarter around the city. The map layers show where crashes, thefts, and bike parking are concentrated, so you can see what's happening in the areas you ride.</p>
-    <p>Routes are safety-weighted — they favor streets with less severe recent crash history, lower max speed limits, better bike lane infrastructure, safer surface material, and lighting, even if that means a slightly longer ride.</p>
-    <button class="about-close" id="about-close">Got it</button>
+    <p>Chicago Bike Map helps you explore cycling conditions around the city. The map layers show where crashes, thefts, and bike parking are concentrated based on recent city data, so you can get a sense of patterns in the areas you ride.</p>
+    <p>Routes prefer streets with better bike infrastructure, lower speed limits, and less severe recent crash history, even if that means a slightly longer ride. We recommend always wearing a helmet while riding.</p>
+    <p>Routes are generated using OpenStreetMap and City of Chicago data that may be incomplete or outdated. Route suggestions are informational and are no substitute for your own judgment while riding.</p>
+    <div class="overlay-links">
+      <a href="#" id="about-terms-link">Terms of Service</a>
+      <a href="#" id="about-privacy-link">Privacy Policy</a>
+    </div>
+    <button class="overlay-close" id="about-close">Got it</button>
+  </div>
+</div>
+
+<!-- ── Terms of Service overlay ───────────────────────── -->
+<div class="overlay" id="terms-overlay">
+  <div class="overlay-card">
+    <h1>Terms of Service</h1>
+
+    <h2>What This Project Is</h2>
+    <p>Chicago Bike Map is a personal project that displays cycling-related data for the Chicago area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.</p>
+
+    <h2>No Safety Guarantee</h2>
+    <p>Route suggestions are informational only. They are generated algorithmically using third-party data sources — including OpenStreetMap and City of Chicago open data — that may be incomplete, outdated, or inaccurate. A route appearing on this map does not mean it is safe, and the absence of crash or theft data in an area does not mean that area is free of risk.</p>
+    <p>You are solely responsible for your own safety while cycling. Always use your own judgment, obey traffic laws, and adapt to real-world conditions regardless of what this app suggests.</p>
+
+    <h2>Data Sources</h2>
+    <p>Map data comes from OpenStreetMap contributors and is subject to the <a href="https://opendatacommons.org/licenses/odbl/" target="_blank" rel="noopener">ODbL license</a>. Crash, theft, and infrastructure data come from the City of Chicago open data portal and other public sources. This project does not independently verify the accuracy or completeness of any of these sources.</p>
+
+    <h2>Limitation of Liability</h2>
+    <p>This project is provided "as is" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of Chicago Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss.</p>
+
+    <h2>Changes</h2>
+    <p>These terms may be updated from time to time. Continued use of the site after changes are posted constitutes acceptance of the revised terms.</p>
+
+    <h2>Contact</h2>
+    <p>Questions about these terms can be directed to the project's <a href="https://github.com/MattTriano/loci_platform" target="_blank" rel="noopener">GitHub repository</a>.</p>
+
+    <div class="overlay-links">
+      <a href="#" id="terms-back-link">← About</a>
+      <a href="#" id="terms-privacy-link">Privacy Policy</a>
+    </div>
+    <button class="overlay-close" id="terms-close">Close</button>
+  </div>
+</div>
+
+<!-- ── Privacy Policy overlay ─────────────────────────── -->
+<div class="overlay" id="privacy-overlay">
+  <div class="overlay-card">
+    <h1>Privacy Policy</h1>
+
+    <h2>What We Collect</h2>
+    <p>When you request a route, the application logs the following information: the start and end points you selected, the route geometry returned, your browser's user agent string, screen and viewport dimensions, and the referring URL if any. The requesting IP address is also recorded server-side as part of normal request handling.</p>
+    <p>No names, email addresses, accounts, or login credentials are collected. The application does not use cookies or browser-based tracking.</p>
+
+    <h2>How We Use It</h2>
+    <p>Logged data is used to understand how routes are being used, identify bugs or routing issues, improve the routing algorithm over time, and detect abuse or unusual traffic patterns. It is not sold, shared with third parties, or used for advertising.</p>
+
+    <h2>Geolocation</h2>
+    <p>If you use the "locate me" button on the map, your browser will ask for permission before sharing your location. This location data is used only to center the map on your position. It is not logged or stored by the application.</p>
+
+    <h2>Third-Party Services</h2>
+    <p>The application loads map tiles from OpenFreeMap and fonts from Google Fonts. These services may collect standard web request information (such as your IP address) according to their own privacy policies. The application itself does not control or have access to that data.</p>
+
+    <h2>Data Retention</h2>
+    <p>Route logs are automatically deleted after 365 days via an S3 lifecycle policy. This retention period may be adjusted in the future.</p>
+
+    <h2>Your Rights</h2>
+    <p>If you would like to request earlier deletion of any logged data, you can open an issue on the project's <a href="https://github.com/MattTriano/loci_platform" target="_blank" rel="noopener">GitHub repository</a> or contact the project maintainer directly.</p>
+
+    <h2>Changes</h2>
+    <p>This policy may be updated from time to time. Continued use of the site after changes are posted constitutes acceptance of the revised policy.</p>
+
+    <div class="overlay-links">
+      <a href="#" id="privacy-back-link">← About</a>
+      <a href="#" id="privacy-terms-link">Terms of Service</a>
+    </div>
+    <button class="overlay-close" id="privacy-close">Close</button>
   </div>
 </div>
 
@@ -780,16 +896,43 @@ fetch('config.json')
   .then(cfg => { Object.assign(CONFIG, cfg); })
   .catch(() => { /* Use defaults */ });
 
-// ── About overlay ────────────────────────────────────────
-const aboutBtn = document.getElementById('about-btn');
-const aboutOverlay = document.getElementById('about-overlay');
-const aboutClose = document.getElementById('about-close');
+// ── Overlay navigation ───────────────────────────────────
+function showOverlay(id) {
+  document.querySelectorAll('.overlay').forEach(o => o.classList.remove('visible'));
+  document.getElementById(id).classList.add('visible');
+}
 
-aboutBtn.addEventListener('click', (e) => { e.stopPropagation(); aboutOverlay.classList.add('visible'); });
-aboutClose.addEventListener('click', () => { aboutOverlay.classList.remove('visible'); });
-aboutOverlay.addEventListener('click', (e) => {
-  if (e.target === aboutOverlay) aboutOverlay.classList.remove('visible');
+function closeAllOverlays() {
+  document.querySelectorAll('.overlay').forEach(o => o.classList.remove('visible'));
+}
+
+// About overlay
+const aboutBtn = document.getElementById('about-btn');
+aboutBtn.addEventListener('click', (e) => { e.stopPropagation(); showOverlay('about-overlay'); });
+document.getElementById('about-close').addEventListener('click', closeAllOverlays);
+document.getElementById('about-overlay').addEventListener('click', (e) => {
+  if (e.target === e.currentTarget) closeAllOverlays();
 });
+
+// About → Terms / Privacy links
+document.getElementById('about-terms-link').addEventListener('click', (e) => { e.preventDefault(); showOverlay('terms-overlay'); });
+document.getElementById('about-privacy-link').addEventListener('click', (e) => { e.preventDefault(); showOverlay('privacy-overlay'); });
+
+// Terms overlay
+document.getElementById('terms-close').addEventListener('click', closeAllOverlays);
+document.getElementById('terms-overlay').addEventListener('click', (e) => {
+  if (e.target === e.currentTarget) closeAllOverlays();
+});
+document.getElementById('terms-back-link').addEventListener('click', (e) => { e.preventDefault(); showOverlay('about-overlay'); });
+document.getElementById('terms-privacy-link').addEventListener('click', (e) => { e.preventDefault(); showOverlay('privacy-overlay'); });
+
+// Privacy overlay
+document.getElementById('privacy-close').addEventListener('click', closeAllOverlays);
+document.getElementById('privacy-overlay').addEventListener('click', (e) => {
+  if (e.target === e.currentTarget) closeAllOverlays();
+});
+document.getElementById('privacy-back-link').addEventListener('click', (e) => { e.preventDefault(); showOverlay('about-overlay'); });
+document.getElementById('privacy-terms-link').addEventListener('click', (e) => { e.preventDefault(); showOverlay('terms-overlay'); });
 
 // ── "Why this route?" toggle ─────────────────────────────
 const whyToggle = document.getElementById('route-why-toggle');
@@ -801,8 +944,6 @@ whyToggle.addEventListener('click', () => {
 });
 
 // ── Panel accordion ──────────────────────────────────────
-// On mobile, panels live inside #panel-container (flexbox column).
-// On desktop, they stay as absolute-positioned elements on <body>.
 function isMobile() { return window.innerWidth <= 640; }
 
 const panelContainer = document.getElementById('panel-container');
@@ -816,7 +957,6 @@ function arrangePanels() {
     panelContainer.appendChild(routePanel);
     panelsInContainer = true;
   } else if (!isMobile() && panelsInContainer) {
-    // Move panels back to body (before the loading bar)
     const loading = document.getElementById('loading');
     document.body.insertBefore(controlsPanel, loading);
     document.body.insertBefore(routePanel, loading);
@@ -829,7 +969,6 @@ function togglePanel(panelId) {
   const wasCollapsed = panel.classList.contains('collapsed');
 
   if (isMobile() && wasCollapsed) {
-    // Collapse the other panel first
     document.querySelectorAll('.panel').forEach(p => {
       if (p.id !== panelId) p.classList.add('collapsed');
     });
@@ -966,7 +1105,6 @@ for (const [id, cfg] of Object.entries(LAYERS)) {
     toggleLayer(id, e.target.checked);
   });
 
-  // Add date filter slider for layers with a dateField
   if (cfg.dateField) {
     const filterDiv = document.createElement('div');
     filterDiv.className = 'date-filter';
@@ -985,17 +1123,14 @@ for (const [id, cfg] of Object.entries(LAYERS)) {
 }
 
 // ── Date filter state ────────────────────────────────────
-// Stores per-layer: { dates: [sorted unique date strings], minIdx, maxIdx }
 const dateFilterState = {};
 
 function parseDate(val) {
-  // Extract YYYY-MM-DD from "2018-10-20 13:40:00+00:00" or similar
   if (!val) return null;
   return String(val).slice(0, 10);
 }
 
 function formatDateShort(dateStr) {
-  // "2018-10-20" → "Oct 2018"
   const [y, m] = dateStr.split('-');
   const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
   return `${months[parseInt(m, 10) - 1]} ${y}`;
@@ -1008,7 +1143,6 @@ function initDateFilter(id) {
   const features = layerData[id].features || [];
   const dateSet = new Set();
 
-  // Precompute parsed date for each feature (avoids repeated string slicing)
   const featureDates = new Array(features.length);
   for (let i = 0; i < features.length; i++) {
     const d = parseDate(features[i].properties[cfg.dateField]);
@@ -1031,7 +1165,6 @@ function initDateFilter(id) {
 
   updateDateLabel(id);
 
-  // Show the filter
   document.getElementById(`date-filter-${id}`).classList.add('active');
 
   let filterRAF = null;
@@ -1044,7 +1177,6 @@ function initDateFilter(id) {
     let lo = parseInt(minInput.value);
     let hi = parseInt(maxInput.value);
 
-    // Prevent handles from crossing
     if (lo > hi) {
       if (this === minInput) { lo = hi; minInput.value = lo; }
       else { hi = lo; maxInput.value = hi; }
@@ -1061,7 +1193,6 @@ function initDateFilter(id) {
   maxInput.addEventListener('input', onSliderInput);
   updateDateFill(id);
 
-  // Drag the fill bar to shift both handles together
   const fill = document.getElementById(`date-fill-${id}`);
   let dragStartX = null;
   let dragStartMin = null;
@@ -1094,7 +1225,6 @@ function initDateFilter(id) {
     let newMin = dragStartMin + deltaSteps;
     let newMax = dragStartMax + deltaSteps;
 
-    // Clamp to bounds
     if (newMin < 0) { newMin = 0; newMax = span; }
     if (newMax > last) { newMax = last; newMin = last - span; }
 
@@ -1171,7 +1301,6 @@ function applyDateFilter(id) {
 
   map.getSource(sourceId).setData({ type: 'FeatureCollection', features: out });
 
-  // Update the count display
   const countEl = document.getElementById(`count-${id}`);
   if (countEl) countEl.textContent = out.length.toLocaleString();
 }
@@ -1235,7 +1364,6 @@ map.on('click', (e) => {
 function setOrigin(lngLat) {
   routeOrigin = lngLat;
 
-  // Auto-expand route panel when user starts placing points
   const routePanel = document.getElementById('route-panel');
   if (routePanel.classList.contains('collapsed')) {
     togglePanel('route-panel');
@@ -1310,8 +1438,8 @@ async function fetchRoute() {
         'X-Api-Key': CONFIG.routing_api_key,
       },
       body: JSON.stringify({
-        origin: [routeOrigin[1], routeOrigin[0]],           // [lat, lon]
-        destination: [routeDestination[1], routeDestination[0]], // [lat, lon]
+        origin: [routeOrigin[1], routeOrigin[0]],
+        destination: [routeDestination[1], routeDestination[0]],
       }),
     });
 
@@ -1323,7 +1451,6 @@ async function fetchRoute() {
     const data = await resp.json();
     routeData = data;
 
-    // Draw route on map — coordinates are already [lon, lat]
     map.getSource('route').setData({
       type: 'Feature',
       geometry: {
@@ -1332,17 +1459,14 @@ async function fetchRoute() {
       },
     });
 
-    // Fit map to route bounds
     const bounds = data.coordinates.reduce(
       (b, c) => b.extend(c),
       new maplibregl.LngLatBounds(data.coordinates[0], data.coordinates[0])
     );
     map.fitBounds(bounds, { padding: 80 });
 
-    // Show route info
     const distKm = data.total_length_m / 1000;
     const distMi = distKm * 0.621371;
-    // Rough estimate: ~15 km/h average city cycling speed
     const durMin = Math.round((data.total_length_m / 1000) / 15 * 60);
 
     document.getElementById('route-distance').textContent = `${distMi.toFixed(1)} mi (${distKm.toFixed(1)} km)`;
@@ -1387,7 +1511,6 @@ function clearRoute() {
   document.getElementById('route-hint').style.display = '';
   document.getElementById('route-hint').textContent = 'Click anywhere on the map to place start and end points';
 
-  // Collapse the "Why this route?" if it was open
   whyToggle.classList.remove('expanded');
   whyText.classList.remove('visible');
 
@@ -1502,7 +1625,6 @@ function addLayerToMap(id) {
     },
   });
 
-  // Invisible hit-area layer (larger radius for easier tapping)
   map.addLayer({
     id: `${id}-points-hitarea`,
     type: 'circle',
@@ -1514,7 +1636,6 @@ function addLayerToMap(id) {
     },
   });
 
-  // Visible points (drawn on top of hit area)
   map.addLayer({
     id: `${id}-points`,
     type: 'circle',

--- a/platform/airflow/dags/dag_files/ckan/update_toronto_bicycle_parking_racks.py
+++ b/platform/airflow/dags/dag_files/ckan/update_toronto_bicycle_parking_racks.py
@@ -2,7 +2,7 @@ import datetime as dt
 from logging import getLogger
 
 from airflow.sdk import dag
-from loci.sources.update_configs import TORONTO_SERIOUS_MOTOR_VEHICLE_COLLISIONS_UC as UPDATE_CONFIG
+from loci.sources.update_configs import TORONTO_BICYCLE_PARKING_RACKS_UC as UPDATE_CONFIG
 from loci.tasks.ckan_tasks import update_ckan_table
 
 task_logger = getLogger("airflow.task")
@@ -17,7 +17,7 @@ CONN_ID = "gis_dwh_db"
     catchup=False,
     tags=["ckan", "traffic", "crashes", "toronto"],
 )
-def update_toronto_serious_motor_vehicle_collisions():
+def update_toronto_bicycle_parking_racks():
     update_ckan_table(
         conn_id=CONN_ID,
         update_config=UPDATE_CONFIG,
@@ -25,4 +25,4 @@ def update_toronto_serious_motor_vehicle_collisions():
     )
 
 
-update_toronto_serious_motor_vehicle_collisions()
+update_toronto_bicycle_parking_racks()

--- a/platform/airflow/dags/dag_files/ckan/update_toronto_serious_motor_vehicle_collisions.py
+++ b/platform/airflow/dags/dag_files/ckan/update_toronto_serious_motor_vehicle_collisions.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.sources.update_configs import TORONTO_SERIOUS_MOTOR_VEHICLE_COLLISIONS_UC as UPDATE_CONFIG
+from loci.tasks.ckan_tasks import update_ckan_table
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["osmnx", "biking", "ways", "nodes"],
+)
+def update_toronto_serious_motor_vehicle_collisions():
+    update_ckan_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_toronto_serious_motor_vehicle_collisions()

--- a/platform/airflow/dags/loci/collectors/ckan/client.py
+++ b/platform/airflow/dags/loci/collectors/ckan/client.py
@@ -1,0 +1,21 @@
+import requests
+
+from loci.collectors.ckan.metadata import CKANMetadata
+
+
+class CKANClient:
+    def __init__(self, base_url: str):
+        self.base_url = base_url
+        self.metadata = CKANMetadata(self.base_url)
+
+    def download_resource(self, resource_url: str, dest_path: str) -> str:
+        """Download a resource file from its URL and save it to dest_path.
+
+        Returns the path the file was saved to.
+        """
+        response = requests.get(resource_url, timeout=60, stream=True)
+        response.raise_for_status()
+        with open(dest_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+        return dest_path

--- a/platform/airflow/dags/loci/collectors/ckan/client.py
+++ b/platform/airflow/dags/loci/collectors/ckan/client.py
@@ -1,21 +1,176 @@
-import requests
+from __future__ import annotations
 
+import logging
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import requests
 from loci.collectors.ckan.metadata import CKANMetadata
+from requests.exceptions import ChunkedEncodingError, ConnectionError, ReadTimeout
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class CKANClient:
-    def __init__(self, base_url: str):
-        self.base_url = base_url
+    """Downloads resources and queries DataStore endpoints on a CKAN portal."""
+
+    def __init__(
+        self,
+        base_url: str,
+        request_timeout: int = 120,
+        page_size: int = 10000,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.request_timeout = request_timeout
+        self.page_size = page_size
+        self.logger = logging.getLogger("ckan_client")
+
+        self._session = requests.Session()
         self.metadata = CKANMetadata(self.base_url)
 
-    def download_resource(self, resource_url: str, dest_path: str) -> str:
-        """Download a resource file from its URL and save it to dest_path.
+    # ------------------------------------------------------------------
+    # File downloads
+    # ------------------------------------------------------------------
 
-        Returns the path the file was saved to.
+    @retry(
+        retry=retry_if_exception_type((ChunkedEncodingError, ConnectionError, ReadTimeout)),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=30, max=300),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+    )
+    def download_to_tempfile(self, url: str, suffix: str = ".csv") -> Path:
+        """Download a URL to a temporary file. Returns the file path.
+
+        The caller is responsible for deleting the file when done.
         """
-        response = requests.get(resource_url, timeout=60, stream=True)
-        response.raise_for_status()
-        with open(dest_path, "wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-        return dest_path
+        self.logger.info("Downloading %s", url)
+        resp = self._session.get(url, stream=True, timeout=self.request_timeout)
+        resp.raise_for_status()
+
+        tmp = tempfile.NamedTemporaryFile(suffix=suffix, prefix="ckan_", delete=False)
+        try:
+            for chunk in resp.iter_content(chunk_size=8192):
+                tmp.write(chunk)
+            tmp.close()
+            filepath = Path(tmp.name)
+            self.logger.info(
+                "Downloaded %s to %s (%.1f MB)",
+                url,
+                filepath,
+                filepath.stat().st_size / (1024 * 1024),
+            )
+            return filepath
+        except Exception:
+            tmp.close()
+            Path(tmp.name).unlink(missing_ok=True)
+            raise
+
+    def _suffix_for_format(self, fmt: str) -> str:
+        """Map a CKAN resource format string to a file suffix."""
+        fmt_upper = (fmt or "").upper()
+        mapping = {
+            "CSV": ".csv",
+            "GEOJSON": ".geojson",
+            "JSON": ".json",
+            "TSV": ".tsv",
+            "XML": ".xml",
+        }
+        return mapping.get(fmt_upper, ".csv")
+
+    # ------------------------------------------------------------------
+    # DataStore queries
+    # ------------------------------------------------------------------
+
+    def datastore_search(
+        self,
+        resource_id: str,
+        fields: list[str] | None = None,
+        filters: dict[str, Any] | None = None,
+        sort: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Execute a single DataStore search and return the records."""
+        params: dict[str, Any] = {"resource_id": resource_id}
+        if fields:
+            params["fields"] = ",".join(fields)
+        if filters:
+            import json
+
+            params["filters"] = json.dumps(filters)
+        if sort:
+            params["sort"] = sort
+        if limit is not None:
+            params["limit"] = limit
+
+        return self._datastore_request(params)
+
+    def datastore_paginate(
+        self,
+        resource_id: str,
+        fields: list[str] | None = None,
+        filters: dict[str, Any] | None = None,
+        sort: str | None = None,
+    ) -> Iterator[list[dict[str, Any]]]:
+        """Yield pages of records from a DataStore resource until exhausted.
+
+        Uses offset-based pagination with the configured page_size.
+        Automatically strips the internal _id field that CKAN adds.
+        """
+        offset = 0
+        while True:
+            params: dict[str, Any] = {
+                "resource_id": resource_id,
+                "limit": self.page_size,
+                "offset": offset,
+            }
+            if fields:
+                params["fields"] = ",".join(fields)
+            if filters:
+                import json
+
+                params["filters"] = json.dumps(filters)
+            if sort:
+                params["sort"] = sort
+
+            records = self._datastore_request(params)
+            if not records:
+                break
+
+            # Strip CKAN's internal _id column
+            for row in records:
+                row.pop("_id", None)
+
+            yield records
+
+            if len(records) < self.page_size:
+                break
+            offset += self.page_size
+
+    @retry(
+        retry=retry_if_exception_type((ConnectionError, ReadTimeout)),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, max=10),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+    )
+    def _datastore_request(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        """Make a single DataStore search request and return the records."""
+        url = f"{self.metadata.api_base}/datastore_search"
+        self.logger.debug("GET %s  params=%s", url, params)
+
+        resp = self._session.get(url, params=params, timeout=self.request_timeout)
+        resp.raise_for_status()
+        data = resp.json()
+
+        if not data.get("success"):
+            raise ValueError(f"DataStore search failed: {data.get('error', data)}")
+
+        return data["result"].get("records", [])

--- a/platform/airflow/dags/loci/collectors/ckan/collector.py
+++ b/platform/airflow/dags/loci/collectors/ckan/collector.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import csv
+import logging
+from pathlib import Path
+from typing import Any
+
+from loci.collectors.ckan.client import CKANClient
+from loci.collectors.ckan.metadata import CKANResource
+from loci.collectors.ckan.spec import CKANDatasetSpec
+from loci.parsers.csv_parser import parse_csv
+from loci.parsers.geojson import parse_geojson
+from loci.tracking.ingestion_tracker import IngestionTracker
+
+logger = logging.getLogger(__name__)
+
+
+class CKANCollector:
+    """
+    High-level orchestrator for CKAN dataset ingestion.
+
+    Usage:
+        collector = CKANCollector(engine=engine)
+
+        # Full refresh (download files, parse, SCD2 merge):
+        spec = CKANDatasetSpec(
+            name="food_inspections",
+            base_url="https://data.cityofchicago.org",
+            dataset_id="4ijn-s7e5",
+            target_table="food_inspections",
+            entity_key=["inspection_id"],
+            resource_format="CSV",
+        )
+        rows = collector.full_refresh(spec)
+
+        # Generate DDL for a new table:
+        print(collector.generate_ddl(spec))
+    """
+
+    SOURCE_NAME = "ckan"
+
+    # Columns that CKAN adds internally — never part of the actual data.
+    # _id: auto-increment row ID, reset on every DataPusher re-import.
+    # _full_text: tsvector column used for full-text search in DataStore.
+    CKAN_INTERNAL_COLUMNS = {"_id", "_full_text"}
+
+    PIPELINE_COLUMNS = {
+        "ingested_at",
+        "record_hash",
+        "valid_from",
+        "valid_to",
+    }
+
+    # CKAN DataStore type -> Postgres DDL type
+    DATASTORE_TYPE_MAP = {
+        "text": "text",
+        "int": "integer",
+        "int4": "integer",
+        "int8": "bigint",
+        "float": "double precision",
+        "float8": "double precision",
+        "numeric": "numeric",
+        "bool": "boolean",
+        "json": "jsonb",
+        "jsonb": "jsonb",
+        "date": "date",
+        "time": "time",
+        "timestamp": "timestamptz",
+        "timestamptz": "timestamptz",
+    }
+
+    def __init__(
+        self,
+        engine: Any,
+        tracker: IngestionTracker | None = None,
+    ) -> None:
+        self.engine = engine
+        self.tracker = tracker or IngestionTracker(engine=self.engine)
+        self.logger = logging.getLogger("ckan_collector")
+
+        self._client_cache: dict[str, CKANClient] = {}
+
+    def _get_client(self, base_url: str) -> CKANClient:
+        """Return a cached CKANClient for the given portal URL."""
+        if base_url not in self._client_cache:
+            self._client_cache[base_url] = CKANClient(base_url)
+        return self._client_cache[base_url]
+
+    # ------------------------------------------------------------------
+    # Resource resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_resources(self, spec: CKANDatasetSpec) -> list[CKANResource]:
+        """Resolve the spec's resource selection to a list of CKANResource objects.
+
+        If resource_ids is set, fetches each resource by ID.
+        Otherwise, filters by resource_format on the dataset.
+        Raises ValueError if no resources are found.
+        """
+        client = self._get_client(spec.base_url)
+        meta = client.metadata
+
+        if spec.resource_ids:
+            resources = [meta.get_resource(rid) for rid in spec.resource_ids]
+        else:
+            resources = meta.find_resources(spec.dataset_id, spec.resource_format)
+
+        if not resources:
+            fmt = spec.resource_format or "(by ID)"
+            raise ValueError(
+                f"No resources found for dataset {spec.dataset_id!r} "
+                f"with format {fmt} on {spec.base_url}"
+            )
+
+        self.logger.info(
+            "Resolved %d resource(s) for %s: %s",
+            len(resources),
+            spec.dataset_id,
+            [r.id for r in resources],
+        )
+        return resources
+
+    # ------------------------------------------------------------------
+    # Full refresh
+    # ------------------------------------------------------------------
+
+    def full_refresh(self, spec: CKANDatasetSpec) -> int:
+        """
+        Download all matching resources, parse them, and ingest via staged_ingest.
+
+        If the spec has an entity_key, uses SCD2 merge. Otherwise, the
+        staging table is merged with INSERT ... ON CONFLICT DO NOTHING
+        (append-only — no entity key means no way to identify duplicates
+        beyond the full row hash).
+
+        Returns the number of rows merged into the target table.
+        """
+        client = self._get_client(spec.base_url)
+        resources = self._resolve_resources(spec)
+        fqn = f"{spec.target_schema}.{spec.target_table}"
+
+        run_metadata = {
+            "mode": "full_refresh",
+            "base_url": spec.base_url,
+            "dataset_id": spec.dataset_id,
+            "resource_ids": [r.id for r in resources],
+            "resource_formats": [r.format for r in resources],
+            "entity_key": spec.entity_key,
+        }
+
+        staged_ingest_kwargs: dict[str, Any] = {}
+        if spec.entity_key:
+            staged_ingest_kwargs["entity_key"] = spec.entity_key
+
+        with self.tracker.track(
+            self.SOURCE_NAME, spec.dataset_id, fqn, metadata=run_metadata
+        ) as run:
+            with self.engine.staged_ingest(
+                target_table=spec.target_table,
+                target_schema=spec.target_schema,
+                metadata_columns=self.PIPELINE_COLUMNS,
+                hash_exclude_columns=self.PIPELINE_COLUMNS,
+                **staged_ingest_kwargs,
+            ) as stager:
+                for resource in resources:
+                    self._ingest_resource(client, resource, stager, spec)
+
+            run.rows_staged = stager.rows_staged
+            run.rows_merged = stager.rows_merged
+            run.rows_ingested = stager.rows_merged
+
+        return stager.rows_merged
+
+    def _ingest_resource(
+        self,
+        client: CKANClient,
+        resource: CKANResource,
+        stager: Any,
+        spec: CKANDatasetSpec,
+    ) -> None:
+        """Download and parse a single resource, writing batches to the stager."""
+        fmt = (resource.format or "").upper()
+        if not resource.url:
+            raise ValueError(f"Resource {resource.id} has no download URL")
+
+        suffix = client._suffix_for_format(fmt)
+        filepath = client.download_to_tempfile(resource.url, suffix=suffix)
+
+        try:
+            if fmt == "GEOJSON":
+                geometry_column = self.engine._get_geometry_column(
+                    spec.target_table, spec.target_schema
+                )
+                batches, geojson_result = parse_geojson(
+                    filepath, geometry_column=geometry_column
+                )
+            else:
+                batches = parse_csv(filepath)
+
+            table_columns = self._get_table_columns(spec.target_table, spec.target_schema)
+
+            for batch in batches:
+                batch = self._strip_ckan_internal_columns(batch)
+                batch = self._filter_to_table_columns(batch, table_columns)
+                stager.write_batch(batch)
+
+        finally:
+            filepath.unlink(missing_ok=True)
+
+    # ------------------------------------------------------------------
+    # Table column helpers
+    # ------------------------------------------------------------------
+
+    def _get_table_columns(self, target_table: str, target_schema: str) -> set[str]:
+        df = self.engine.query(
+            """
+            select column_name
+            from information_schema.columns
+            where table_schema = %(schema)s and table_name = %(table)s
+            """,
+            {"schema": target_schema, "table": target_table},
+        )
+        return set(df["column_name"])
+
+    def _filter_to_table_columns(
+        self, rows: list[dict[str, Any]], table_columns: set[str]
+    ) -> list[dict[str, Any]]:
+        dropped = set()
+        for row in rows:
+            extra = set(row.keys()) - table_columns
+            for k in extra:
+                del row[k]
+            dropped.update(extra)
+        if dropped:
+            self.logger.warning("Dropped columns not in target table: %s", dropped)
+        return rows
+
+    @staticmethod
+    def _strip_ckan_internal_columns(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Remove CKAN internal columns (_id, _full_text) from rows."""
+        for row in rows:
+            for col in CKANCollector.CKAN_INTERNAL_COLUMNS:
+                row.pop(col, None)
+        return rows
+
+    # ------------------------------------------------------------------
+    # DDL generation
+    # ------------------------------------------------------------------
+
+    def generate_ddl(self, spec: CKANDatasetSpec) -> str:
+        """
+        Generate a CREATE TABLE statement for a CKANDatasetSpec.
+
+        Column discovery strategy:
+        1. If any resolved resource has DataStore enabled, use DataStore
+           field metadata (gives us column names and types).
+        2. Otherwise, download a sample of the first resource file and
+           read CSV headers (all columns typed as text).
+
+        If the spec has an entity_key, SCD2 columns (record_hash, valid_from,
+        valid_to) and a unique constraint + partial index are included.
+        """
+        client = self._get_client(spec.base_url)
+        resources = self._resolve_resources(spec)
+
+        columns = self._discover_columns(client, resources, spec)
+        self._validate_columns_across_resources(client, resources, spec, columns)
+
+        return self._build_ddl(spec, columns)
+
+    def _discover_columns(
+        self,
+        client: CKANClient,
+        resources: list[CKANResource],
+        spec: CKANDatasetSpec,
+    ) -> list[tuple[str, str]]:
+        """Return a list of (column_name, pg_type) for the dataset.
+
+        Tries DataStore first, falls back to file header scanning.
+        """
+        # Try DataStore on the first resource
+        first = resources[0]
+        if first.datastore_active or client.metadata.has_datastore(first.id):
+            self.logger.info("Using DataStore fields for column discovery on %s", first.id)
+            return self._columns_from_datastore(client, first.id)
+
+        # Fall back to file header scanning
+        self.logger.info("DataStore not available, scanning file for column discovery")
+        return self._columns_from_file(client, first)
+
+    def _columns_from_datastore(
+        self, client: CKANClient, resource_id: str
+    ) -> list[tuple[str, str]]:
+        """Get columns from DataStore field metadata."""
+        fields = client.metadata.get_datastore_fields(resource_id)
+        columns = []
+        for field in fields:
+            name = field["id"]
+            ckan_type = field.get("type", "text")
+            pg_type = self.DATASTORE_TYPE_MAP.get(ckan_type, "text")
+            columns.append((name, pg_type))
+        return columns
+
+    def _columns_from_file(
+        self, client: CKANClient, resource: CKANResource
+    ) -> list[tuple[str, str]]:
+        """Download a resource file and infer columns from headers.
+
+        For CSV: reads the header row, all columns typed as text.
+        For GeoJSON: reads the first feature's properties, all typed as text,
+        plus a 'geom' geometry column.
+        """
+        fmt = (resource.format or "").upper()
+        suffix = client._suffix_for_format(fmt)
+        filepath = client.download_to_tempfile(resource.url, suffix=suffix)
+
+        try:
+            if fmt == "GEOJSON":
+                return self._columns_from_geojson_file(filepath)
+            else:
+                return self._columns_from_csv_file(filepath)
+        finally:
+            filepath.unlink(missing_ok=True)
+
+    def _columns_from_csv_file(self, filepath: Path) -> list[tuple[str, str]]:
+        """Read CSV headers and return (name, 'text') pairs."""
+        with open(filepath, encoding="utf-8", newline="") as f:
+            reader = csv.reader(f)
+            headers = next(reader)
+        return [(h.strip(), "text") for h in headers if h.strip()]
+
+    def _columns_from_geojson_file(self, filepath: Path) -> list[tuple[str, str]]:
+        """Read the first GeoJSON feature's properties for column names."""
+        import ijson
+
+        with open(filepath, "rb") as f:
+            for feat in ijson.items(f, "features.item"):
+                props = feat.get("properties") or {}
+                columns = [(k, "text") for k in props.keys()]
+                columns.append(("geom", "geometry"))
+                return columns
+
+        raise ValueError(f"No features found in {filepath}")
+
+    def _validate_columns_across_resources(
+        self,
+        client: CKANClient,
+        resources: list[CKANResource],
+        spec: CKANDatasetSpec,
+        columns: list[tuple[str, str]],
+    ) -> None:
+        """Check that all resources have the same columns. Fails hard on mismatch."""
+        if len(resources) <= 1:
+            return
+
+        expected_names = {name for name, _ in columns}
+
+        for resource in resources[1:]:
+            if resource.datastore_active or client.metadata.has_datastore(resource.id):
+                fields = client.metadata.get_datastore_fields(resource.id)
+                other_names = {f["id"] for f in fields}
+            else:
+                # For file-based resources, we'd need to download and check headers.
+                # Only do this if the resource format is CSV (cheap to read one line).
+                fmt = (resource.format or "").upper()
+                if fmt in ("CSV", "TSV"):
+                    suffix = client._suffix_for_format(fmt)
+                    filepath = client.download_to_tempfile(resource.url, suffix=suffix)
+                    try:
+                        with open(filepath, encoding="utf-8", newline="") as f:
+                            reader = csv.reader(f)
+                            headers = next(reader)
+                        other_names = {h.strip() for h in headers if h.strip()}
+                    finally:
+                        filepath.unlink(missing_ok=True)
+                else:
+                    self.logger.warning(
+                        "Cannot validate columns for non-CSV resource %s (%s), skipping",
+                        resource.id,
+                        resource.format,
+                    )
+                    continue
+
+            if other_names != expected_names:
+                extra = other_names - expected_names
+                missing = expected_names - other_names
+                raise ValueError(
+                    f"Column mismatch between resources. "
+                    f"Resource {resource.id} has extra columns {extra} "
+                    f"and is missing columns {missing} compared to {resources[0].id}."
+                )
+
+    def _build_ddl(
+        self,
+        spec: CKANDatasetSpec,
+        columns: list[tuple[str, str]],
+    ) -> str:
+        """Assemble the CREATE TABLE DDL string."""
+        fqn = f"{spec.target_schema}.{spec.target_table}"
+
+        col_defs = []
+        for name, pg_type in columns:
+            if pg_type == "geometry":
+                col_defs.append(f'    "{name}" geometry')
+            else:
+                col_defs.append(f'    "{name}" {pg_type}')
+
+        # Ingestion metadata
+        col_defs.append(
+            "    \"ingested_at\" timestamptz not null default (now() at time zone 'UTC')"
+        )
+
+        # SCD2 columns (always included — entity_key controls whether the
+        # unique constraint and index are added)
+        if spec.entity_key:
+            col_defs.append('    "record_hash" text not null')
+            col_defs.append(
+                "    \"valid_from\" timestamptz not null default (now() at time zone 'UTC')"
+            )
+            col_defs.append('    "valid_to" timestamptz')
+
+        ddl = f"create table if not exists {fqn} (\n"
+        ddl += ",\n".join(col_defs)
+        ddl += "\n);\n"
+
+        if spec.entity_key:
+            ek_cols = ", ".join(f'"{c}"' for c in spec.entity_key)
+            constraint_name = f"uq_{spec.target_table}_entity_hash"
+            index_name = f"ix_{spec.target_table}_current"
+
+            ddl += (
+                f"\nalter table {fqn}\n"
+                f"    add constraint {constraint_name}\n"
+                f'    unique ({ek_cols}, "record_hash");\n'
+            )
+            ddl += (
+                f"\ncreate index if not exists {index_name}\n"
+                f"    on {fqn} ({ek_cols})\n"
+                f"    where valid_to is null;\n"
+            )
+
+        return ddl
+
+    # ------------------------------------------------------------------
+    # Convenience
+    # ------------------------------------------------------------------
+
+    def preview(
+        self,
+        spec: CKANDatasetSpec,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Return a few rows from the first resolved resource.
+
+        Tries DataStore first for a quick preview. Falls back to
+        downloading the file and reading the first few rows.
+        """
+        client = self._get_client(spec.base_url)
+        resources = self._resolve_resources(spec)
+        first = resources[0]
+
+        if first.datastore_active or client.metadata.has_datastore(first.id):
+            return client.datastore_search(first.id, limit=limit)
+
+        # File fallback: download and parse just enough rows
+        suffix = client._suffix_for_format(first.format or "csv")
+        filepath = client.download_to_tempfile(first.url, suffix=suffix)
+        try:
+            rows = []
+            for batch in parse_csv(filepath):
+                rows.extend(batch)
+                if len(rows) >= limit:
+                    break
+            return rows[:limit]
+        finally:
+            filepath.unlink(missing_ok=True)
+
+    def print_ddl(self, spec: CKANDatasetSpec) -> None:
+        """Generate and print DDL for easy copy-paste into a migration script."""
+        print(self.generate_ddl(spec))

--- a/platform/airflow/dags/loci/collectors/ckan/collector.py
+++ b/platform/airflow/dags/loci/collectors/ckan/collector.py
@@ -73,10 +73,11 @@ class CKANCollector:
         self,
         engine: Any,
         tracker: IngestionTracker | None = None,
+        logger: logging.Logger | None = None,
     ) -> None:
         self.engine = engine
         self.tracker = tracker or IngestionTracker(engine=self.engine)
-        self.logger = logging.getLogger("ckan_collector")
+        self.logger = logger or logging.getLogger("ckan_collector")
 
         self._client_cache: dict[str, CKANClient] = {}
 
@@ -159,7 +160,7 @@ class CKANCollector:
                 target_table=spec.target_table,
                 target_schema=spec.target_schema,
                 metadata_columns=self.PIPELINE_COLUMNS,
-                hash_exclude_columns=self.PIPELINE_COLUMNS,
+                hash_exclude_columns=self.PIPELINE_COLUMNS | self.CKAN_INTERNAL_COLUMNS,
                 **staged_ingest_kwargs,
             ) as stager:
                 for resource in resources:
@@ -243,6 +244,11 @@ class CKANCollector:
                 row.pop(col, None)
         return rows
 
+    @classmethod
+    def _exclude_internal(cls, names: set[str]) -> set[str]:
+        """Remove CKAN internal column names from a set of column names."""
+        return names - cls.CKAN_INTERNAL_COLUMNS
+
     # ------------------------------------------------------------------
     # DDL generation
     # ------------------------------------------------------------------
@@ -291,11 +297,17 @@ class CKANCollector:
     def _columns_from_datastore(
         self, client: CKANClient, resource_id: str
     ) -> list[tuple[str, str]]:
-        """Get columns from DataStore field metadata."""
+        """Get columns from DataStore field metadata.
+
+        CKAN internal columns (_id, _full_text) are excluded — they are
+        DataStore implementation details, not part of the dataset.
+        """
         fields = client.metadata.get_datastore_fields(resource_id)
         columns = []
         for field in fields:
             name = field["id"]
+            if name in self.CKAN_INTERNAL_COLUMNS:
+                continue
             ckan_type = field.get("type", "text")
             pg_type = self.DATASTORE_TYPE_MAP.get(ckan_type, "text")
             columns.append((name, pg_type))
@@ -323,20 +335,36 @@ class CKANCollector:
             filepath.unlink(missing_ok=True)
 
     def _columns_from_csv_file(self, filepath: Path) -> list[tuple[str, str]]:
-        """Read CSV headers and return (name, 'text') pairs."""
+        """Read CSV headers and return (name, 'text') pairs.
+
+        CKAN internal columns (_id, _full_text) are excluded — they can
+        appear in CSV exports from CKAN's DataStore.
+        """
         with open(filepath, encoding="utf-8", newline="") as f:
             reader = csv.reader(f)
             headers = next(reader)
-        return [(h.strip(), "text") for h in headers if h.strip()]
+        return [
+            (h.strip(), "text")
+            for h in headers
+            if h.strip() and h.strip() not in self.CKAN_INTERNAL_COLUMNS
+        ]
 
     def _columns_from_geojson_file(self, filepath: Path) -> list[tuple[str, str]]:
-        """Read the first GeoJSON feature's properties for column names."""
+        """Read the first GeoJSON feature's properties for column names.
+
+        CKAN internal columns (_id, _full_text) are excluded — they can
+        appear in GeoJSON exports from CKAN's DataStore.
+        """
         import ijson
 
         with open(filepath, "rb") as f:
             for feat in ijson.items(f, "features.item"):
                 props = feat.get("properties") or {}
-                columns = [(k, "text") for k in props.keys()]
+                columns = [
+                    (k, "text")
+                    for k in props.keys()
+                    if k not in self.CKAN_INTERNAL_COLUMNS
+                ]
                 columns.append(("geom", "geometry"))
                 return columns
 
@@ -358,7 +386,7 @@ class CKANCollector:
         for resource in resources[1:]:
             if resource.datastore_active or client.metadata.has_datastore(resource.id):
                 fields = client.metadata.get_datastore_fields(resource.id)
-                other_names = {f["id"] for f in fields}
+                other_names = self._exclude_internal({f["id"] for f in fields})
             else:
                 # For file-based resources, we'd need to download and check headers.
                 # Only do this if the resource format is CSV (cheap to read one line).
@@ -370,7 +398,9 @@ class CKANCollector:
                         with open(filepath, encoding="utf-8", newline="") as f:
                             reader = csv.reader(f)
                             headers = next(reader)
-                        other_names = {h.strip() for h in headers if h.strip()}
+                        other_names = self._exclude_internal(
+                            {h.strip() for h in headers if h.strip()}
+                        )
                     finally:
                         filepath.unlink(missing_ok=True)
                 else:

--- a/platform/airflow/dags/loci/collectors/ckan/collector.py
+++ b/platform/airflow/dags/loci/collectors/ckan/collector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -73,11 +74,10 @@ class CKANCollector:
         self,
         engine: Any,
         tracker: IngestionTracker | None = None,
-        logger: logging.Logger | None = None,
     ) -> None:
         self.engine = engine
         self.tracker = tracker or IngestionTracker(engine=self.engine)
-        self.logger = logger or logging.getLogger("ckan_collector")
+        self.logger = logging.getLogger("ckan_collector")
 
         self._client_cache: dict[str, CKANClient] = {}
 
@@ -192,16 +192,24 @@ class CKANCollector:
                 geometry_column = self.engine._get_geometry_column(
                     spec.target_table, spec.target_schema
                 )
-                batches, geojson_result = parse_geojson(
-                    filepath, geometry_column=geometry_column
-                )
+                batches, geojson_result = parse_geojson(filepath, geometry_column=geometry_column)
             else:
                 batches = parse_csv(filepath)
 
             table_columns = self._get_table_columns(spec.target_table, spec.target_schema)
+            name_map: dict[str, str] | None = None
 
             for batch in batches:
                 batch = self._strip_ckan_internal_columns(batch)
+
+                # Build the raw -> normalized name map from the first batch's keys
+                # and reuse it for all subsequent batches from this resource.
+                if name_map is None and batch:
+                    name_map = self._normalize_column_names(list(batch[0].keys()))
+
+                if name_map:
+                    batch = self._rename_batch_keys(batch, name_map)
+
                 batch = self._filter_to_table_columns(batch, table_columns)
                 stager.write_batch(batch)
 
@@ -244,10 +252,65 @@ class CKANCollector:
                 row.pop(col, None)
         return rows
 
+    @staticmethod
+    def _rename_batch_keys(
+        rows: list[dict[str, Any]], name_map: dict[str, str]
+    ) -> list[dict[str, Any]]:
+        """Rename dict keys in each row using the raw -> normalized mapping.
+
+        Keys not in the mapping are dropped (they produced empty normalized
+        names, e.g. a header of whitespace only).
+        """
+        return [{name_map[k]: v for k, v in row.items() if k in name_map} for row in rows]
+
     @classmethod
     def _exclude_internal(cls, names: set[str]) -> set[str]:
         """Remove CKAN internal column names from a set of column names."""
         return names - cls.CKAN_INTERNAL_COLUMNS
+
+    @staticmethod
+    def _normalize_column_name(raw: str) -> str:
+        """Normalize a single column name: lowercase, non-alphanumerics -> '_', trim '_'."""
+        return re.sub(r"[^a-z0-9]+", "_", raw.lower()).strip("_")
+
+    def _normalize_column_names(self, raw_names: list[str]) -> dict[str, str]:
+        """Build an ordered raw -> normalized mapping with collision handling.
+
+        When two raw names normalize to the same value, the later one is
+        suffixed with '_2', '_3', etc. A warning is logged listing the raw
+        names involved.
+
+        Empty normalized names (e.g. from a header of '   ') are skipped.
+        """
+        mapping: dict[str, str] = {}
+        taken: dict[str, list[str]] = {}  # normalized -> [raw names that produced it]
+
+        for raw in raw_names:
+            base = self._normalize_column_name(raw)
+            if not base:
+                continue
+
+            if base not in taken:
+                taken[base] = [raw]
+                mapping[raw] = base
+                continue
+
+            # Collision: suffix _2, _3, ...
+            taken[base].append(raw)
+            suffix = len(taken[base])
+            candidate = f"{base}_{suffix}"
+            # Very unlikely but possible: the suffixed name also clashes.
+            while candidate in taken:
+                suffix += 1
+                candidate = f"{base}_{suffix}"
+            taken[candidate] = [raw]
+            mapping[raw] = candidate
+
+        collisions = {n: rs for n, rs in taken.items() if len(rs) > 1}
+        if collisions:
+            self.logger.warning("Column name collisions after normalization: %s", collisions)
+
+        return mapping
 
     # ------------------------------------------------------------------
     # DDL generation
@@ -283,16 +346,21 @@ class CKANCollector:
         """Return a list of (column_name, pg_type) for the dataset.
 
         Tries DataStore first, falls back to file header scanning.
+        Column names are normalized: lowercased, non-alphanumerics replaced
+        with '_', collisions suffixed with '_2', '_3', etc.
         """
         # Try DataStore on the first resource
         first = resources[0]
         if first.datastore_active or client.metadata.has_datastore(first.id):
             self.logger.info("Using DataStore fields for column discovery on %s", first.id)
-            return self._columns_from_datastore(client, first.id)
+            raw_columns = self._columns_from_datastore(client, first.id)
+        else:
+            self.logger.info("DataStore not available, scanning file for column discovery")
+            raw_columns = self._columns_from_file(client, first)
 
-        # Fall back to file header scanning
-        self.logger.info("DataStore not available, scanning file for column discovery")
-        return self._columns_from_file(client, first)
+        name_map = self._normalize_column_names([name for name, _ in raw_columns])
+        # Preserve order and types; drop any that normalized to empty.
+        return [(name_map[name], pg_type) for name, pg_type in raw_columns if name in name_map]
 
     def _columns_from_datastore(
         self, client: CKANClient, resource_id: str
@@ -360,11 +428,7 @@ class CKANCollector:
         with open(filepath, "rb") as f:
             for feat in ijson.items(f, "features.item"):
                 props = feat.get("properties") or {}
-                columns = [
-                    (k, "text")
-                    for k in props.keys()
-                    if k not in self.CKAN_INTERNAL_COLUMNS
-                ]
+                columns = [(k, "text") for k in props.keys() if k not in self.CKAN_INTERNAL_COLUMNS]
                 columns.append(("geom", "geometry"))
                 return columns
 
@@ -386,7 +450,8 @@ class CKANCollector:
         for resource in resources[1:]:
             if resource.datastore_active or client.metadata.has_datastore(resource.id):
                 fields = client.metadata.get_datastore_fields(resource.id)
-                other_names = self._exclude_internal({f["id"] for f in fields})
+                raw_names = [f["id"] for f in fields if f["id"] not in self.CKAN_INTERNAL_COLUMNS]
+                other_names = set(self._normalize_column_names(raw_names).values())
             else:
                 # For file-based resources, we'd need to download and check headers.
                 # Only do this if the resource format is CSV (cheap to read one line).
@@ -398,9 +463,12 @@ class CKANCollector:
                         with open(filepath, encoding="utf-8", newline="") as f:
                             reader = csv.reader(f)
                             headers = next(reader)
-                        other_names = self._exclude_internal(
-                            {h.strip() for h in headers if h.strip()}
-                        )
+                        raw_names = [
+                            h.strip()
+                            for h in headers
+                            if h.strip() and h.strip() not in self.CKAN_INTERNAL_COLUMNS
+                        ]
+                        other_names = set(self._normalize_column_names(raw_names).values())
                     finally:
                         filepath.unlink(missing_ok=True)
                 else:

--- a/platform/airflow/dags/loci/collectors/ckan/metadata.py
+++ b/platform/airflow/dags/loci/collectors/ckan/metadata.py
@@ -1,0 +1,105 @@
+import requests
+
+
+class CKANMetadata:
+    """A simple client for interacting with a CKAN data portal."""
+
+    def __init__(self, base_url: str):
+        # Strip trailing slash so we can build URLs cleanly
+        self.base_url = base_url.rstrip("/")
+
+    def _get(self, endpoint: str, params: dict | None = None) -> dict:
+        """Make a GET request to a CKAN API endpoint and return the JSON response."""
+        url = f"{self.base_url}/api/{endpoint}"
+        response = requests.get(url, params=params, timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+    def api_version(self) -> int:
+        """Return the API version number used by this CKAN portal."""
+        data = self._get("action/status_show")
+        return data["result"]["ckan_version"]
+
+    def list_datasets(self) -> list[str]:
+        """Return a list of all dataset names (package IDs) on this portal."""
+        data = self._get("action/package_list")
+        return data["result"]
+
+    def get_dataset_metadata(self, dataset_id: str) -> dict:
+        """Return the full metadata for a dataset and its resources.
+
+        dataset_id can be either the dataset's name (URL slug) or its UUID.
+        """
+        data = self._get("action/package_show", params={"id": dataset_id})
+        return data["result"]
+
+    def search_datasets(self, query: str, rows: int = 10) -> list[dict]:
+        """Search for datasets matching a query string.
+
+        Returns a list of dataset metadata dicts (up to `rows` results).
+        Uses CKAN's Solr-backed search, so standard Solr query syntax works.
+        """
+        data = self._get("action/package_search", params={"q": query, "rows": rows})
+        return data["result"]["results"]
+
+    def list_organizations(self) -> list[str]:
+        """Return a list of all organization names on this portal.
+
+        Organizations are the publishers — each dataset belongs to exactly one.
+        """
+        data = self._get("action/organization_list")
+        return data["result"]
+
+    def list_groups(self) -> list[str]:
+        """Return a list of all group names on this portal.
+
+        Groups are thematic collections of datasets that cut across organizations
+        (e.g. "Health", "Environment"). A dataset can belong to multiple groups.
+        """
+        data = self._get("action/group_list")
+        return data["result"]
+
+    def list_tags(self) -> list[str]:
+        """Return a list of all tags used across datasets on this portal."""
+        data = self._get("action/tag_list")
+        return data["result"]
+
+    def get_organization(self, org_id: str) -> dict:
+        """Return details for an organization, including its dataset count.
+
+        org_id can be the organization's name (URL slug) or UUID.
+        """
+        data = self._get(
+            "action/organization_show",
+            params={"id": org_id, "include_datasets": True},
+        )
+        return data["result"]
+
+    def get_group(self, group_id: str) -> dict:
+        """Return details for a group, including its datasets.
+
+        group_id can be the group's name (URL slug) or UUID.
+        """
+        data = self._get(
+            "action/group_show",
+            params={"id": group_id, "include_datasets": True},
+        )
+        return data["result"]
+
+    def get_tag(self, tag_id: str) -> dict:
+        """Return details for a tag, including the datasets that use it.
+
+        tag_id can be the tag's name or UUID.
+        """
+        data = self._get("action/tag_show", params={"id": tag_id})
+        return data["result"]
+
+    def find_resources(self, dataset_id: str, fmt: str) -> list[dict]:
+        """Return resources from a dataset that match a given format (e.g. 'CSV', 'GeoJSON').
+
+        The format comparison is case-insensitive.
+        """
+        meta = self.get_dataset_metadata(dataset_id)
+        return [
+            r for r in meta.get("resources", []) if (r.get("format") or "").upper() == fmt.upper()
+        ]

--- a/platform/airflow/dags/loci/collectors/ckan/metadata.py
+++ b/platform/airflow/dags/loci/collectors/ckan/metadata.py
@@ -1,105 +1,223 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
 import requests
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CKANResource:
+    """Lightweight wrapper around a CKAN resource dict."""
+
+    id: str
+    name: str | None
+    format: str | None
+    url: str | None
+    size: int | None
+    last_modified: str | None
+    created: str | None
+    datastore_active: bool
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CKANResource:
+        return cls(
+            id=d["id"],
+            name=d.get("name"),
+            format=(d.get("format") or "").upper() or None,
+            url=d.get("url"),
+            size=d.get("size"),
+            last_modified=d.get("last_modified"),
+            created=d.get("created"),
+            datastore_active=d.get("datastore_active", False),
+        )
 
 
 class CKANMetadata:
-    """A simple client for interacting with a CKAN data portal."""
+    """Client for exploring and introspecting a CKAN data portal."""
 
     def __init__(self, base_url: str):
-        # Strip trailing slash so we can build URLs cleanly
         self.base_url = base_url.rstrip("/")
+        self._api_base: str | None = None
+        self._session = requests.Session()
+        self.logger = logging.getLogger("ckan_metadata")
 
-    def _get(self, endpoint: str, params: dict | None = None) -> dict:
-        """Make a GET request to a CKAN API endpoint and return the JSON response."""
-        url = f"{self.base_url}/api/{endpoint}"
-        response = requests.get(url, params=params, timeout=30)
-        response.raise_for_status()
-        return response.json()
+    @property
+    def api_base(self) -> str:
+        """Resolve and cache the API base path (v3 preferred, v2 fallback)."""
+        if self._api_base is None:
+            self._api_base = self._detect_api_base()
+        return self._api_base
 
-    def api_version(self) -> int:
-        """Return the API version number used by this CKAN portal."""
-        data = self._get("action/status_show")
+    def _detect_api_base(self) -> str:
+        """Probe the portal to find a working API path.
+
+        Tries /api/3/action first (CKAN 2.2+), then /api/action (common alias),
+        then /api/2/rest as a last resort for very old portals.
+        """
+        candidates = [
+            "/api/3/action",
+            "/api/action",
+        ]
+        for path in candidates:
+            try:
+                url = f"{self.base_url}{path}/status_show"
+                resp = self._session.get(url, timeout=15)
+                if resp.status_code == 200 and resp.json().get("success"):
+                    self.logger.info("Using API base: %s", path)
+                    return f"{self.base_url}{path}"
+            except Exception:
+                continue
+
+        # Default to v3 — most portals support it even if status_show
+        # isn't available without auth.
+        self.logger.warning(
+            "Could not probe API version for %s, defaulting to /api/3/action",
+            self.base_url,
+        )
+        return f"{self.base_url}/api/3/action"
+
+    def _get(self, action: str, params: dict | None = None) -> dict:
+        """Make a GET request to a CKAN action endpoint and return the result."""
+        url = f"{self.api_base}/{action}"
+        resp = self._session.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("success"):
+            raise ValueError(f"CKAN API error on {action}: {data.get('error', data)}")
+        return data
+
+    # ------------------------------------------------------------------
+    # Portal exploration
+    # ------------------------------------------------------------------
+
+    def portal_version(self) -> str:
+        """Return the CKAN version string for this portal."""
+        data = self._get("status_show")
         return data["result"]["ckan_version"]
 
     def list_datasets(self) -> list[str]:
-        """Return a list of all dataset names (package IDs) on this portal."""
-        data = self._get("action/package_list")
+        """Return all dataset names (package IDs) on this portal."""
+        data = self._get("package_list")
         return data["result"]
 
     def get_dataset_metadata(self, dataset_id: str) -> dict:
-        """Return the full metadata for a dataset and its resources.
+        """Return full metadata for a dataset including its resources.
 
-        dataset_id can be either the dataset's name (URL slug) or its UUID.
+        dataset_id can be the package name (URL slug) or UUID.
         """
-        data = self._get("action/package_show", params={"id": dataset_id})
+        data = self._get("package_show", params={"id": dataset_id})
         return data["result"]
 
     def search_datasets(self, query: str, rows: int = 10) -> list[dict]:
         """Search for datasets matching a query string.
 
-        Returns a list of dataset metadata dicts (up to `rows` results).
         Uses CKAN's Solr-backed search, so standard Solr query syntax works.
         """
-        data = self._get("action/package_search", params={"q": query, "rows": rows})
+        data = self._get("package_search", params={"q": query, "rows": rows})
         return data["result"]["results"]
 
     def list_organizations(self) -> list[str]:
-        """Return a list of all organization names on this portal.
-
-        Organizations are the publishers — each dataset belongs to exactly one.
-        """
-        data = self._get("action/organization_list")
+        """Return all organization names on this portal."""
+        data = self._get("organization_list")
         return data["result"]
 
     def list_groups(self) -> list[str]:
-        """Return a list of all group names on this portal.
-
-        Groups are thematic collections of datasets that cut across organizations
-        (e.g. "Health", "Environment"). A dataset can belong to multiple groups.
-        """
-        data = self._get("action/group_list")
+        """Return all group names on this portal."""
+        data = self._get("group_list")
         return data["result"]
 
     def list_tags(self) -> list[str]:
-        """Return a list of all tags used across datasets on this portal."""
-        data = self._get("action/tag_list")
+        """Return all tags used across datasets on this portal."""
+        data = self._get("tag_list")
         return data["result"]
 
     def get_organization(self, org_id: str) -> dict:
-        """Return details for an organization, including its dataset count.
-
-        org_id can be the organization's name (URL slug) or UUID.
-        """
+        """Return details for an organization, including its datasets."""
         data = self._get(
-            "action/organization_show",
+            "organization_show",
             params={"id": org_id, "include_datasets": True},
         )
         return data["result"]
 
     def get_group(self, group_id: str) -> dict:
-        """Return details for a group, including its datasets.
-
-        group_id can be the group's name (URL slug) or UUID.
-        """
+        """Return details for a group, including its datasets."""
         data = self._get(
-            "action/group_show",
+            "group_show",
             params={"id": group_id, "include_datasets": True},
         )
         return data["result"]
 
     def get_tag(self, tag_id: str) -> dict:
-        """Return details for a tag, including the datasets that use it.
-
-        tag_id can be the tag's name or UUID.
-        """
-        data = self._get("action/tag_show", params={"id": tag_id})
+        """Return details for a tag, including datasets that use it."""
+        data = self._get("tag_show", params={"id": tag_id})
         return data["result"]
 
-    def find_resources(self, dataset_id: str, fmt: str) -> list[dict]:
-        """Return resources from a dataset that match a given format (e.g. 'CSV', 'GeoJSON').
+    # ------------------------------------------------------------------
+    # Resource helpers
+    # ------------------------------------------------------------------
 
-        The format comparison is case-insensitive.
-        """
+    def get_resources(self, dataset_id: str) -> list[CKANResource]:
+        """Return all resources for a dataset as CKANResource objects."""
         meta = self.get_dataset_metadata(dataset_id)
-        return [
-            r for r in meta.get("resources", []) if (r.get("format") or "").upper() == fmt.upper()
-        ]
+        return [CKANResource.from_dict(r) for r in meta.get("resources", [])]
+
+    def get_resource(self, resource_id: str) -> CKANResource:
+        """Return a single resource by its UUID."""
+        data = self._get("resource_show", params={"id": resource_id})
+        return CKANResource.from_dict(data["result"])
+
+    def find_resources(self, dataset_id: str, fmt: str) -> list[CKANResource]:
+        """Return resources from a dataset that match a given format (case-insensitive)."""
+        return [r for r in self.get_resources(dataset_id) if r.format == fmt.upper()]
+
+    def dataset_last_modified(self, dataset_id: str) -> str | None:
+        """Return the metadata_modified timestamp for a dataset, or None."""
+        meta = self.get_dataset_metadata(dataset_id)
+        return meta.get("metadata_modified")
+
+    # ------------------------------------------------------------------
+    # DataStore detection
+    # ------------------------------------------------------------------
+
+    def has_datastore(self, resource_id: str) -> bool:
+        """Check whether a resource has DataStore data available.
+
+        Tries a minimal datastore_search request. If the DataStore extension
+        is not installed or the resource isn't in the DataStore, this returns False.
+        """
+        try:
+            self._get(
+                "datastore_search",
+                params={"resource_id": resource_id, "limit": "0"},
+            )
+            return True
+        except Exception:
+            return False
+
+    def get_datastore_fields(self, resource_id: str) -> list[dict[str, str]]:
+        """Return the field definitions from the DataStore for a resource.
+
+        Each field is a dict with at least 'id' (column name) and 'type'
+        (e.g. 'text', 'int', 'numeric', 'timestamp').
+
+        Raises ValueError if the resource is not in the DataStore.
+        """
+        data = self._get(
+            "datastore_search",
+            params={"resource_id": resource_id, "limit": "0"},
+        )
+        fields = data["result"].get("fields", [])
+        # Filter out the internal _id field that CKAN adds automatically
+        return [f for f in fields if f.get("id") != "_id"]
+
+    def get_datastore_row_count(self, resource_id: str) -> int:
+        """Return the total number of rows in a DataStore resource."""
+        data = self._get(
+            "datastore_search",
+            params={"resource_id": resource_id, "limit": "0", "include_total": "true"},
+        )
+        return data["result"].get("total", 0)

--- a/platform/airflow/dags/loci/collectors/ckan/spec.py
+++ b/platform/airflow/dags/loci/collectors/ckan/spec.py
@@ -1,0 +1,78 @@
+"""
+CKANDatasetSpec — defines a CKAN dataset to collect.
+
+Usage:
+    from loci.collectors.ckan.spec import CKANDatasetSpec
+
+    spec = CKANDatasetSpec(
+        name="chicago_food_inspections",
+        base_url="https://data.cityofchicago.org",
+        dataset_id="4ijn-s7e5",
+        target_table="chicago_food_inspections",
+        entity_key=["inspection_id"],
+        resource_format="CSV",
+    )
+
+    # Or target specific resources by ID:
+    spec = CKANDatasetSpec(
+        name="transit_stops",
+        base_url="https://data.gov",
+        dataset_id="transit-stops-2024",
+        target_table="transit_stops",
+        resource_ids=["a1b2c3d4-...", "e5f6g7h8-..."],
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loci.collectors.base_spec import DatasetSpec
+
+
+@dataclass
+class CKANDatasetSpec(DatasetSpec):
+    """
+    Defines a CKAN dataset to collect.
+
+    Parameters
+    ----------
+    name : str
+        Human-readable name (e.g. "chicago_food_inspections").
+    base_url : str
+        Root URL of the CKAN portal (e.g. "https://data.cityofchicago.org").
+    dataset_id : str
+        CKAN package name (URL slug) or UUID.
+    target_table : str
+        Destination table name.
+    target_schema : str
+        Destination schema name. Default "raw_data".
+    entity_key : list[str] | None
+        Columns that uniquely identify a record for SCD2 merge.
+        None means append-only ingestion.
+    resource_ids : list[str] | None
+        Explicit list of CKAN resource UUIDs to ingest. If provided,
+        only these resources are downloaded. Takes precedence over
+        resource_format.
+    resource_format : str | None
+        Format filter (e.g. "CSV", "GeoJSON"). All resources matching
+        this format are ingested. Ignored if resource_ids is set.
+    """
+
+    name: str
+    base_url: str
+    dataset_id: str
+    target_table: str
+    target_schema: str = "raw_data"
+    entity_key: list[str] | None = None
+    resource_ids: list[str] | None = None
+    resource_format: str | None = None
+    source: str = "ckan"
+
+    def __post_init__(self):
+        self.base_url = self.base_url.rstrip("/")
+        if not self.resource_ids and not self.resource_format:
+            raise ValueError(
+                "Provide either resource_ids (explicit resource UUIDs) or "
+                "resource_format (e.g. 'CSV') to select which resources to ingest."
+            )

--- a/platform/airflow/dags/loci/collectors/osmnx/client.py
+++ b/platform/airflow/dags/loci/collectors/osmnx/client.py
@@ -243,7 +243,7 @@ class OsmnxClient:
         )
 
         # --- Base bike network ---
-        G = self._fetch_graph(bbox, network_type=network_type)
+        G = self._fetch_graph(bbox, network_type=network_type, simplify=simplify)
         self.logger.info(
             "Base bike graph: %d nodes, %d edges",
             G.number_of_nodes(),

--- a/platform/airflow/dags/loci/collectors/socrata/metadata.py
+++ b/platform/airflow/dags/loci/collectors/socrata/metadata.py
@@ -270,7 +270,7 @@ class SocrataTableMetadata:
     ) -> None:
         """Generate and print DDL for easy copy-paste into a migration script."""
         ddl = self.generate_ddl(
-            schema=schema,
+            # schema=schema,
             table_name=table_name,
             include_ingested_at=include_ingested_at,
             include_comments=include_comments,

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -788,7 +788,7 @@ CHICAGO_HOMICIDE_AND_NON_FATAL_SHOOTING_VICTIMIZATIONS_SPEC = SocrataDatasetSpec
 #    CKAN                                                                             #
 #######################################################################################
 
-crash_spec = CKANDatasetSpec(
+TORONTO_SERIOUS_MOTOR_VEHICLE_COLLISIONS_SPEC = CKANDatasetSpec(
     name="toronto_serious_motor_vehicle_collisions",
     base_url="https://ckan0.cf.opendata.inter.prod-toronto.ca",
     dataset_id="motor-vehicle-collisions-involving-killed-or-seriously-injured-persons",

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -1,5 +1,6 @@
 from loci.collectors.bike_index.spec import BikeIndexDatasetSpec
 from loci.collectors.census.spec import CensusDatasetSpec
+from loci.collectors.ckan.spec import CKANDatasetSpec
 from loci.collectors.osm.spec import OsmDatasetSpec
 from loci.collectors.osmnx.spec import OsmnxDatasetSpec
 from loci.collectors.socrata.spec import SocrataDatasetSpec
@@ -780,4 +781,19 @@ CHICAGO_HOMICIDE_AND_NON_FATAL_SHOOTING_VICTIMIZATIONS_SPEC = SocrataDatasetSpec
     target_schema="raw_data",
     entity_key=["unique_id"],
     full_update_mode="api",
+)
+
+
+#######################################################################################
+#    CKAN                                                                             #
+#######################################################################################
+
+crash_spec = CKANDatasetSpec(
+    name="toronto_serious_motor_vehicle_collisions",
+    base_url="https://ckan0.cf.opendata.inter.prod-toronto.ca",
+    dataset_id="motor-vehicle-collisions-involving-killed-or-seriously-injured-persons",
+    target_table="toronto_serious_motor_vehicle_collisions",
+    target_schema="raw_data",
+    entity_key=["collision_id", "per_no"],
+    resource_ids=["f8faf384-a96d-4dff-af59-db40f777c7d3"],
 )

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -797,3 +797,13 @@ TORONTO_SERIOUS_MOTOR_VEHICLE_COLLISIONS_SPEC = CKANDatasetSpec(
     entity_key=["collision_id", "per_no"],
     resource_ids=["f8faf384-a96d-4dff-af59-db40f777c7d3"],
 )
+
+TORONTO_BICYCLE_PARKING_RACKS_SPEC = CKANDatasetSpec(
+    name="toronto_bicycle_parking_racks",
+    base_url="https://ckan0.cf.opendata.inter.prod-toronto.ca",
+    dataset_id="bicycle-parking-racks",
+    target_table="toronto_bicycle_parking_racks",
+    target_schema="raw_data",
+    entity_key=["objectid"],
+    resource_ids=["4d105465-6e64-4a69-957b-6e0eee5bca8b"],
+)

--- a/platform/airflow/dags/loci/sources/update_configs.py
+++ b/platform/airflow/dags/loci/sources/update_configs.py
@@ -613,3 +613,15 @@ OSMNX_CHICAGO_BIKE_NETWORK_UC = DatasetUpdateConfig(
     full_update_day_of_week=4,
     full_update_mode="api",
 )
+
+#######################################################################################
+#    CKAN                                                                             #
+#######################################################################################
+
+TORONTO_SERIOUS_MOTOR_VEHICLE_COLLISIONS_UC = DatasetUpdateConfig(
+    spec=specs.TORONTO_SERIOUS_MOTOR_VEHICLE_COLLISIONS_SPEC,
+    update_cron="0 6 * * 2",
+    full_update_week_of_month=1,
+    full_update_day_of_week=4,
+    full_update_mode="api",
+)

--- a/platform/airflow/dags/loci/sources/update_configs.py
+++ b/platform/airflow/dags/loci/sources/update_configs.py
@@ -625,3 +625,11 @@ TORONTO_SERIOUS_MOTOR_VEHICLE_COLLISIONS_UC = DatasetUpdateConfig(
     full_update_day_of_week=4,
     full_update_mode="api",
 )
+
+TORONTO_BICYCLE_PARKING_RACKS_UC = DatasetUpdateConfig(
+    spec=specs.TORONTO_BICYCLE_PARKING_RACKS_SPEC,
+    update_cron="3 6 * * 2",
+    full_update_week_of_month=1,
+    full_update_day_of_week=4,
+    full_update_mode="api",
+)

--- a/platform/airflow/dags/loci/tasks/ckan_tasks.py
+++ b/platform/airflow/dags/loci/tasks/ckan_tasks.py
@@ -1,0 +1,41 @@
+import shutil
+from logging import Logger
+from pathlib import Path
+
+from airflow.sdk import task, task_group
+from airflow.sdk.bases.operator import chain
+from loci.collectors.ckan.collector import CKANCollector
+from loci.db.af_utils import get_postgres_engine
+from loci.sources.update_configs import DatasetUpdateConfig
+from loci.tasks.task_utils import check_ingestion_log
+from loci.tracking.ingestion_tracker import IngestionTracker
+
+
+def _get_collector(conn_id: str, task_logger: Logger) -> CKANCollector:
+    pg_engine = get_postgres_engine(conn_id=conn_id, logger=task_logger)
+    tracker = IngestionTracker(engine=pg_engine)
+    return CKANCollector(engine=pg_engine, logger=task_logger, tracker=tracker)
+
+
+@task
+def run_full_update(update_config: DatasetUpdateConfig, conn_id: str, task_logger: Logger) -> bool:
+    collector = _get_collector(conn_id, task_logger)
+    summary_results = collector.full_refresh(spec=update_config.spec)
+    task_logger.info("Collection summary", extra={"payload": summary_results})
+    return True
+
+
+@task_group
+def update_ckan_table(
+    update_config: DatasetUpdateConfig,
+    conn_id: str,
+    task_logger: Logger,
+) -> None:
+    _full_update = run_full_update(
+        conn_id=conn_id, update_config=update_config, task_logger=task_logger
+    )
+    _check_ingestion_log = check_ingestion_log(
+        conn_id=conn_id, update_config=update_config, task_logger=task_logger
+    )
+
+    chain(_full_update, _check_ingestion_log)

--- a/platform/migrations/postgres/V36__adjust_names.sql
+++ b/platform/migrations/postgres/V36__adjust_names.sql
@@ -1,0 +1,2 @@
+alter table raw_data.osmnx_bike_network_nodes rename to osmnx_chicago_bike_network_nodes;
+alter table raw_data.osmnx_bike_network_edges rename to osmnx_chicago_bike_network_edges;

--- a/platform/migrations/postgres/V37__adjust_names_back.sql
+++ b/platform/migrations/postgres/V37__adjust_names_back.sql
@@ -1,0 +1,2 @@
+alter table raw_data.osmnx_chicago_bike_network_nodes rename to osmnx_bike_network_nodes;
+alter table raw_data.osmnx_chicago_bike_network_edges rename to osmnx_bike_network_edges;

--- a/platform/migrations/postgres/V38__adds_ckan_dataset_ddl.sql
+++ b/platform/migrations/postgres/V38__adds_ckan_dataset_ddl.sql
@@ -1,0 +1,101 @@
+create table if not exists raw_data.toronto_serious_motor_vehicle_collisions (
+    "collision_id" text,
+    "accdate" text,
+    "stname1" text,
+    "stname2" text,
+    "stname3" text,
+    "per_inv" text,
+    "acclass" text,
+    "accloc" text,
+    "traffictl" text,
+    "impactype" text,
+    "visible" text,
+    "light" text,
+    "rdsfcond" text,
+    "road_class" text,
+    "failtorem" text,
+    "longitude" text,
+    "latitude" text,
+    "veh_no" text,
+    "vehtype" text,
+    "initdir" text,
+    "per_no" text,
+    "invage" text,
+    "injury" text,
+    "safequip" text,
+    "drivact" text,
+    "drivcond" text,
+    "pedact" text,
+    "pedcond" text,
+    "manoeuvre" text,
+    "pedtype" text,
+    "cyclistype" text,
+    "cycact" text,
+    "cyccond" text,
+    "road_user" text,
+    "fatal_no" text,
+    "wardname" text,
+    "division" text,
+    "neighbourhood" text,
+    "aggressive" text,
+    "distracted" text,
+    "cyclist" text,
+    "motorcyclist" text,
+    "other_micromobility" text,
+    "older_adult" text,
+    "pedestrian" text,
+    "red_light" text,
+    "school_child" text,
+    "heavy_truck" text,
+    "geom" geometry,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.toronto_serious_motor_vehicle_collisions
+    add constraint uq_toronto_serious_motor_vehicle_collisions_entity_hash
+    unique ("collision_id", "per_no", "record_hash");
+create index if not exists ix_toronto_serious_motor_vehicle_collisions_current
+    on raw_data.toronto_serious_motor_vehicle_collisions ("collision_id", "per_no")
+    where valid_to is null;
+
+
+create table if not exists raw_data.toronto_bicycle_parking_racks (
+    "address_point_id" text,
+    "address_number" text,
+    "linear_name_full" text,
+    "address_full" text,
+    "postal_code" text,
+    "municipality" text,
+    "city" text,
+    "centreline_id" text,
+    "lo_num" text,
+    "lo_num_suf" text,
+    "hi_num" text,
+    "hi_num_suf" text,
+    "linear_name_id" text,
+    "ward_name" text,
+    "mi_prinx" text,
+    "objectid" text,
+    "capacity" text,
+    "multimodal" text,
+    "seasonal" text,
+    "sheltered" text,
+    "surface" text,
+    "status" text,
+    "location" text,
+    "notes" text,
+    "map_class" text,
+    "geom" geometry,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.toronto_bicycle_parking_racks
+    add constraint uq_toronto_bicycle_parking_racks_entity_hash
+    unique ("objectid", "record_hash");
+create index if not exists ix_toronto_bicycle_parking_racks_current
+    on raw_data.toronto_bicycle_parking_racks ("objectid")
+    where valid_to is null;


### PR DESCRIPTION
Changes:
* Adds tooling to collect datasets from CKAN data portals (closes #141)
    * CKAN is rarely used by US cities but it's used by the US Federal data.gov and by many Canadian cities.
*  Improves language on the site, adding terms of service and a privacy policy (closes #142)

## Example workflow for developing a CKANDatasetSpec

Determining the entitity_id takes a bit more work, but this is the general process to determine a preliminary spec that you can use to stand up a table, run a collection, and determine ingest 

```python
ckan_metadata = CKANMetadata("https://ckan0.cf.opendata.inter.prod-toronto.ca")
toronto_datasets = ckan_metadata.list_datasets()
[ds for ds in toronto_datasets if "bicycle" in ds]
['bicycle-and-micromobility-cordon-count',
 'bicycle-cordon-count-2010-2013-2014',
 'bicycle-count-and-locations',
 'bicycle-counts',
 'bicycle-parking-bike-stations-indoor',
 'bicycle-parking-high-capacity-outdoor',
 'bicycle-parking-racks',
 'bicycle-post-and-ring-locations',
 'bicycle-shops',
 'bicycle-thefts',
 'permanent-bicycle-counters',
 'street-furniture-bicycle-parking']

ds_metadata = ckan_metadata.get_dataset_metadata("bicycle-parking-racks")
[d for d in ds_metadata["resources"] if d["datastore_active"] == True]
[{'cache_last_updated': None,
  'cache_url': None,
  'created': '2020-12-02T16:19:36.152957',
  'datastore_active': True,
  'datastore_cache': {'CSV': {'4326': '3526d6da-040d-4475-8009-5fd07eaabbfa',
    '2952': 'a6ef4cc6-af39-4d0f-9b72-079415c6a5e9'},
   'SHP': {'4326': 'f6d248d6-1f49-480d-972a-b10000cb70cb',
    '2952': 'bbedab50-f7bd-40ab-9e60-de4ea889021d'},
   'GPKG': {'4326': '42bed328-8de9-489a-8102-251812a95bee',
    '2952': 'd855cf1d-a422-43a6-8a74-052cc2954c64'},
   'GEOJSON': {'4326': '4d105465-6e64-4a69-957b-6e0eee5bca8b'}},
  'datastore_cache_last_update': '2026-02-20T21:30:08.315555',
  'extract_job': 'N1_BikeParkingRacks',
  'format': 'GeoJSON',
  'hash': '',
  'id': '12ef161c-1553-43f6-8180-fed700e42912',
  'is_datastore_cache_file': False,
  'is_preview': True,
  'last_modified': '2022-11-28T10:00:21.000670',
  'metadata_modified': '2026-02-20T21:30:08.697190',
  'mimetype': None,
  'mimetype_inner': None,
  'name': 'Bicycle Parking Racks Data',
  'package_id': '4ddba232-d235-4455-b710-537c89dec7d5',
  'position': 1,
  'record_count': 241,
  'resource_type': None,
  'revision_id': '3a647796-ba54-4e12-8fe8-189af0ab13a0',
  'size': None,
  'state': 'active',
  'url': 'https://ckan0.cf.opendata.inter.prod-toronto.ca/datastore/dump/12ef161c-1553-43f6-8180-fed700e42912',
  'url_type': 'datastore',
  'vertex_count': 241}]

TORONTO_BICYCLE_PARKING_RACKS_SPEC = CKANDatasetSpec(
    name="toronto_bicycle_parking_racks",
    base_url="https://ckan0.cf.opendata.inter.prod-toronto.ca",
    dataset_id="bicycle-parking-racks",
    target_table="toronto_bicycle_parking_racks",
    target_schema="raw_data",
    resource_ids=["4d105465-6e64-4a69-957b-6e0eee5bca8b"],
)
```

## Example workflow 

```python
ckan_collector = CKANCollector(postgis_engine)
ddl = ckan_collector.generate_ddl(TORONTO_BICYCLE_PARKING_RACKS_SPEC)
print(ddl)
create table if not exists raw_data.toronto_bicycle_parking_racks (
    "address_point_id" text,
    "address_number" text,
    "linear_name_full" text,
    "address_full" text,
    "postal_code" text,
    "municipality" text,
    "city" text,
    "centreline_id" text,
    "lo_num" text,
    "lo_num_suf" text,
    "hi_num" text,
    "hi_num_suf" text,
    "linear_name_id" text,
    "ward_name" text,
    "mi_prinx" text,
    "objectid" text,
    "capacity" text,
    "multimodal" text,
    "seasonal" text,
    "sheltered" text,
    "surface" text,
    "status" text,
    "location" text,
    "notes" text,
    "map_class" text,
    "geom" geometry,
    "ingested_at" timestamptz not null default (now() at time zone 'UTC')
);

postgis_engine.execute(ddl)
ckan_collector.full_refresh(spec=TORONTO_BICYCLE_PARKING_RACKS_SPEC)
2026-04-17 16:14:55,216 - postgres_engine - INFO - StagedIngest: staging table _staging_toronto_bicycle_parking_racks6d618e2c for target raw_data.toronto_bicycle_parking_racks (mode: scd2)
2026-04-17 16:14:55,359 - postgres_engine - INFO - Created staging table _staging_toronto_bicycle_parking_racks6d618e2c
2026-04-17 16:14:55,364 - postgres_engine - INFO - write_batch: 241 rows (buffer=0.00s, copy=0.00s)
2026-04-17 16:14:55,364 - postgres_engine - INFO - Casting geometry column 'geom' in staging table
2026-04-17 16:14:55,366 - postgres_engine - INFO - SCD2: hashing columns: ['address_point_id', 'address_number', 'linear_name_full', 'address_full', 'postal_code', 'municipality', 'city', 'centreline_id', 'lo_num', 'lo_num_suf', 'hi_num', 'hi_num_suf', 'linear_name_id', 'ward_name', 'mi_prinx', 'capacity', 'multimodal', 'seasonal', 'sheltered', 'surface', 'status', 'location', 'notes', 'map_class', 'geom']
2026-04-17 16:14:55,368 - postgres_engine - INFO - SCD2: closed out 0 superseded versions in raw_data.toronto_bicycle_parking_racks
2026-04-17 16:14:55,374 - postgres_engine - INFO - SCD2: inserted 241 new versions into raw_data.toronto_bicycle_parking_racks (staged 241, invalidated 0, closed 0)
2026-04-17 16:14:55,382 - postgres_engine - INFO - Dropped staging table _staging_toronto_bicycle_parking_racks6d618e2c

postgis_engine.query("""
    select count(*), objectid
    from raw_data.toronto_bicycle_parking_racks
    group by objectid
    having count(*) > 1 """)

TORONTO_BICYCLE_PARKING_RACKS_SPEC = CKANDatasetSpec(
    name="toronto_bicycle_parking_racks",
    base_url="https://ckan0.cf.opendata.inter.prod-toronto.ca",
    dataset_id="bicycle-parking-racks",
    target_table="toronto_bicycle_parking_racks",
    target_schema="raw_data",
    entity_key=["objectid"],
    resource_ids=["4d105465-6e64-4a69-957b-6e0eee5bca8b"],
)
ddl = ckan_collector.generate_ddl(TORONTO_BICYCLE_PARKING_RACKS_SPEC)
print(ddl)
create table if not exists raw_data.toronto_bicycle_parking_racks (
    "address_point_id" text,
    "address_number" text,
    "linear_name_full" text,
    "address_full" text,
    "postal_code" text,
    "municipality" text,
    "city" text,
    "centreline_id" text,
    "lo_num" text,
    "lo_num_suf" text,
    "hi_num" text,
    "hi_num_suf" text,
    "linear_name_id" text,
    "ward_name" text,
    "mi_prinx" text,
    "objectid" text,
    "capacity" text,
    "multimodal" text,
    "seasonal" text,
    "sheltered" text,
    "surface" text,
    "status" text,
    "location" text,
    "notes" text,
    "map_class" text,
    "geom" geometry,
    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
    "record_hash" text not null,
    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
    "valid_to" timestamptz
);

alter table raw_data.toronto_bicycle_parking_racks
    add constraint uq_toronto_bicycle_parking_racks_entity_hash
    unique ("objectid", "record_hash");

create index if not exists ix_toronto_bicycle_parking_racks_current
    on raw_data.toronto_bicycle_parking_racks ("objectid")
    where valid_to is null;
```