### PR TITLE
Iss147 parameterize env

### DIFF
--- a/platform/airflow/dags/dag_files/arcgishub/update_detroit_boundary.py
+++ b/platform/airflow/dags/dag_files/arcgishub/update_detroit_boundary.py
@@ -1,0 +1,24 @@
+import datetime as dt
+import logging
+
+from airflow.sdk import dag
+from loci.sources.update_configs import DETROIT_BOUNDARY_UC as UPDATE_CONFIG
+from loci.tasks.arcgishub_tasks import update_arcgishub_table
+
+task_logger = logging.getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["arcgishub", "boundary", "detroit"],
+)
+def update_detroit_boundary():
+    update_arcgishub_table(update_config=UPDATE_CONFIG, conn_id=CONN_ID, task_logger=task_logger)
+
+
+update_detroit_boundary()

--- a/platform/airflow/dags/dag_files/refresh_bike_map_app.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_app.py
@@ -1,10 +1,10 @@
 import logging
-import os
 from datetime import datetime
 from pathlib import Path
 
 from airflow.sdk import dag, task, task_group
 from airflow.sdk.bases.operator import chain
+from loci.aws import get_boto_session
 from loci.db.af_utils import get_postgres_engine
 from loci.deploy import upload_file_to_s3
 from loci.environments import get_env
@@ -94,14 +94,14 @@ def run_tests(graph_path: str, task_logger: logging.Logger) -> list:
 
 
 @task
-def deploy_graph(graph_path: str, task_logger: logging.Logger) -> str:
-    bucket = os.environ["BIKE_MAP_ROUTING_GRAPH_BUCKET"]
-    key = os.environ.get("BIKE_MAP_ROUTING_GRAPH_KEY", "graph/routing_graph.pkl.gz")
+def deploy_graph(env: str, graph_path: str, task_logger: logging.Logger) -> str:
+    cfg = get_env(env)
     uri = upload_file_to_s3(
         local_path=graph_path,
-        bucket=bucket,
-        key=key,
+        bucket=cfg.routing_graph_bucket,
+        key=cfg.routing_graph_key,
         logger=task_logger,
+        s3_client=get_boto_session(cfg).client("s3"),
     )
     task_logger.info("Routing graph uploaded to %s", uri)
     return uri
@@ -125,8 +125,10 @@ def refresh_bike_map_app():
     )
     _build_parking_table = build_chicago_bike_parking(env=env)
     _build_crashes_table = build_chicago_bike_crash_hotspots(env=env)
-    _export_layer_data = export_bike_map_geojson(env=env, conn_id=CONN_ID, task_logger=task_logger)
-    _deploy_map = deploy_bike_map(task_logger=task_logger)
+    _export_layer_data = export_bike_map_geojson(
+        env=env, conn_id=CONN_ID, task_logger=task_logger
+    )
+    _deploy_map = deploy_bike_map(env=env, task_logger=task_logger)
     chain(
         _deps,
         [_build_geocoded_tables, _build_parking_table, _build_crashes_table],
@@ -135,14 +137,13 @@ def refresh_bike_map_app():
     )
 
     _build_weights = build_bike_safety_weighted_edges(env=env)
-    # _export_graph = export_routing_graph(conn_id=CONN_ID, task_logger=task_logger)
     _build_graph = build_routing_graph(
         env=env, conn_id=CONN_ID, task_logger=task_logger, graph_path=GRAPH_PATH
     )
     _run_tests = run_tests(task_logger=task_logger, graph_path=GRAPH_PATH)
-    _deploy_graph = deploy_graph(graph_path=GRAPH_PATH, task_logger=task_logger)
+    _deploy_graph = deploy_graph(env=env, graph_path=GRAPH_PATH, task_logger=task_logger)
 
-    _deploy_lambda = deploy_lambda(task_logger=task_logger)
+    _deploy_lambda = deploy_lambda(env=env, task_logger=task_logger)
 
     chain(
         _deps,

--- a/platform/airflow/dags/dag_files/refresh_bike_map_app.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_app.py
@@ -2,12 +2,12 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from airflow.sdk import dag, task, task_group
+from airflow.sdk import Param, dag, task, task_group
 from airflow.sdk.bases.operator import chain
 from loci.aws import get_boto_session
 from loci.db.af_utils import get_postgres_engine
 from loci.deploy import upload_file_to_s3
-from loci.environments import get_env
+from loci.environments import VALID_ENVS, get_env
 from loci.exports.graph_export import RoutingGraphExporter
 from loci.tasks.deploy_tasks import deploy_bike_map, deploy_lambda
 from loci.tasks.export_tasks import export_bike_map_geojson
@@ -18,8 +18,11 @@ task_logger = logging.getLogger("airflow.task")
 
 
 CONN_ID = "gis_dwh_db"
-GRAPH_PATH = "/tmp/routing_graph.pkl.gz"
-DEFAULT_ENV = "dev"
+
+# At task execution time, Jinja renders "{{ params.env }}" into the actual
+# env string (e.g. "dev") that the DAG was triggered with.
+ENV_TEMPLATE = "{{ params.env }}"
+GRAPH_PATH_TEMPLATE = "/tmp/routing_graph_{{ params.env }}.pkl.gz"
 
 
 @task
@@ -34,7 +37,7 @@ def build_chicago_bike_theft_hotspots(env: str) -> str:
     return run_dbt(
         "build",
         "--select",
-        "geocoded_address_cache+,+chicago_bike_theft_hotspots",
+        "geocoded_address_cache+,+chicago_bike_theft_hotspots stg__bikeindex_chicago_stolen_bikes",
         target=target,
     )
 
@@ -59,7 +62,17 @@ def build_chicago_bike_parking(env: str) -> str:
 @task
 def build_chicago_bike_crash_hotspots(env: str) -> str:
     target = get_env(env).dbt_target
-    return run_dbt("build", "--select", "+bike_crash_hotspots", target=target)
+    # --indirect-selection=cautious prevents dbt from running the
+    # compare_aggregations test (defined on bike_safety_weighted_edges but
+    # refs bike_crash_hotspots), which would fail here because
+    # bike_safety_weighted_edges hasn't been built yet.
+    return run_dbt(
+        "build",
+        "--select",
+        "+bike_crash_hotspots",
+        "--indirect-selection=cautious",
+        target=target,
+    )
 
 
 @task
@@ -112,23 +125,30 @@ def deploy_graph(env: str, graph_path: str, task_logger: logging.Logger) -> str:
     schedule=None,
     catchup=False,
     tags=["dbt"],
+    params={
+        "env": Param(
+            "dev",
+            type="string",
+            enum=list(VALID_ENVS),
+            title="Target environment",
+            description="Which AWS account + dbt target to build and deploy to.",
+        ),
+    },
 )
 def refresh_bike_map_app():
-    env = DEFAULT_ENV
-
-    _deps = install_dependencies(env=env)
+    _deps = install_dependencies(env=ENV_TEMPLATE)
     _build_geocoded_tables = build_bike_marts_with_geocoding(
-        env=env,
+        env=ENV_TEMPLATE,
         conn_id=CONN_ID,
         task_logger=task_logger,
         restrict_region="ST_MakeEnvelope(-87.94, 41.64, -87.52, 42.03, 4269)",
     )
-    _build_parking_table = build_chicago_bike_parking(env=env)
-    _build_crashes_table = build_chicago_bike_crash_hotspots(env=env)
+    _build_parking_table = build_chicago_bike_parking(env=ENV_TEMPLATE)
+    _build_crashes_table = build_chicago_bike_crash_hotspots(env=ENV_TEMPLATE)
     _export_layer_data = export_bike_map_geojson(
-        env=env, conn_id=CONN_ID, task_logger=task_logger
+        env=ENV_TEMPLATE, conn_id=CONN_ID, task_logger=task_logger
     )
-    _deploy_map = deploy_bike_map(env=env, task_logger=task_logger)
+    _deploy_map = deploy_bike_map(env=ENV_TEMPLATE, task_logger=task_logger)
     chain(
         _deps,
         [_build_geocoded_tables, _build_parking_table, _build_crashes_table],
@@ -136,14 +156,19 @@ def refresh_bike_map_app():
         _deploy_map,
     )
 
-    _build_weights = build_bike_safety_weighted_edges(env=env)
+    _build_weights = build_bike_safety_weighted_edges(env=ENV_TEMPLATE)
     _build_graph = build_routing_graph(
-        env=env, conn_id=CONN_ID, task_logger=task_logger, graph_path=GRAPH_PATH
+        env=ENV_TEMPLATE,
+        conn_id=CONN_ID,
+        task_logger=task_logger,
+        graph_path=GRAPH_PATH_TEMPLATE,
     )
-    _run_tests = run_tests(task_logger=task_logger, graph_path=GRAPH_PATH)
-    _deploy_graph = deploy_graph(env=env, graph_path=GRAPH_PATH, task_logger=task_logger)
+    _run_tests = run_tests(task_logger=task_logger, graph_path=GRAPH_PATH_TEMPLATE)
+    _deploy_graph = deploy_graph(
+        env=ENV_TEMPLATE, graph_path=GRAPH_PATH_TEMPLATE, task_logger=task_logger
+    )
 
-    _deploy_lambda = deploy_lambda(env=env, task_logger=task_logger)
+    _deploy_lambda = deploy_lambda(env=ENV_TEMPLATE, task_logger=task_logger)
 
     chain(
         _deps,

--- a/platform/airflow/dags/dag_files/refresh_bike_map_app.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_app.py
@@ -7,6 +7,7 @@ from airflow.sdk import dag, task, task_group
 from airflow.sdk.bases.operator import chain
 from loci.db.af_utils import get_postgres_engine
 from loci.deploy import upload_file_to_s3
+from loci.environments import get_env
 from loci.exports.graph_export import RoutingGraphExporter
 from loci.tasks.deploy_tasks import deploy_bike_map, deploy_lambda
 from loci.tasks.export_tasks import export_bike_map_geojson
@@ -18,49 +19,63 @@ task_logger = logging.getLogger("airflow.task")
 
 CONN_ID = "gis_dwh_db"
 GRAPH_PATH = "/tmp/routing_graph.pkl.gz"
+DEFAULT_ENV = "dev"
 
 
 @task
-def install_dependencies() -> str:
-    return run_dbt("deps")
+def install_dependencies(env: str) -> str:
+    target = get_env(env).dbt_target
+    return run_dbt("deps", target=target)
 
 
 @task
-def build_chicago_bike_theft_hotspots() -> str:
-    return run_dbt("build", "--select", "geocoded_address_cache+,+chicago_bike_theft_hotspots")
+def build_chicago_bike_theft_hotspots(env: str) -> str:
+    target = get_env(env).dbt_target
+    return run_dbt(
+        "build",
+        "--select",
+        "geocoded_address_cache+,+chicago_bike_theft_hotspots",
+        target=target,
+    )
 
 
 @task_group
 def build_bike_marts_with_geocoding(
-    conn_id: str, task_logger: logging.Logger, restrict_region: str | None
+    env: str, conn_id: str, task_logger: logging.Logger, restrict_region: str | None
 ) -> None:
-    _pre_build = build_pre_geocode()
+    _pre_build = build_pre_geocode(env=env)
     _geocode = geocode(conn_id=conn_id, task_logger=task_logger, restrict_region=restrict_region)
-    _build_theft_hotspots = build_chicago_bike_theft_hotspots()
+    _build_theft_hotspots = build_chicago_bike_theft_hotspots(env=env)
 
     chain(_pre_build, _geocode, _build_theft_hotspots)
 
 
 @task
-def build_chicago_bike_parking() -> str:
-    return run_dbt("build", "--select", "+chicago_bike_parking")
+def build_chicago_bike_parking(env: str) -> str:
+    target = get_env(env).dbt_target
+    return run_dbt("build", "--select", "+chicago_bike_parking", target=target)
 
 
 @task
-def build_chicago_bike_crash_hotspots() -> str:
-    return run_dbt("build", "--select", "+bike_crash_hotspots")
+def build_chicago_bike_crash_hotspots(env: str) -> str:
+    target = get_env(env).dbt_target
+    return run_dbt("build", "--select", "+bike_crash_hotspots", target=target)
 
 
 @task
-def build_bike_safety_weighted_edges() -> str:
-    return run_dbt("build", "--select", "+bike_safety_weighted_edges")
+def build_bike_safety_weighted_edges(env: str) -> str:
+    target = get_env(env).dbt_target
+    return run_dbt("build", "--select", "+bike_safety_weighted_edges", target=target)
 
 
 @task
-def build_routing_graph(conn_id: str, graph_path: str, task_logger: logging.Logger) -> str:
+def build_routing_graph(
+    env: str, conn_id: str, graph_path: str, task_logger: logging.Logger
+) -> str:
     """Build the safety-weighted routing graph for testing."""
+    cfg = get_env(env)
     engine = get_postgres_engine(conn_id=conn_id, logger=task_logger)
-    exporter = RoutingGraphExporter(engine)
+    exporter = RoutingGraphExporter(engine, marts_schema=cfg.marts_schema)
     output_path = Path(graph_path)
     if output_path.exists():
         output_path.unlink()
@@ -99,15 +114,18 @@ def deploy_graph(graph_path: str, task_logger: logging.Logger) -> str:
     tags=["dbt"],
 )
 def refresh_bike_map_app():
-    _deps = install_dependencies()
+    env = DEFAULT_ENV
+
+    _deps = install_dependencies(env=env)
     _build_geocoded_tables = build_bike_marts_with_geocoding(
+        env=env,
         conn_id=CONN_ID,
         task_logger=task_logger,
         restrict_region="ST_MakeEnvelope(-87.94, 41.64, -87.52, 42.03, 4269)",
     )
-    _build_parking_table = build_chicago_bike_parking()
-    _build_crashes_table = build_chicago_bike_crash_hotspots()
-    _export_layer_data = export_bike_map_geojson(conn_id=CONN_ID, task_logger=task_logger)
+    _build_parking_table = build_chicago_bike_parking(env=env)
+    _build_crashes_table = build_chicago_bike_crash_hotspots(env=env)
+    _export_layer_data = export_bike_map_geojson(env=env, conn_id=CONN_ID, task_logger=task_logger)
     _deploy_map = deploy_bike_map(task_logger=task_logger)
     chain(
         _deps,
@@ -116,10 +134,10 @@ def refresh_bike_map_app():
         _deploy_map,
     )
 
-    _build_weights = build_bike_safety_weighted_edges()
+    _build_weights = build_bike_safety_weighted_edges(env=env)
     # _export_graph = export_routing_graph(conn_id=CONN_ID, task_logger=task_logger)
     _build_graph = build_routing_graph(
-        conn_id=CONN_ID, task_logger=task_logger, graph_path=GRAPH_PATH
+        env=env, conn_id=CONN_ID, task_logger=task_logger, graph_path=GRAPH_PATH
     )
     _run_tests = run_tests(task_logger=task_logger, graph_path=GRAPH_PATH)
     _deploy_graph = deploy_graph(graph_path=GRAPH_PATH, task_logger=task_logger)

--- a/platform/airflow/dags/loci/aws.py
+++ b/platform/airflow/dags/loci/aws.py
@@ -1,0 +1,25 @@
+"""
+Boto3 session helper that respects per-env AWS profile configuration.
+
+Using a Session lets us select the SSO profile explicitly from EnvConfig
+rather than relying on ambient environment state, so the env param on the
+DAG is the single source of truth for which AWS account we target.
+"""
+
+from __future__ import annotations
+
+import boto3
+from loci.environments import EnvConfig
+
+
+def get_boto_session(cfg: EnvConfig) -> boto3.Session:
+    """Return a boto3 Session for the given env.
+
+    If cfg.aws_profile is set, uses that profile. Otherwise falls back to
+    whatever boto3 picks up from the ambient environment (env vars,
+    ~/.aws/credentials, instance role, etc.).
+    """
+    kwargs: dict = {"region_name": cfg.aws_region}
+    if cfg.aws_profile:
+        kwargs["profile_name"] = cfg.aws_profile
+    return boto3.Session(**kwargs)

--- a/platform/airflow/dags/loci/collectors/ckan/collector.py
+++ b/platform/airflow/dags/loci/collectors/ckan/collector.py
@@ -74,10 +74,11 @@ class CKANCollector:
         self,
         engine: Any,
         tracker: IngestionTracker | None = None,
+        logger: logging.Logger | None = None,
     ) -> None:
         self.engine = engine
         self.tracker = tracker or IngestionTracker(engine=self.engine)
-        self.logger = logging.getLogger("ckan_collector")
+        self.logger = logger or logging.getLogger("ckan_collector")
 
         self._client_cache: dict[str, CKANClient] = {}
 

--- a/platform/airflow/dags/loci/deploy.py
+++ b/platform/airflow/dags/loci/deploy.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
 import boto3
 
@@ -10,7 +11,7 @@ def upload_file_to_s3(
     bucket: str,
     key: str,
     logger: logging.Logger | None = None,
-    s3_client: str | None = None,
+    s3_client: Any | None = None,
 ) -> str:
     """Upload a local file to S3.
 
@@ -20,6 +21,8 @@ def upload_file_to_s3(
         key: S3 object key (e.g. "routing_graph/costs.parquet").
         logger: Optional logger instance. Falls back to module logger.
         s3_client: Optional boto3 S3 client. Created if not provided.
+            Pass a client built from an env-specific boto3.Session to
+            ensure uploads go to the right AWS account.
 
     Returns:
         The s3:// URI of the uploaded file.

--- a/platform/airflow/dags/loci/environments.py
+++ b/platform/airflow/dags/loci/environments.py
@@ -65,7 +65,7 @@ def get_env(env: str) -> EnvConfig:
     return EnvConfig(
         name=env,
         aws_profile=os.environ.get(f"AWS_PROFILE_{suffix}"),
-        aws_region=os.environ.get("AWS_REGION", "us-east-1"),
+        aws_region=_require("BIKE_MAP_AWS_REGION", suffix),
         app_file_bucket=_require("BIKE_MAP_APP_FILE_BUCKET", suffix),
         cloudfront_dist_id=_require("BIKE_MAP_CLOUDFRONT_DIST_ID", suffix),
         routing_graph_bucket=_require("BIKE_MAP_ROUTING_GRAPH_BUCKET", suffix),

--- a/platform/airflow/dags/loci/environments.py
+++ b/platform/airflow/dags/loci/environments.py
@@ -1,0 +1,79 @@
+"""
+Per-environment configuration for the bike map pipeline.
+
+Values live in environment variables, namespaced by env with an uppercase
+suffix (e.g. BIKE_MAP_APP_FILE_BUCKET_DEV, BIKE_MAP_APP_FILE_BUCKET_STAGING).
+This module maps them into a typed EnvConfig at task-run time.
+
+Usage:
+
+    from loci.environments import get_env
+
+    cfg = get_env("staging")
+    bucket = cfg.app_file_bucket
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+VALID_ENVS = ("dev", "staging", "prod")
+
+# Must match what the dbt generate_schema_name macro produces.
+# dev     → dbt_{user}_marts   (user='loci' per profiles.yml)
+# staging → staging_marts
+# prod    → marts
+_MARTS_SCHEMA_BY_ENV = {
+    "dev": "dbt_loci_marts",
+    "staging": "staging_marts",
+    "prod": "marts",
+}
+
+
+@dataclass(frozen=True)
+class EnvConfig:
+    name: str
+    aws_profile: str | None
+    aws_region: str
+    app_file_bucket: str
+    cloudfront_dist_id: str
+    routing_graph_bucket: str
+    routing_graph_key: str
+    routing_lambda_arn: str
+    dbt_target: str
+    marts_schema: str
+
+
+def _require(key: str, suffix: str) -> str:
+    full_key = f"{key}_{suffix}"
+    val = os.environ.get(full_key)
+    if not val:
+        raise RuntimeError(
+            f"Missing required environment variable: {full_key}. Check your .env file."
+        )
+    return val
+
+
+def get_env(env: str) -> EnvConfig:
+    """Load the EnvConfig for the given environment name."""
+    if env not in VALID_ENVS:
+        raise ValueError(f"Unknown env: {env!r}. Expected one of {VALID_ENVS}.")
+
+    suffix = env.upper()
+
+    return EnvConfig(
+        name=env,
+        aws_profile=os.environ.get(f"AWS_PROFILE_{suffix}"),
+        aws_region=os.environ.get("AWS_REGION", "us-east-1"),
+        app_file_bucket=_require("BIKE_MAP_APP_FILE_BUCKET", suffix),
+        cloudfront_dist_id=_require("BIKE_MAP_CLOUDFRONT_DIST_ID", suffix),
+        routing_graph_bucket=_require("BIKE_MAP_ROUTING_GRAPH_BUCKET", suffix),
+        routing_graph_key=os.environ.get(
+            f"BIKE_MAP_ROUTING_GRAPH_KEY_{suffix}",
+            "graph/routing_graph.pkl.gz",
+        ),
+        routing_lambda_arn=_require("BIKE_MAP_ROUTING_LAMBDA_ARN", suffix),
+        dbt_target=env,
+        marts_schema=_MARTS_SCHEMA_BY_ENV[env],
+    )

--- a/platform/airflow/dags/loci/exports/geojson_export.py
+++ b/platform/airflow/dags/loci/exports/geojson_export.py
@@ -8,13 +8,11 @@ and writes it to disk.
 
 Usage from an Airflow task:
 
-    from loci.exports.geojson_export import export_all, BIKE_MAP_EXPORTS
+    from loci.exports.geojson_export import GeoJsonExporter, build_bike_map_exports
 
-    export_all(engine, BIKE_MAP_EXPORTS, output_dir="/opt/airflow/exports/bike-map")
-
-Usage standalone:
-
-    python -m loci.exports.geojson_export
+    configs = build_bike_map_exports(marts_schema="dbt_loci_marts")
+    exporter = GeoJsonExporter(engine, output_dir="/opt/airflow/exports/bike-map")
+    exporter.export_all(configs)
 """
 
 from __future__ import annotations
@@ -22,7 +20,6 @@ from __future__ import annotations
 import json
 import logging
 import math
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -69,74 +66,74 @@ class GeoJSONExportConfig:
     """Optional row limit."""
 
 
-# ── Export configs for the bike map app ───────────────────
-
-BIKE_MAP_EXPORTS: list[GeoJSONExportConfig] = [
-    GeoJSONExportConfig(
-        name="crashes",
-        schema=os.environ.get("MARTS_SCHEMA_NAME", "marts"),
-        table="bike_crash_hotspots",
-        geometry_column="geom",
-        properties=[
-            "crash_record_id",
-            "crash_date",
-            "local_crash_time",
-            "local_crash_day_of_week",
-            "first_crash_type",
-            "most_severe_injury",
-            "hit_and_run_i",
-            "dooring_i",
-            "weather_condition",
-            "lighting_condition",
-            "street_name",
-            "street_direction",
-            "prim_contributory_cause",
-            "injuries_total",
-            "injuries_fatal",
-            "injuries_incapacitating",
-            "severity_score",
-            "crash_year",
-        ],
-    ),
-    GeoJSONExportConfig(
-        name="thefts",
-        schema=os.environ.get("MARTS_SCHEMA_NAME", "marts"),
-        table="chicago_bike_theft_hotspots",
-        latitude_column="latitude",
-        longitude_column="longitude",
-        properties=[
-            "source",
-            "source_id",
-            "theft_date",
-            "theft_year",
-            "theft_hour",
-            "location_description",
-            "bike_description",
-            "theft_description",
-            "locking_description",
-        ],
-    ),
-    GeoJSONExportConfig(
-        name="parking",
-        schema=os.environ.get("MARTS_SCHEMA_NAME", "marts"),
-        table="chicago_bike_parking",
-        geometry_column="geom",
-        properties=[
-            "source",
-            "id",
-            "location",
-            "name",
-            "type",
-            "capacity",
-            "covered",
-            "indoor",
-            "fee",
-            "lit",
-            "operator",
-            "access",
-        ],
-    ),
-]
+def build_bike_map_exports(marts_schema: str) -> list[GeoJSONExportConfig]:
+    """Build the list of bike map export configs for the given marts schema."""
+    return [
+        GeoJSONExportConfig(
+            name="crashes",
+            schema=marts_schema,
+            table="bike_crash_hotspots",
+            geometry_column="geom",
+            properties=[
+                "crash_record_id",
+                "crash_date",
+                "local_crash_time",
+                "local_crash_day_of_week",
+                "first_crash_type",
+                "most_severe_injury",
+                "hit_and_run_i",
+                "dooring_i",
+                "weather_condition",
+                "lighting_condition",
+                "street_name",
+                "street_direction",
+                "prim_contributory_cause",
+                "injuries_total",
+                "injuries_fatal",
+                "injuries_incapacitating",
+                "severity_score",
+                "crash_year",
+            ],
+        ),
+        GeoJSONExportConfig(
+            name="thefts",
+            schema=marts_schema,
+            table="chicago_bike_theft_hotspots",
+            latitude_column="latitude",
+            longitude_column="longitude",
+            properties=[
+                "source",
+                "source_id",
+                "theft_date",
+                "theft_year",
+                "theft_hour",
+                "location_description",
+                "bike_description",
+                "theft_description",
+                "locking_description",
+            ],
+        ),
+        GeoJSONExportConfig(
+            name="parking",
+            schema=marts_schema,
+            table="chicago_bike_parking",
+            geometry_column="geom",
+            properties=[
+                "source",
+                "id",
+                "location",
+                "name",
+                "type",
+                "capacity",
+                "covered",
+                "indoor",
+                "fee",
+                "lit",
+                "operator",
+                "access",
+            ],
+        ),
+    ]
 
 
 class GeoJsonExporter:
@@ -229,7 +226,6 @@ class GeoJsonExporter:
 
         Args:
             cfg:        Export configuration.
-            output_dir: Directory to write the .geojson file into.
 
         Returns:
             Path to the written file.
@@ -272,9 +268,7 @@ class GeoJsonExporter:
         """Export all configured mart tables to GeoJSON files.
 
         Args:
-            engine:     A PostgresEngine instance.
-            configs:    List of export configurations.
-            output_dir: Directory to write files into.
+            configs: List of export configurations.
 
         Returns:
             List of paths to written files.

--- a/platform/airflow/dags/loci/exports/graph_export.py
+++ b/platform/airflow/dags/loci/exports/graph_export.py
@@ -14,11 +14,8 @@ Usage from an Airflow task:
 
     from loci.exports.graph_export import RoutingGraphExporter
 
-    exporter = RoutingGraphExporter(engine)
+    exporter = RoutingGraphExporter(engine, marts_schema="dbt_loci_marts")
     output_path = exporter.export(output_path=Path("/tmp/routing_graph.pkl.gz"))
-
-Configuration via environment variables:
-    MARTS_SCHEMA_NAME  — dbt marts schema (e.g. dbt_loci_marts)
 """
 
 from __future__ import annotations
@@ -26,7 +23,6 @@ from __future__ import annotations
 import gzip
 import json
 import logging
-import os
 import pickle
 from pathlib import Path
 
@@ -42,10 +38,11 @@ class RoutingGraphExporter:
     Parameters
     ----------
     engine : PostgresEngine
+    marts_schema : str
+        dbt marts schema name. Caller is responsible for determining this
+        from the target environment.
     batch_size : int
         Rows per batch when streaming edges from the database.
-    marts_schema : str, optional
-        dbt marts schema name. Falls back to the MARTS_SCHEMA_NAME env var.
     min_component_size : int
         Weakly connected components smaller than this are dropped before
         serialization. This removes isolated subgraphs (parking lots,
@@ -88,15 +85,13 @@ class RoutingGraphExporter:
     def __init__(
         self,
         engine: PostgresEngine,
+        marts_schema: str,
         batch_size: int = 50_000,
-        marts_schema: str | None = None,
         min_component_size: int = 75,
     ):
         self.engine = engine
+        self.marts_schema = marts_schema
         self.batch_size = batch_size
-        self.marts_schema = (
-            marts_schema if marts_schema is not None else os.environ["MARTS_SCHEMA_NAME"]
-        )
         self.min_component_size = min_component_size
 
     def export(self, output_path: Path) -> Path:

--- a/platform/airflow/dags/loci/tasks/deploy_tasks.py
+++ b/platform/airflow/dags/loci/tasks/deploy_tasks.py
@@ -4,10 +4,8 @@ Airflow tasks for deploying the bike map to S3 + CloudFront.
 Syncs all files from the local export directory to an S3 bucket and
 creates a CloudFront cache invalidation.
 
-Configuration via environment variables:
-    BIKE_MAP_APP_FILE_BUCKET    — S3 bucket name
-    BIKE_MAP_CLOUDFRONT_DIST_ID — CloudFront distribution ID
-    BIKE_MAP_ENVIRONMENT        — Environment name (dev, staging, prod)
+Per-env configuration (buckets, CloudFront distribution, Lambda ARN,
+AWS profile) comes from loci.environments.get_env.
 
 Usage in a DAG:
 
@@ -16,10 +14,9 @@ Usage in a DAG:
     @dag(...)
     def my_dag():
         ...
-        export_bike_map_geojson(conn_id="gis_dwh_db") >> deploy_bike_map()
+        export_bike_map_geojson(env="dev", conn_id="gis_dwh_db") >> deploy_bike_map(env="dev")
 """
 
-import os
 import subprocess
 import tempfile
 import time
@@ -27,10 +24,11 @@ import zipfile
 from logging import Logger
 from pathlib import Path
 
-import boto3
 from airflow.sdk import task
+from loci.aws import get_boto_session
 from loci.db.af_utils import get_postgres_engine
 from loci.deploy import upload_file_to_s3
+from loci.environments import EnvConfig, get_env
 from loci.exports.graph_export import RoutingGraphExporter
 
 BIKE_MAP_APP_DIR = "/opt/airflow/app-files/bike-map"
@@ -54,7 +52,7 @@ def _get_content_type(path: Path) -> str:
     return CONTENT_TYPES.get(path.suffix, "application/octet-stream")
 
 
-def _sync_to_s3(local_dirs: list[str], bucket: str, logger: Logger) -> int:
+def _sync_to_s3(local_dirs: list[str], cfg: EnvConfig, logger: Logger) -> int:
     """Upload files from multiple local directories to the S3 bucket.
 
     Each directory is synced relative to itself, preserving structure.
@@ -62,12 +60,12 @@ def _sync_to_s3(local_dirs: list[str], bucket: str, logger: Logger) -> int:
     Subdirectories listed in SKIP_DIRS are excluded.
 
     For example, given:
-        /opt/airflow/app-files/bike-map/index.html         → index.html
+        /opt/airflow/app-files/bike-map/index.html              → index.html
         /opt/airflow/exports/bike-map/dev/data/crashes.geojson  → data/crashes.geojson
 
     Returns the number of files uploaded.
     """
-    s3 = boto3.client("s3")
+    s3 = get_boto_session(cfg).client("s3")
     count = 0
 
     for local_dir in local_dirs:
@@ -89,10 +87,16 @@ def _sync_to_s3(local_dirs: list[str], bucket: str, logger: Logger) -> int:
             key = str(rel)
             content_type = _get_content_type(file_path)
 
-            logger.info("Uploading %s → s3://%s/%s (%s)", file_path, bucket, key, content_type)
+            logger.info(
+                "Uploading %s → s3://%s/%s (%s)",
+                file_path,
+                cfg.app_file_bucket,
+                key,
+                content_type,
+            )
             s3.upload_file(
                 str(file_path),
-                bucket,
+                cfg.app_file_bucket,
                 key,
                 ExtraArgs={"ContentType": content_type},
             )
@@ -101,14 +105,14 @@ def _sync_to_s3(local_dirs: list[str], bucket: str, logger: Logger) -> int:
     return count
 
 
-def _invalidate_cloudfront(distribution_id: str, logger: Logger) -> str:
+def _invalidate_cloudfront(cfg: EnvConfig, logger: Logger) -> str:
     """Create a CloudFront invalidation for all paths.
 
     Returns the invalidation ID.
     """
-    cf = boto3.client("cloudfront")
+    cf = get_boto_session(cfg).client("cloudfront")
     resp = cf.create_invalidation(
-        DistributionId=distribution_id,
+        DistributionId=cfg.cloudfront_dist_id,
         InvalidationBatch={
             "Paths": {"Quantity": 1, "Items": ["/*"]},
             "CallerReference": str(int(time.time())),
@@ -119,60 +123,54 @@ def _invalidate_cloudfront(distribution_id: str, logger: Logger) -> str:
     return invalidation_id
 
 
-def _sync_bike_map_config(logger: Logger) -> dict:
+def _sync_bike_map_config(cfg: EnvConfig, logger: Logger) -> dict:
     """Upload the environment-specific config.json to S3.
 
-    Reads config/{environment}.json from the app directory and uploads
-    it as config.json in the S3 bucket root, where index.html expects it.
+    Reads config/{env}.json from the app directory and uploads it as
+    config.json in the S3 bucket root, where index.html expects it.
     """
-    bucket = os.environ["BIKE_MAP_APP_FILE_BUCKET"]
-    env = os.environ.get("BIKE_MAP_ENVIRONMENT", "dev")
-
-    config_path = Path(BIKE_MAP_APP_DIR) / "config" / f"{env}.json"
+    config_path = Path(BIKE_MAP_APP_DIR) / "config" / f"{cfg.name}.json"
     if not config_path.exists():
         raise FileNotFoundError(
             f"Config file not found: {config_path}. "
             f"Expected one of: dev.json, staging.json, prod.json"
         )
 
-    s3 = boto3.client("s3")
-    logger.info("Uploading %s → s3://%s/config.json", config_path, bucket)
+    s3 = get_boto_session(cfg).client("s3")
+    logger.info("Uploading %s → s3://%s/config.json", config_path, cfg.app_file_bucket)
     s3.upload_file(
         str(config_path),
-        bucket,
+        cfg.app_file_bucket,
         "config.json",
         ExtraArgs={"ContentType": "application/json"},
     )
-    return {"bucket": bucket, "environment": env, "source": str(config_path)}
+    return {"bucket": cfg.app_file_bucket, "environment": cfg.name, "source": str(config_path)}
 
 
 @task
-def deploy_bike_map(task_logger: Logger) -> dict:
+def deploy_bike_map(env: str, task_logger: Logger) -> dict:
     """Sync bike map files to S3 and invalidate the CloudFront cache."""
-    bucket = os.environ["BIKE_MAP_APP_FILE_BUCKET"]
-    distribution_id = os.environ["BIKE_MAP_CLOUDFRONT_DIST_ID"]
-
-    env = os.environ.get("BIKE_MAP_ENVIRONMENT", "dev")
-    export_dir = str(Path(BIKE_MAP_EXPORT_DIR_BASE) / env)
+    cfg = get_env(env)
+    export_dir = str(Path(BIKE_MAP_EXPORT_DIR_BASE) / cfg.name)
 
     file_count = _sync_to_s3(
         [BIKE_MAP_APP_DIR, export_dir],
-        bucket,
+        cfg,
         task_logger,
     )
-    task_logger.info("Uploaded %d files to s3://%s", file_count, bucket)
+    task_logger.info("Uploaded %d files to s3://%s", file_count, cfg.app_file_bucket)
 
-    conf_log = _sync_bike_map_config(task_logger)
+    conf_log = _sync_bike_map_config(cfg, task_logger)
     task_logger.info(
         "Uploaded %s env config to s3://%s",
         conf_log.get("environment", "missing_env"),
         conf_log.get("bucket", "missing_bucket"),
     )
 
-    invalidation_id = _invalidate_cloudfront(distribution_id, task_logger)
+    invalidation_id = _invalidate_cloudfront(cfg, task_logger)
 
     return {
-        "bucket": bucket,
+        "bucket": cfg.app_file_bucket,
         "files_uploaded": file_count,
         "invalidation_id": invalidation_id,
     }
@@ -227,33 +225,33 @@ def build_lambda_zip(output_path: Path) -> Path:
 
 
 @task
-def export_routing_graph(conn_id: str, task_logger: Logger) -> dict:
+def export_routing_graph(env: str, conn_id: str, task_logger: Logger) -> dict:
     """Build the safety-weighted routing graph and upload it to S3."""
-    bucket = os.environ["BIKE_MAP_ROUTING_GRAPH_BUCKET"]
-    key = os.environ.get("BIKE_MAP_ROUTING_GRAPH_KEY", "graph/routing_graph.pkl.gz")
-    marts_schema = os.environ["MARTS_SCHEMA_NAME"]
+    cfg = get_env(env)
+    session = get_boto_session(cfg)
     engine = get_postgres_engine(conn_id=conn_id, logger=task_logger)
-    exporter = RoutingGraphExporter(engine, marts_schema=marts_schema)
+    exporter = RoutingGraphExporter(engine, marts_schema=cfg.marts_schema)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = Path(tmpdir) / "routing_graph.pkl.gz"
         exporter.export(output_path)
         uri = upload_file_to_s3(
             local_path=output_path,
-            bucket=bucket,
-            key=key,
+            bucket=cfg.routing_graph_bucket,
+            key=cfg.routing_graph_key,
             logger=task_logger,
+            s3_client=session.client("s3"),
         )
 
     task_logger.info("Routing graph uploaded to %s", uri)
-    return {"uri": uri, "bucket": bucket, "key": key}
+    return {"uri": uri, "bucket": cfg.routing_graph_bucket, "key": cfg.routing_graph_key}
 
 
 @task
-def deploy_lambda(task_logger: Logger) -> dict:
+def deploy_lambda(env: str, task_logger: Logger) -> dict:
     """Build the Lambda deployment package and update the function code."""
-    bucket = os.environ["BIKE_MAP_ROUTING_GRAPH_BUCKET"]
-    lambda_arn = os.environ["BIKE_MAP_ROUTING_LAMBDA_ARN"]
+    cfg = get_env(env)
+    session = get_boto_session(cfg)
     zip_key = "lambda/routing_api.zip"
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -266,17 +264,18 @@ def deploy_lambda(task_logger: Logger) -> dict:
 
         uri = upload_file_to_s3(
             local_path=zip_path,
-            bucket=bucket,
+            bucket=cfg.routing_graph_bucket,
             key=zip_key,
             logger=task_logger,
+            s3_client=session.client("s3"),
         )
 
     task_logger.info("Lambda package uploaded to %s", uri)
 
-    lam = boto3.client("lambda", region_name=os.environ.get("BIKE_MAP_AWS_REGION", "us-east-1"))
+    lam = session.client("lambda")
     response = lam.update_function_code(
-        FunctionName=lambda_arn,
-        S3Bucket=bucket,
+        FunctionName=cfg.routing_lambda_arn,
+        S3Bucket=cfg.routing_graph_bucket,
         S3Key=zip_key,
     )
     task_logger.info(
@@ -287,6 +286,6 @@ def deploy_lambda(task_logger: Logger) -> dict:
 
     return {
         "uri": uri,
-        "lambda_arn": lambda_arn,
+        "lambda_arn": cfg.routing_lambda_arn,
         "last_update_status": response.get("LastUpdateStatus"),
     }

--- a/platform/airflow/dags/loci/tasks/deploy_tasks.py
+++ b/platform/airflow/dags/loci/tasks/deploy_tasks.py
@@ -34,7 +34,7 @@ from loci.deploy import upload_file_to_s3
 from loci.exports.graph_export import RoutingGraphExporter
 
 BIKE_MAP_APP_DIR = "/opt/airflow/app-files/bike-map"
-BIKE_MAP_EXPORT_DIR = "/opt/airflow/exports/bike-map"
+BIKE_MAP_EXPORT_DIR_BASE = "/opt/airflow/exports/bike-map"
 _LAMBDA_DIR = Path("/opt/airflow/app-infra/bike-map/lambda")
 _LOCI_DIR = Path("/opt/airflow/dags/loci")
 
@@ -63,7 +63,7 @@ def _sync_to_s3(local_dirs: list[str], bucket: str, logger: Logger) -> int:
 
     For example, given:
         /opt/airflow/app-files/bike-map/index.html         → index.html
-        /opt/airflow/exports/bike-map/data/crashes.geojson  → data/crashes.geojson
+        /opt/airflow/exports/bike-map/dev/data/crashes.geojson  → data/crashes.geojson
 
     Returns the number of files uploaded.
     """
@@ -152,8 +152,11 @@ def deploy_bike_map(task_logger: Logger) -> dict:
     bucket = os.environ["BIKE_MAP_APP_FILE_BUCKET"]
     distribution_id = os.environ["BIKE_MAP_CLOUDFRONT_DIST_ID"]
 
+    env = os.environ.get("BIKE_MAP_ENVIRONMENT", "dev")
+    export_dir = str(Path(BIKE_MAP_EXPORT_DIR_BASE) / env)
+
     file_count = _sync_to_s3(
-        [BIKE_MAP_APP_DIR, BIKE_MAP_EXPORT_DIR],
+        [BIKE_MAP_APP_DIR, export_dir],
         bucket,
         task_logger,
     )
@@ -228,8 +231,9 @@ def export_routing_graph(conn_id: str, task_logger: Logger) -> dict:
     """Build the safety-weighted routing graph and upload it to S3."""
     bucket = os.environ["BIKE_MAP_ROUTING_GRAPH_BUCKET"]
     key = os.environ.get("BIKE_MAP_ROUTING_GRAPH_KEY", "graph/routing_graph.pkl.gz")
+    marts_schema = os.environ["MARTS_SCHEMA_NAME"]
     engine = get_postgres_engine(conn_id=conn_id, logger=task_logger)
-    exporter = RoutingGraphExporter(engine)
+    exporter = RoutingGraphExporter(engine, marts_schema=marts_schema)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = Path(tmpdir) / "routing_graph.pkl.gz"

--- a/platform/airflow/dags/loci/tasks/export_tasks.py
+++ b/platform/airflow/dags/loci/tasks/export_tasks.py
@@ -8,24 +8,30 @@ Usage in a DAG:
     @dag(...)
     def my_dag():
         ...
-        export_bike_map_geojson(conn_id="gis_dwh_db")
+        export_bike_map_geojson(env="dev", conn_id="gis_dwh_db", task_logger=...)
 """
 
 from logging import Logger
+from pathlib import Path
 
 from airflow.sdk import task
 from loci.db.af_utils import get_postgres_engine
-from loci.exports.geojson_export import BIKE_MAP_EXPORTS, GeoJsonExporter
+from loci.environments import get_env
+from loci.exports.geojson_export import GeoJsonExporter, build_bike_map_exports
 
-BIKE_MAP_EXPORT_DIR = "/opt/airflow/exports/bike-map/data"
+BIKE_MAP_EXPORT_DIR_BASE = "/opt/airflow/exports/bike-map"
 
 
 @task
-def export_bike_map_geojson(conn_id: str, task_logger: Logger) -> list[str]:
+def export_bike_map_geojson(env: str, conn_id: str, task_logger: Logger) -> list[str]:
     """Export bike map mart tables to GeoJSON files."""
+    cfg = get_env(env)
+    output_dir = Path(BIKE_MAP_EXPORT_DIR_BASE) / env / "data"
+
     exporter = GeoJsonExporter(
         engine=get_postgres_engine(conn_id=conn_id, logger=task_logger),
-        output_dir=BIKE_MAP_EXPORT_DIR,
+        output_dir=output_dir,
     )
-    paths = exporter.export_all(BIKE_MAP_EXPORTS)
+    configs = build_bike_map_exports(marts_schema=cfg.marts_schema)
+    paths = exporter.export_all(configs)
     return [str(p) for p in paths]

--- a/platform/airflow/dags/loci/tasks/testing/route_tests.py
+++ b/platform/airflow/dags/loci/tasks/testing/route_tests.py
@@ -1,3 +1,4 @@
+# loci_platform/platform/airflow/dags/loci/tasks/testing/route_tests.py
 """
 Route quality tests for the bike safety routing graph.
 

--- a/platform/airflow/dags/loci/tasks/transform_tasks.py
+++ b/platform/airflow/dags/loci/tasks/transform_tasks.py
@@ -3,18 +3,23 @@ from logging import Logger
 
 from airflow.sdk import task, task_group
 from airflow.sdk.bases.operator import chain
+from loci.environments import get_env
 
 DBT_CMD = "/home/airflow/dbt_venv/bin/dbt"
 DBT_PROJECT_DIR = "/opt/airflow/dbt"
 
 
-def run_dbt(*args: str) -> str:
-    """Run a dbt command and return stdout. Raises on failure."""
-    result = subprocess.run(
-        [DBT_CMD, *args, "--project-dir", DBT_PROJECT_DIR],
-        capture_output=True,
-        text=True,
-    )
+def run_dbt(*args: str, target: str | None = None) -> str:
+    """Run a dbt command and return stdout. Raises on failure.
+
+    If target is provided, passes --target to dbt so the right
+    profiles.yml output is used.
+    """
+    cmd = [DBT_CMD, *args, "--project-dir", DBT_PROJECT_DIR]
+    if target:
+        cmd += ["--target", target]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
     print("=== STDOUT ===")
     print(result.stdout)
     print("=== STDERR ===")
@@ -27,8 +32,9 @@ def run_dbt(*args: str) -> str:
 
 
 @task
-def build_pre_geocode() -> str:
-    return run_dbt("build", "--select", "+geocoded_address_cache")
+def build_pre_geocode(env: str) -> str:
+    target = get_env(env).dbt_target
+    return run_dbt("build", "--select", "+geocoded_address_cache", target=target)
 
 
 @task
@@ -46,16 +52,17 @@ def geocode(conn_id: str, task_logger: Logger, restrict_region: str | None) -> d
 
 
 @task
-def build_post_geocode() -> str:
-    return run_dbt("build", "--select", "geocoded_address_cache+")
+def build_post_geocode(env: str) -> str:
+    target = get_env(env).dbt_target
+    return run_dbt("build", "--select", "geocoded_address_cache+", target=target)
 
 
 @task_group
 def dbt_build_with_geocoding(
-    conn_id: str, task_logger: Logger, restrict_region: str | None
+    env: str, conn_id: str, task_logger: Logger, restrict_region: str | None
 ) -> None:
-    _pre_build = build_pre_geocode()
+    _pre_build = build_pre_geocode(env=env)
     _geocode = geocode(conn_id=conn_id, task_logger=task_logger, restrict_region=restrict_region)
-    _post_build = build_post_geocode()
+    _post_build = build_post_geocode(env=env)
 
     chain(_pre_build, _geocode, _post_build)

--- a/platform/dbt/macros/generate_schema_name.sql
+++ b/platform/dbt/macros/generate_schema_name.sql
@@ -1,9 +1,11 @@
 {% macro generate_schema_name(custom_schema_name, node) -%}
-    {%- set default_schema = target.schema -%}
+        {%- set default_schema = target.schema -%}
     {%- if node.config.get('skip_schema_prefix', false) -%}
         {{ custom_schema_name | default(default_schema, true) }}
     {%- elif target.name == 'dev' -%}
         dbt_{{ target.user }}_{{ custom_schema_name | default(default_schema, true) }}
+    {%- elif target.name == 'staging' -%}
+        staging_{{ custom_schema_name | default(default_schema, true) }}
     {%- else -%}
         {{ custom_schema_name | default(default_schema, true) }}
     {%- endif -%}

--- a/platform/dbt/models/marts/cycling/_marts_cycling.yml
+++ b/platform/dbt/models/marts/cycling/_marts_cycling.yml
@@ -139,8 +139,9 @@ models:
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 1
-              max_value: 5
+              arguments:
+                min_value: 1
+                max_value: 5
       - name: geom
         tests:
           - not_null

--- a/platform/profiles.yml
+++ b/platform/profiles.yml
@@ -10,3 +10,23 @@ loci:
       dbname: loci
       schema: staging
       threads: 12
+
+    staging:
+      type: postgres
+      host: postgis
+      user: loci
+      password: loci
+      port: 5432
+      dbname: loci
+      schema: staging
+      threads: 12
+
+    prod:
+      type: postgres
+      host: postgis
+      user: loci
+      password: loci
+      port: 5432
+      dbname: loci
+      schema: staging
+      threads: 12


### PR DESCRIPTION
Changes:
* Changes tasks so that the env is a parameter that can be passed in at the DAG and be applied consistently. (Closes #147)

There are more env-vars to include in the `.env` file. Add these for each env.

```.env
BIKE_MAP_APP_FILE_BUCKET_<ENV>=  # this is an opentofu output
BIKE_MAP_ROUTING_GRAPH_BUCKET_<ENV>=  # this is an opentofu output
BIKE_MAP_CLOUDFRONT_DIST_ID_<ENV>= # this is an opentofu output
BIKE_MAP_ENVIRONMENT_<ENV>= # e.g. dev, staging, prod
BIKE_MAP_ROUTING_LAMBDA_ARN_<ENV>=  # this is an opentofu output
BIKE_MAP_AWS_REGION_<ENV>=  # e.g. us-east-1
AWS_PROFILE_<ENV>=
MARTS_SCHEMA_NAME_<ENV>= # (dbt_<user>_marts, staging_marts, marts)
```

The changes to the `@dag` decorator in refresh_bike_map_app.py enable this kind of input in the Airflow UI.

<img width="2518" height="1014" alt="701A6B00-1336-4161-AB7E-4074B328D329" src="https://github.com/user-attachments/assets/96f271fb-4975-48b0-85fb-296db8c011eb" />
