### PR TITLE
Adds postgresql.conf file and changes to support tuning the database for analytical workloads

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -20,6 +20,8 @@ and if the images build successfully, you can start the system up via
 podman compose up
 ```
 
+If you want to tune the PostGIS database for your hardware, see the `Local Postgres Overrides` section below.
+
 ### API Keys / App Tokens
 
 #### Census API key
@@ -165,3 +167,58 @@ There are some tests that actually make network calls, and this can be somewhat 
 ```console
 uv run pytest -m "not network"
 ```
+
+# Local Postgres Overrides
+
+To override the default `postgresql.conf` file and tune the database for your hardware, create a `.conf` file in directory `<project_root>/platform/podman/storage/conf.d/` and override the Postgres configs you want to tweak. I'd recommend copying the content in the `.../storage/postgresql.conf` file up until the "LOCAL OVERRIDES" section, pasting that into a `.../storage/conf.d/postgresql.local.conf` file and then adjust values based on the hardware you're running this project on.
+
+## How it works
+
+`postgresql.conf` ends with `include_dir = '/etc/postgresql/conf.d'`, which loads every `*.conf` file in this directory in alphabetical order. Anything set in a local file overrides the corresponding setting in the main config.
+
+Files in this directory (other than the `.gitignore`) are gitignored, so your overrides won't conflict with upstream changes when you pull.
+
+## Quick start
+
+Create a `local.conf` file in `<project_root>/platform/podman/storage/conf.d/` with your overrides. For example, on a decent workstation laptop-sized machine (32 GB RAM, 8 cores):
+
+```conf
+# conf.d/local.conf
+shared_buffers = 8GB
+effective_cache_size = 24GB
+work_mem = 64MB
+maintenance_work_mem = 1GB
+
+max_worker_processes = 8
+max_parallel_workers = 6
+max_parallel_workers_per_gather = 3
+max_parallel_maintenance_workers = 3
+```
+
+Restart the container, then verify your settings are active:
+
+```sql
+show shared_buffers
+```
+
+## Rough sizing guidelines
+
+These are starting points, not rules. Adjust based on your actual workload.
+
+| Setting                            | Formula                          |
+|------------------------------------|----------------------------------|
+| `shared_buffers`                   | ~25% of RAM                      |
+| `effective_cache_size`             | ~75% of RAM                      |
+| `work_mem`                         | RAM / (max_connections * ~4)     |
+| `maintenance_work_mem`             | RAM / 32, capped around 4 GB     |
+| `max_worker_processes`             | physical core count              |
+| `max_parallel_workers_per_gather`  | ~1/3 of physical cores           |
+
+## When to override what
+
+- **Less RAM than 128 GB** → scale down all memory settings
+- **Fewer cores than 16** → scale down parallelism settings
+- **Spinning disks instead of SSD** → set `random_page_cost = 4.0`,
+  `effective_io_concurrency = 1`
+- **Warehouse is a system of record** → set `synchronous_commit = on`
+- **Running many concurrent dbt threads (>8)** → lower `work_mem`

--- a/platform/docker-compose.yaml
+++ b/platform/docker-compose.yaml
@@ -120,6 +120,8 @@ services:
 
   postgis:
     image: postgis/postgis:18-3.6
+    env_file:
+    - ${ENV_FILE_PATH:-.env}
     environment:
       POSTGRES_USER: loci
       POSTGRES_PASSWORD: loci
@@ -129,6 +131,10 @@ services:
     volumes:
       - postgis-db-volume:/var/lib/postgresql
       - ./podman/storage/postgis_init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./podman/storage/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+      - ./podman/storage/conf.d:/etc/postgresql/conf.d:ro
+    shm_size: ${POSTGIS_SHM_SIZE:-256mb}
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf
     healthcheck:
       test:
         [

--- a/platform/podman/storage/conf.d/.gitignore
+++ b/platform/podman/storage/conf.d/.gitignore
@@ -1,0 +1,6 @@
+# Ignore all local override files in this directory
+*
+
+# But keep the directory itself and its documentation tracked
+!.gitignore
+

--- a/platform/podman/storage/postgresql.conf
+++ b/platform/podman/storage/postgresql.conf
@@ -1,0 +1,135 @@
+# =============================================================================
+# PostgreSQL configuration for PostGIS analytics warehouse
+#
+# These defaults target a small host (~8 GB RAM, 4 cores, SSD) so that anyone
+# forking this repo can run it without immediate tuning. The settings are
+# analytics-oriented (favoring throughput over OLTP latency) but conservative
+# in their resource use.
+#
+# If your host has more RAM or cores, override settings in conf.d/.
+# See <project_root>/platform/README.md for sizing guidelines and examples.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# CONNECTIONS
+# -----------------------------------------------------------------------------
+# Analytics warehouses need few connections, not many. Each connection costs
+# memory, and work_mem is allocated per-operation per-connection.
+listen_addresses = '*'
+max_connections = 50
+
+# -----------------------------------------------------------------------------
+# MEMORY
+# -----------------------------------------------------------------------------
+# shared_buffers ~25% of RAM is the standard recommendation. The OS page cache
+# also caches the same data, so going much higher tends to waste RAM.
+shared_buffers = 2GB
+
+# effective_cache_size is NOT an allocation — it's a planner hint about how
+# much data is likely cached (Postgres + OS combined). ~75% of RAM.
+effective_cache_size = 6GB
+
+# work_mem is per-operation, per-worker. A single query with parallel workers
+# and multiple sort/hash nodes can multiply this several times over.
+work_mem = 32MB
+
+# Used by VACUUM, CREATE INDEX, ALTER TABLE ADD FOREIGN KEY.
+maintenance_work_mem = 512MB
+autovacuum_work_mem = 256MB
+
+# -----------------------------------------------------------------------------
+# PARALLELISM
+# -----------------------------------------------------------------------------
+# Plan around physical core count. SMT/hyperthreading gives diminishing
+# returns for CPU-bound spatial work.
+max_worker_processes = 4
+max_parallel_workers = 4
+max_parallel_workers_per_gather = 2
+max_parallel_maintenance_workers = 2
+
+# Lower thresholds make Postgres consider parallelism for smaller tables.
+# Defaults (8MB / 1000 rows) are conservative for analytics workloads.
+min_parallel_table_scan_size = 8MB
+min_parallel_index_scan_size = 512kB
+
+# Tells the planner that parallelism is cheap. Defaults assume otherwise,
+# which isn't true on modern hardware for analytics queries.
+parallel_tuple_cost = 0.05
+parallel_setup_cost = 500.0
+
+# -----------------------------------------------------------------------------
+# PLANNER
+# -----------------------------------------------------------------------------
+# random_page_cost default (4.0) assumes spinning disk. SSDs make random
+# reads nearly as cheap as sequential. This is the most-impactful planner
+# setting people forget to change.
+random_page_cost = 1.1
+seq_page_cost = 1.0
+
+# How many concurrent I/O requests the storage can handle. SSDs handle many.
+# If you're on NVMe, override to 300-500. On spinning disks, set to 1.
+effective_io_concurrency = 200
+
+# How detailed column statistics are. Higher = better plans for complex/
+# skewed data, slower ANALYZE. 500 is a reasonable bump for a warehouse
+# with complex spatial distributions.
+default_statistics_target = 500
+
+# JIT helps for long-running analytics queries, occasionally hurts PostGIS
+# due to overhead on queries with many spatial function calls. Leave on but
+# raise the threshold so it only kicks in for genuinely expensive queries.
+jit = on
+jit_above_cost = 500000
+jit_inline_above_cost = 1000000
+jit_optimize_above_cost = 1000000
+
+# -----------------------------------------------------------------------------
+# WRITE-AHEAD LOG / CHECKPOINTS
+# -----------------------------------------------------------------------------
+# Spreads checkpoints over more time and allows more WAL between them.
+# Trades a bit of recovery time for smoother performance during bulk loads
+# (e.g. dbt builds).
+wal_level = replica
+wal_compression = on
+max_wal_size = 4GB
+min_wal_size = 512MB
+checkpoint_timeout = 30min
+checkpoint_completion_target = 0.9
+wal_buffers = 16MB
+
+# Turning this off accepts the risk of losing the last few hundred ms of
+# transactions on crash, in exchange for faster bulk writes. Acceptable
+# when source data lives upstream and can be re-loaded. Override to 'on'
+# in conf.d/ if your warehouse is a system of record.
+synchronous_commit = off
+
+# -----------------------------------------------------------------------------
+# AUTOVACUUM
+# -----------------------------------------------------------------------------
+# dbt creates and drops a lot of tables. Autovacuum needs to keep up,
+# especially on heavily-updated incremental models.
+autovacuum = on
+autovacuum_max_workers = 3
+autovacuum_naptime = 30s
+autovacuum_vacuum_scale_factor = 0.1
+autovacuum_analyze_scale_factor = 0.05
+autovacuum_vacuum_cost_limit = 2000
+
+# -----------------------------------------------------------------------------
+# LOGGING
+# -----------------------------------------------------------------------------
+# Log slow queries so you can find tuning targets. 5 seconds catches genuine
+# offenders without flooding logs from normal model builds.
+log_min_duration_statement = 5000
+log_checkpoints = on
+log_lock_waits = on
+log_temp_files = 10MB
+log_autovacuum_min_duration = 1000
+log_line_prefix = '%m [%p] %q%u@%d '
+
+# =============================================================================
+# LOCAL OVERRIDES
+# Files in conf.d/ are read in alphabetical order. Anything set there wins
+# over the values above. Keep this line LAST.
+# =============================================================================
+include_dir = '/etc/postgresql/conf.d'


### PR DESCRIPTION
Changes:
* Enables tuning the database for analytical workloads. (Closes #152)
    * Includes instructions on setting database configs for local hardware.
    * Keeps local config out of version control but makes it very easy to tune for any reasonable hardware.

I confirmed the configs from my `postgresql.local.conf` were used in place of the default ones and that logging is capturing long-running queries (ie ones that take longer than 5s to run). 


<img width="864" height="818" alt="image" src="https://github.com/user-attachments/assets/0983a4d7-6dcc-457c-a2df-4cd3b96cc0cd" />

<img width="3440" height="437" alt="441CAF30-586C-4D22-9E26-541F9DF8D532_1_201_a" src="https://github.com/user-attachments/assets/5f2ac763-438d-479c-8f7e-680b01bd3e3e" />
