### PR TITLE
Iss149 add soc max rows

### DIFF
--- a/platform/airflow/dags/dag_files/socrata/update_cook_county_assessed_parcel_values.py
+++ b/platform/airflow/dags/dag_files/socrata/update_cook_county_assessed_parcel_values.py
@@ -1,0 +1,26 @@
+import datetime as dt
+import logging
+
+from airflow.sdk import dag
+from loci.sources.update_configs import (
+    COOK_COUNTY_ASSESSED_PARCEL_VALUES_UC as UPDATE_CONFIG,
+)
+from loci.tasks.socrata_tasks import update_socrata_table
+
+task_logger = logging.getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["socrata", "update", "Cook County", "parcels", "real estate"],
+)
+def update_cook_county_assessed_parcel_values():
+    update_socrata_table(update_config=UPDATE_CONFIG, conn_id=CONN_ID, task_logger=task_logger)
+
+
+update_cook_county_assessed_parcel_values()

--- a/platform/airflow/dags/dag_files/socrata/update_cook_county_assessed_parcel_values.py
+++ b/platform/airflow/dags/dag_files/socrata/update_cook_county_assessed_parcel_values.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import logging
 
-from airflow.sdk import dag
+from airflow.sdk import Param, dag
 from loci.sources.update_configs import (
     COOK_COUNTY_ASSESSED_PARCEL_VALUES_UC as UPDATE_CONFIG,
 )
@@ -18,6 +18,19 @@ CONN_ID = "gis_dwh_db"
     start_date=dt.datetime(2022, 11, 1),
     catchup=False,
     tags=["socrata", "update", "Cook County", "parcels", "real estate"],
+    params={
+        "force_full_refresh": Param(
+            False,
+            type="boolean",
+            title="Force full refresh",
+            description=(
+                "If enabled, routes all datasets in this DAG run through run_full_update "
+                "regardless of the scheduled full-refresh cadence. Useful for manually "
+                "triggering a full refresh on a giant dataset without waiting for the "
+                "next scheduled full-update day."
+            ),
+        ),
+    },
 )
 def update_cook_county_assessed_parcel_values():
     update_socrata_table(update_config=UPDATE_CONFIG, conn_id=CONN_ID, task_logger=task_logger)

--- a/platform/airflow/dags/loci/collectors/socrata/collector.py
+++ b/platform/airflow/dags/loci/collectors/socrata/collector.py
@@ -59,12 +59,15 @@ class SocrataCollector:
         tracker: IngestionTracker | None = None,
         app_token: str | None = None,
         page_size: int = 25000,
+        max_rows: int | None = None,
+        logger: logging.Logger | None = None,
     ) -> None:
         self.engine = engine
         self.tracker = tracker or IngestionTracker(engine=self.engine)
         self.app_token = app_token
         self.page_size = page_size
-        self.logger = logging.getLogger("socrata_collector")
+        self.max_rows = max_rows
+        self.logger = logger or logging.getLogger("socrata_collector")
 
         self._client: SocrataClient | None = None
         self._metadata_cache: dict[str, SocrataTableMetadata] = {}
@@ -437,6 +440,7 @@ class SocrataCollector:
         config: IncrementalConfig | None = None,
         entity_key: list[str] | None = None,
         high_water_mark_override: str | None = None,
+        max_rows: int | None = None,
     ) -> int:
         """
         Run an incremental paginated ingest using staged_ingest.
@@ -475,6 +479,9 @@ class SocrataCollector:
             "prior_high_water_mark": f"{hwm_value}|{hwm_id}" if hwm_id else hwm_value,
             "domain": domain,
         }
+        effective_max_rows = max_rows if max_rows is not None else self.max_rows
+        if effective_max_rows is not None:
+            run_metadata["max_rows"] = effective_max_rows
 
         # Determine merge strategy
         if entity_key:
@@ -557,6 +564,14 @@ class SocrataCollector:
                         max_hwm,
                         max_hwm_id,
                     )
+                    if effective_max_rows is not None and stager.rows_staged >= effective_max_rows:
+                        self.logger.info(
+                            "Reached max_rows cap (%d staged >= %d); stopping pagination",
+                            stager.rows_staged,
+                            effective_max_rows,
+                        )
+                        run.metadata["max_rows_hit"] = True
+                        break
 
             # stager has now merged — record results on the run
             run.rows_staged = stager.rows_staged

--- a/platform/airflow/dags/loci/collectors/socrata/collector.py
+++ b/platform/airflow/dags/loci/collectors/socrata/collector.py
@@ -480,6 +480,17 @@ class SocrataCollector:
             "domain": domain,
         }
         effective_max_rows = max_rows if max_rows is not None else self.max_rows
+
+        # A full refresh via API forces high_water_mark_override="" to restart from
+        # the beginning of the dataset on every run. Combining that with max_rows
+        # would re-ingest the same prefix on each run and never reach the tail.
+        if effective_max_rows is not None and high_water_mark_override == "":
+            raise ValueError(
+                "max_rows cannot be used with full_refresh_via_api: a capped full "
+                "refresh would re-ingest the same prefix on every run. Use "
+                "full_refresh_via_file for large datasets, or drop max_rows."
+            )
+
         if effective_max_rows is not None:
             run_metadata["max_rows"] = effective_max_rows
 

--- a/platform/airflow/dags/loci/collectors/socrata/spec.py
+++ b/platform/airflow/dags/loci/collectors/socrata/spec.py
@@ -43,6 +43,10 @@ class SocrataDatasetSpec(DatasetSpec):
     full_update_mode : str
         "api" for paginated SODA API, "file_download" for bulk
         CSV/GeoJSON export. Default "api".
+    max_rows : int | None
+        Optional cap on rows staged per incremental run. Stops at the
+        first page boundary after the cap is reached, so the actual
+        count may slightly exceed this value. None means no cap.
     """
 
     name: str
@@ -52,6 +56,7 @@ class SocrataDatasetSpec(DatasetSpec):
     entity_key: list[str] | None = None
     incremental_column: str = ":updated_at"
     full_update_mode: str = "api"
+    max_rows: int | None = None
     source: str = "socrata"
 
     def __post_init__(self):
@@ -59,3 +64,5 @@ class SocrataDatasetSpec(DatasetSpec):
             raise ValueError(
                 f"full_update_mode must be 'api' or 'file_download', got {self.full_update_mode!r}"
             )
+        if self.max_rows is not None and self.max_rows <= 0:
+            raise ValueError(f"max_rows must be positive, got {self.max_rows}")

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -749,6 +749,7 @@ COOK_COUNTY_ASSESSED_PARCEL_VALUES_SPEC = SocrataDatasetSpec(
     target_schema="raw_data",
     entity_key=["row_id"],
     full_update_mode="file_download",
+    max_rows=1_500_000,
 )
 
 COOK_COUNTY_NEIGHBORHOOD_BOUNDARIES_SPEC = SocrataDatasetSpec(

--- a/platform/airflow/dags/loci/sources/update_configs.py
+++ b/platform/airflow/dags/loci/sources/update_configs.py
@@ -523,7 +523,7 @@ COOK_COUNTY_PARCEL_SALES = DatasetUpdateConfig(
     full_update_mode="api",
 )
 
-COOK_COUNTY_ASSESSED_PARCEL_VALUES = DatasetUpdateConfig(
+COOK_COUNTY_ASSESSED_PARCEL_VALUES_UC = DatasetUpdateConfig(
     spec=specs.COOK_COUNTY_ASSESSED_PARCEL_VALUES_SPEC,
     update_cron="30 1 * * 1,4",
     full_update_week_of_month=1,

--- a/platform/airflow/dags/loci/tasks/socrata_tasks.py
+++ b/platform/airflow/dags/loci/tasks/socrata_tasks.py
@@ -59,6 +59,7 @@ def run_incremental_update(
             entity_key=update_config.spec.entity_key or None,
         ),
         entity_key=update_config.spec.entity_key or None,
+        max_rows=update_config.spec.max_rows,
     )
     task_logger.info(
         f"Incremental: ingested {rows} rows into raw_data.{update_config.spec.target_table}"

--- a/platform/airflow/dags/loci/tasks/task_utils.py
+++ b/platform/airflow/dags/loci/tasks/task_utils.py
@@ -21,6 +21,11 @@ def choose_update_mode(update_config: DatasetUpdateConfig, task_logger: Logger) 
     tg_id_prefix = get_task_group_id_prefix(task_instance=context["ti"])
     logical_date = context["logical_date"]
 
+    force_full_refresh = context["params"].get("force_full_refresh", False)
+    if force_full_refresh:
+        task_logger.info("force_full_refresh=True in DAG run conf; routing to full update")
+        return f"{tg_id_prefix}run_full_update"
+
     week_number = (logical_date.day - 1) // 7 + 1
     task_logger.info(f"Current week_number: {week_number}")
     task_logger.info(f"Current month:       {logical_date.month}")

--- a/platform/tests/collectors/bike_index/test_client.py
+++ b/platform/tests/collectors/bike_index/test_client.py
@@ -60,6 +60,7 @@ class TestBikeIndexClient:
 
         assert result == {"bikes": []}
 
+    @pytest.mark.network
     @patch.object(requests.Session, "request")
     def test_request_raises_rate_limited_on_429(self, mock_request):
         resp = MagicMock()
@@ -76,6 +77,7 @@ class TestBikeIndexClient:
             assert last_exc.retry_after == 5.0
             assert mock_request.call_count == 4
 
+    @pytest.mark.network
     @patch.object(requests.Session, "request")
     def test_request_raises_server_error_on_500(self, mock_request):
         resp = MagicMock()

--- a/platform/tests/collectors/socrata/test_collector.py
+++ b/platform/tests/collectors/socrata/test_collector.py
@@ -402,3 +402,211 @@ class TestMetadataCache:
 
         assert collector._get_metadata("abcd-1234") is meta
         assert collector._get_metadata("abcd-1234") is meta  # same object
+
+
+# ---------------------------------------------------------------------------
+# max_rows cap tests
+# ---------------------------------------------------------------------------
+
+
+class TestMaxRowsCap:
+    """Tests for the optional row cap on incremental runs."""
+
+    CONFIG = IncrementalConfig(
+        incremental_column="updated_on",
+        entity_key=["id"],
+    )
+
+    def _setup_preflight(self, mock_engine):
+        stub_table_columns(mock_engine, _STANDARD_TABLE_COLUMNS)
+
+    def test_stops_at_page_boundary_when_cap_equals_page(self, collector, mock_engine):
+        """Cap exactly at page size: one page stages, no further pages fetched."""
+        collector._metadata_cache["abcd-1234"] = make_metadata_mock()
+        self._setup_preflight(mock_engine)
+
+        page1 = make_batch(
+            {"id": "1", "updated_on": "2024-01-01", "val": "a"},
+            {"id": "2", "updated_on": "2024-01-02", "val": "b"},
+        )
+        page2 = make_batch(
+            {"id": "3", "updated_on": "2024-01-03", "val": "c"},
+        )
+        attach_mock_client(collector, [page1, page2])
+
+        total = collector.incremental_update(
+            "abcd-1234", "test", "raw_data", self.CONFIG, max_rows=2
+        )
+
+        assert total == 2
+        stager = mock_engine._stagers[0]
+        assert stager.rows_staged == 2
+        assert len(stager.batches) == 1
+
+    def test_overshoots_to_finish_page_when_cap_hit_mid_page(self, collector, mock_engine):
+        """Cap between page boundaries: finishes the current page, then stops."""
+        collector._metadata_cache["abcd-1234"] = make_metadata_mock()
+        self._setup_preflight(mock_engine)
+
+        page1 = make_batch(
+            {"id": "1", "updated_on": "2024-01-01", "val": "a"},
+            {"id": "2", "updated_on": "2024-01-02", "val": "b"},
+        )
+        page2 = make_batch(
+            {"id": "3", "updated_on": "2024-01-03", "val": "c"},
+            {"id": "4", "updated_on": "2024-01-04", "val": "d"},
+        )
+        page3 = make_batch(
+            {"id": "5", "updated_on": "2024-01-05", "val": "e"},
+        )
+        attach_mock_client(collector, [page1, page2, page3])
+
+        total = collector.incremental_update(
+            "abcd-1234", "test", "raw_data", self.CONFIG, max_rows=3
+        )
+
+        # Cap is 3, but page 2 pushes us to 4; we stop there without fetching page 3.
+        assert total == 4
+        stager = mock_engine._stagers[0]
+        assert stager.rows_staged == 4
+        assert len(stager.batches) == 2
+
+    def test_cap_larger_than_available_rows_ingests_everything(self, collector, mock_engine):
+        """Cap above total row count behaves like no cap."""
+        collector._metadata_cache["abcd-1234"] = make_metadata_mock()
+        self._setup_preflight(mock_engine)
+
+        page1 = make_batch(
+            {"id": "1", "updated_on": "2024-01-01", "val": "a"},
+            {"id": "2", "updated_on": "2024-01-02", "val": "b"},
+        )
+        page2 = make_batch(
+            {"id": "3", "updated_on": "2024-01-03", "val": "c"},
+        )
+        attach_mock_client(collector, [page1, page2])
+
+        total = collector.incremental_update(
+            "abcd-1234", "test", "raw_data", self.CONFIG, max_rows=1000
+        )
+
+        assert total == 3
+        stager = mock_engine._stagers[0]
+        assert stager.rows_staged == 3
+
+    def test_cap_hit_recorded_in_run_metadata(self, collector, mock_engine):
+        """When the cap fires, run.metadata['max_rows_hit'] is True."""
+        collector._metadata_cache["abcd-1234"] = make_metadata_mock()
+        self._setup_preflight(mock_engine)
+
+        page1 = make_batch(
+            {"id": "1", "updated_on": "2024-01-01", "val": "a"},
+            {"id": "2", "updated_on": "2024-01-02", "val": "b"},
+        )
+        page2 = make_batch(
+            {"id": "3", "updated_on": "2024-01-03", "val": "c"},
+        )
+        attach_mock_client(collector, [page1, page2])
+
+        collector.incremental_update("abcd-1234", "test", "raw_data", self.CONFIG, max_rows=2)
+
+        run = collector.tracker.last_run
+        assert run.metadata.get("max_rows_hit") is True
+
+    def test_cap_not_hit_is_not_recorded_in_run_metadata(self, collector, mock_engine):
+        """When the run finishes naturally, max_rows_hit is absent or False."""
+        collector._metadata_cache["abcd-1234"] = make_metadata_mock()
+        self._setup_preflight(mock_engine)
+
+        batch = make_batch(
+            {"id": "1", "updated_on": "2024-01-01", "val": "a"},
+        )
+        attach_mock_client(collector, [batch])
+
+        collector.incremental_update("abcd-1234", "test", "raw_data", self.CONFIG, max_rows=1000)
+
+        run = collector.tracker.last_run
+        assert not run.metadata.get("max_rows_hit", False)
+
+    def test_hwm_after_capped_run_reflects_last_staged_page(self, collector, mock_engine):
+        """HWM advances through fully-staged pages so a follow-up run resumes correctly."""
+        collector._metadata_cache["abcd-1234"] = make_metadata_mock()
+        self._setup_preflight(mock_engine)
+
+        page1 = make_batch(
+            {"id": "1", "updated_on": "2024-01-01", "val": "a"},
+            {"id": "2", "updated_on": "2024-01-02", "val": "b"},
+        )
+        # Page 2 would advance the HWM further, but we cap before fetching it.
+        page2 = make_batch(
+            {"id": "3", "updated_on": "2024-06-15", "val": "c"},
+        )
+        attach_mock_client(collector, [page1, page2])
+
+        collector.incremental_update("abcd-1234", "test", "raw_data", self.CONFIG, max_rows=2)
+
+        run = collector.tracker.last_run
+        assert run.high_water_mark is not None
+        assert "2024-01-02" in run.high_water_mark
+        assert "2024-06-15" not in run.high_water_mark
+
+    def test_explicit_argument_overrides_instance_default(self, mock_engine):
+        """max_rows passed to incremental_update wins over SocrataCollector(max_rows=...)."""
+        collector = SocrataCollector(engine=mock_engine, page_size=100, max_rows=1000)
+        collector._metadata_cache["abcd-1234"] = make_metadata_mock()
+        stub_table_columns(mock_engine, _STANDARD_TABLE_COLUMNS)
+
+        page1 = make_batch(
+            {"id": "1", "updated_on": "2024-01-01", "val": "a"},
+            {"id": "2", "updated_on": "2024-01-02", "val": "b"},
+        )
+        page2 = make_batch(
+            {"id": "3", "updated_on": "2024-01-03", "val": "c"},
+        )
+        attach_mock_client(collector, [page1, page2])
+
+        total = collector.incremental_update(
+            "abcd-1234", "test", "raw_data", self.CONFIG, max_rows=2
+        )
+
+        assert total == 2
+
+    def test_instance_default_applies_when_no_argument_passed(self, mock_engine):
+        """SocrataCollector(max_rows=...) caps a run with no explicit arg."""
+        collector = SocrataCollector(engine=mock_engine, page_size=100, max_rows=2)
+        collector._metadata_cache["abcd-1234"] = make_metadata_mock()
+        stub_table_columns(mock_engine, _STANDARD_TABLE_COLUMNS)
+
+        page1 = make_batch(
+            {"id": "1", "updated_on": "2024-01-01", "val": "a"},
+            {"id": "2", "updated_on": "2024-01-02", "val": "b"},
+        )
+        page2 = make_batch(
+            {"id": "3", "updated_on": "2024-01-03", "val": "c"},
+        )
+        attach_mock_client(collector, [page1, page2])
+
+        total = collector.incremental_update("abcd-1234", "test", "raw_data", self.CONFIG)
+
+        assert total == 2
+
+    def test_rejects_max_rows_on_full_refresh_via_api(self, collector, mock_engine):
+        """max_rows with an empty HWM override (full refresh via API) must raise."""
+        collector._metadata_cache["abcd-1234"] = make_metadata_mock()
+
+        with pytest.raises(ValueError, match="full_refresh_via_api"):
+            collector.incremental_update(
+                "abcd-1234",
+                "test",
+                "raw_data",
+                self.CONFIG,
+                high_water_mark_override="",
+                max_rows=100,
+            )
+
+    def test_full_refresh_via_api_rejects_instance_max_rows(self, mock_engine):
+        """Instance-level max_rows must not silently apply to full_refresh_via_api."""
+        collector = SocrataCollector(engine=mock_engine, page_size=100, max_rows=100)
+        collector._metadata_cache["abcd-1234"] = make_metadata_mock()
+
+        with pytest.raises(ValueError, match="full_refresh_via_api"):
+            collector.full_refresh_via_api("abcd-1234", "test", "raw_data")

--- a/platform/tests/collectors/socrata/test_spec.py
+++ b/platform/tests/collectors/socrata/test_spec.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+from loci.collectors.socrata.spec import SocrataDatasetSpec
+
+
+class TestSpecMaxRowsValidation:
+    def _base_kwargs(self):
+        return {
+            "name": "test",
+            "dataset_id": "abcd-1234",
+            "target_table": "test",
+        }
+
+    def test_accepts_positive_max_rows(self):
+        spec = SocrataDatasetSpec(**self._base_kwargs(), max_rows=1000)
+        assert spec.max_rows == 1000
+
+    def test_accepts_none_max_rows(self):
+        spec = SocrataDatasetSpec(**self._base_kwargs(), max_rows=None)
+        assert spec.max_rows is None
+
+    def test_rejects_zero_max_rows(self):
+        with pytest.raises(ValueError, match="max_rows"):
+            SocrataDatasetSpec(**self._base_kwargs(), max_rows=0)
+
+    def test_rejects_negative_max_rows(self):
+        with pytest.raises(ValueError, match="max_rows"):
+            SocrataDatasetSpec(**self._base_kwargs(), max_rows=-5)


### PR DESCRIPTION
Changes:
* Added a `max_rows` param to the `SocrataCollector` and functionality to use that to limit the number of rows collected in a single collection run (via the incremental mode). (closes #149)
    * Collectors all ingest to a temp staging table while running collection and when the collection is complete, it merges the data in that staging table into the persistent `raw_data` table. This approach is intended to avoid resource conflicts on the raw_data table while collections are running (although they're still possible during the merge part, but that's much shorter than the collection time). For extremely large Socrata datasets, these collections could take more than 24 hours via the API mode, and data wouldn't merge over until the run completes, and if it's interrupted, nothing is merged into the persistent table. The `max_rows` param makes it possible to force merging collected data sooner.
        * I could have modified this so that it performed in-process merges at intervals in the collection run, but I want to schedule collections during times when there's less demand on Socrata's servers (as well as free up bandwidth on my home network during the day).
* Added a mechanism to force a full refresh run regardless of the full refresh schedule for the respective `UpdateConfig`.
* Added test coverage.
