### PR TITLE
Iss162 reimplement network building using osm

### DIFF
--- a/apps/bike-map/index.html
+++ b/apps/bike-map/index.html
@@ -636,6 +636,16 @@
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   }
 
+  .popup-section-title {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: rgba(255, 255, 255, 0.4);
+    margin-top: 8px;
+    margin-bottom: 2px;
+  }
+
   .popup-row {
     display: flex;
     justify-content: space-between;
@@ -785,7 +795,7 @@
           Why this route?
         </button>
         <div class="route-why-text" id="route-why-text">
-          This route prefers streets with better bike infrastructure, lower speed limits, lighting, and less severe recent crash history, even if that means a slightly longer ride. It may differ from the shortest path based on these preferences. Conditions change — always use your own judgment.
+          This route prefers streets with better bike infrastructure, lower speed limits, lighting, and less severe recent crash history, even if that means a slightly longer ride. It may differ from the shortest path based on these preferences. Conditions change — always use your own judgment. Hover or tap any segment to see what factors drove its cost.
         </div>
       </div>
     </div>
@@ -978,6 +988,16 @@ const LAYERS = {
   },
 };
 
+// ── Route segment color scale ────────────────────────────
+// Stops for stress-cost-per-meter. Used as a fallback when there are
+// too few segments to compute meaningful percentiles.
+const ROUTE_COLOR_STOPS = [
+  { max: 1.0, color: '#22c55e' },  // green: cycleway/quiet residential, no penalties
+  { max: 2.0, color: '#84cc16' },  // lime: typical residential
+  { max: 3.5, color: '#f59e0b' },  // orange: tertiary, mild penalty
+  { max: Infinity, color: '#ef4444' }, // red: arterial or heavy penalties
+];
+
 // ── Runtime state ────────────────────────────────────────
 const layerData = {};
 const layerCounts = {};
@@ -992,6 +1012,13 @@ let routeDestination = null;
 let routeData = null;
 let originMarker = null;
 let destMarker = null;
+
+// Route segment hover/click popup state (separate from currentPopup so
+// dataset point popups and route segment popups don't fight each other).
+let hoverPopup = null;
+let hoveredSegmentIdx = null;
+let clickPopup = null;
+let clickedSegmentIdx = null;
 
 const whyToggle = document.getElementById('route-why-toggle');
 const whyText = document.getElementById('route-why-text');
@@ -1177,30 +1204,54 @@ function initMap() {
   }), 'top-right');
 
   map.on('load', () => {
-    map.addSource('route', {
+    // Route source: a FeatureCollection of per-segment LineStrings. Each
+    // feature has its own color (driven by stress cost), cost components
+    // for the popup, and a numeric id used for hover feature-state.
+    map.addSource('route-segments', {
       type: 'geojson',
       data: { type: 'FeatureCollection', features: [] },
     });
 
+    // Dark casing under the route line for legibility on light tiles.
     map.addLayer({
       id: 'route-casing',
       type: 'line',
-      source: 'route',
+      source: 'route-segments',
       layout: { 'line-join': 'round', 'line-cap': 'round' },
       paint: {
-        'line-color': 'rgba(0, 0, 0, 0.4)',
+        'line-color': 'rgba(0, 0, 0, 0.45)',
         'line-width': 8,
       },
     });
 
+    // The visible route line. Color comes from the feature's `color`
+    // property (set per-segment based on stress cost). Hover/clicked
+    // segments get a slight width bump.
     map.addLayer({
       id: 'route-line',
       type: 'line',
-      source: 'route',
+      source: 'route-segments',
       layout: { 'line-join': 'round', 'line-cap': 'round' },
       paint: {
-        'line-color': '#6366f1',
-        'line-width': 5,
+        'line-color': ['get', 'color'],
+        'line-width': [
+          'case',
+          ['boolean', ['feature-state', 'hover'], false], 7,
+          5,
+        ],
+        'line-opacity': 0.95,
+      },
+    });
+
+    // Wider invisible line for easier hover/click targeting (~14px).
+    map.addLayer({
+      id: 'route-segments-hitarea',
+      type: 'line',
+      source: 'route-segments',
+      layout: { 'line-join': 'round', 'line-cap': 'round' },
+      paint: {
+        'line-color': 'rgba(0, 0, 0, 0)',
+        'line-width': 14,
       },
     });
 
@@ -1434,17 +1485,23 @@ function applyDateFilter(id) {
 function wireRouting() {
   map.on('click', handleMapClick);
   document.getElementById('route-clear-btn').addEventListener('click', clearRoute);
+  wireRouteSegmentInteractions();
 }
 
 function handleMapClick(e) {
-  const pointLayers = Object.keys(LAYERS)
-    .flatMap(id => [`${id}-clusters`, `${id}-points-hitarea`])
-    .filter(lid => map.getLayer(lid));
-  const hitFeatures = map.queryRenderedFeatures(e.point, { layers: pointLayers });
-  if (hitFeatures.length > 0) return;
+  // Don't place waypoints when clicking on dataset points or route segments
+  // (those layers have their own click handlers).
+  const blockingLayers = [
+    ...Object.keys(LAYERS).flatMap(id => [`${id}-clusters`, `${id}-points-hitarea`]),
+    'route-segments-hitarea',
+  ].filter(lid => map.getLayer(lid));
+  if (map.queryRenderedFeatures(e.point, { layers: blockingLayers }).length > 0) return;
+
+  // If a route is already displayed, blank clicks do nothing. Users can
+  // drag the A/B markers to update the route, or use the Clear button.
+  if (routeData) return;
 
   const lngLat = [e.lngLat.lng, e.lngLat.lat];
-
   if (!routeOrigin) {
     setOrigin(lngLat);
   } else if (!routeDestination) {
@@ -1511,6 +1568,42 @@ function updateRouteLabel(which, lngLat) {
   labelEl.classList.add('set');
 }
 
+// ── Route segment color scale ────────────────────────────
+// Pick a color for each segment based on stress cost per meter. When a
+// route has enough segments, we use percentile bins relative to the
+// route itself so the worst parts of any route are clearly visible.
+// Otherwise we fall back to absolute thresholds.
+function colorForCostPerMeter(costPerMeter) {
+  for (const stop of ROUTE_COLOR_STOPS) {
+    if (costPerMeter <= stop.max) return stop.color;
+  }
+  return ROUTE_COLOR_STOPS[ROUTE_COLOR_STOPS.length - 1].color;
+}
+
+function assignSegmentColors(segments) {
+  const cpm = segments.map(s => {
+    const len = s.length_m || 0;
+    return len > 0 ? (s.stress_cost || 0) / len : 0;
+  });
+
+  // Few segments → absolute thresholds. Many segments → quartile bins
+  // computed from this route's own distribution.
+  if (segments.length < 5) return cpm.map(colorForCostPerMeter);
+
+  const sorted = [...cpm].sort((a, b) => a - b);
+  const q = (p) => sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))];
+  const q25 = q(0.25);
+  const q50 = q(0.50);
+  const q75 = q(0.75);
+
+  return cpm.map(v => {
+    if (v <= q25) return ROUTE_COLOR_STOPS[0].color;
+    if (v <= q50) return ROUTE_COLOR_STOPS[1].color;
+    if (v <= q75) return ROUTE_COLOR_STOPS[2].color;
+    return ROUTE_COLOR_STOPS[3].color;
+  });
+}
+
 // ── Route: fetch from Lambda ─────────────────────────────
 async function fetchRoute() {
   if (!CONFIG.routing_api_url) {
@@ -1543,18 +1636,41 @@ async function fetchRoute() {
     const data = await resp.json();
     routeData = data;
 
-    map.getSource('route').setData({
+    const colors = assignSegmentColors(data.segments);
+
+    const features = data.segments.map((seg, idx) => ({
       type: 'Feature',
+      id: idx,
+      properties: {
+        idx,
+        name: seg.name,
+        highway: seg.highway,
+        infra_type: seg.infra_type,
+        length_m: seg.length_m,
+        stress_cost: seg.stress_cost,
+        color: colors[idx],
+        // cost_components becomes a JSON string in feature.properties when
+        // queried from the map; we round-trip it through JSON ourselves
+        // so popup code can rely on parse(string) → object.
+        cost_components: JSON.stringify(seg.cost_components),
+      },
       geometry: {
         type: 'LineString',
-        coordinates: data.coordinates,
+        coordinates: seg.coordinates,
       },
+    }));
+
+    map.getSource('route-segments').setData({
+      type: 'FeatureCollection',
+      features,
     });
 
-    const bounds = data.coordinates.reduce(
-      (b, c) => b.extend(c),
-      new maplibregl.LngLatBounds(data.coordinates[0], data.coordinates[0])
-    );
+    // Fit bounds across all segment coordinates
+    const firstCoord = data.segments[0].coordinates[0];
+    const bounds = new maplibregl.LngLatBounds(firstCoord, firstCoord);
+    for (const seg of data.segments) {
+      for (const c of seg.coordinates) bounds.extend(c);
+    }
     map.fitBounds(bounds, { padding: 80 });
 
     const distKm = data.total_length_m / 1000;
@@ -1585,9 +1701,15 @@ function clearRoute() {
   if (originMarker) { originMarker.remove(); originMarker = null; }
   if (destMarker) { destMarker.remove(); destMarker = null; }
 
-  if (map.getSource('route')) {
-    map.getSource('route').setData({ type: 'FeatureCollection', features: [] });
+  if (map.getSource('route-segments')) {
+    map.getSource('route-segments').setData({ type: 'FeatureCollection', features: [] });
   }
+
+  // Clean up any open route-segment popups and hover state
+  if (hoverPopup) { hoverPopup.remove(); hoverPopup = null; }
+  if (clickPopup) { clickPopup.remove(); clickPopup = null; }
+  hoveredSegmentIdx = null;
+  clickedSegmentIdx = null;
 
   const startLabel = document.getElementById('route-start-label');
   const endLabel = document.getElementById('route-end-label');
@@ -1606,9 +1728,205 @@ function clearRoute() {
   map.getContainer().classList.add('crosshair-cursor');
 }
 
+// ── Route segment popup builder ──────────────────────────
+const ROUTE_SEGMENT_COLOR = '#a5b4fc';
+
+function fmtMultiplier(v) {
+  if (v == null) return null;
+  return `×${(+v).toFixed(2)}`;
+}
+
+function fmtMeters(v) {
+  if (v == null) return null;
+  return `${(+v).toFixed(1)} m`;
+}
+
+function buildRouteSegmentPopupHTML(props) {
+  // cost_components is JSON-stringified in feature properties; parse back.
+  const cc = typeof props.cost_components === 'string'
+    ? JSON.parse(props.cost_components)
+    : props.cost_components;
+
+  const headerRows = [
+    ['Street', props.name],
+    ['Type', props.highway],
+    ['Infra', props.infra_type],
+  ].filter(([, v]) => v != null && v !== '');
+
+  const factorRows = [
+    ['Speed',          fmtMultiplier(cc.speed_factor)],
+    ['Road type',      fmtMultiplier(cc.road_type_factor)],
+    ['Infrastructure', fmtMultiplier(cc.infrastructure_factor)],
+    ['Tunnel',         fmtMultiplier(cc.tunnel_factor)],
+    ['Surface',        fmtMultiplier(cc.surface_factor)],
+    ['Lighting',       fmtMultiplier(cc.lighting_factor)],
+  ];
+
+  const penaltyRows = [
+    ['Crash penalty',     fmtMeters(cc.crash_penalty)],
+    ['Traffic control',   fmtMeters(cc.traffic_control_penalty)],
+    ['Left-turn penalty', fmtMeters(cc.left_turn_penalty)],
+  ].filter(([, v]) => v != null && parseFloat(v) > 0);
+
+  function renderRows(rows) {
+    return rows
+      .map(([k, v]) => `<div class="popup-row"><span class="popup-key">${k}</span><span class="popup-val">${escHtml(String(v))}</span></div>`)
+      .join('');
+  }
+
+  const headerSection = headerRows.length ? renderRows(headerRows) : '';
+  const factorsSection = factorRows.length
+    ? `<div class="popup-section-title">Multipliers</div>${renderRows(factorRows)}`
+    : '';
+  const penaltiesSection = penaltyRows.length
+    ? `<div class="popup-section-title">Penalties</div>${renderRows(penaltyRows)}`
+    : '';
+
+  return `
+    <div class="popup-title" style="color:${ROUTE_SEGMENT_COLOR}">Route Segment</div>
+    ${headerSection}
+    <div class="popup-row"><span class="popup-key">Length</span><span class="popup-val">${fmtMeters(props.length_m)}</span></div>
+    <div class="popup-row"><span class="popup-key">Stress cost</span><span class="popup-val">${fmtMeters(props.stress_cost)}</span></div>
+    ${factorsSection}
+    ${penaltiesSection}
+  `;
+}
+
+// ── Route segment hover + click ──────────────────────────
+function clearHoverState() {
+  if (hoveredSegmentIdx !== null && hoveredSegmentIdx !== clickedSegmentIdx) {
+    map.setFeatureState(
+      { source: 'route-segments', id: hoveredSegmentIdx },
+      { hover: false },
+    );
+  }
+  hoveredSegmentIdx = null;
+  if (hoverPopup) { hoverPopup.remove(); hoverPopup = null; }
+  map.getCanvas().style.cursor = '';
+}
+
+function wireRouteSegmentInteractions() {
+  map.on('mousemove', 'route-segments-hitarea', (e) => {
+    if (!e.features.length) return;
+    const feat = e.features[0];
+    const idx = feat.id;
+
+    // If the click popup is already open for this segment, suppress hover.
+    if (clickedSegmentIdx === idx) return;
+
+    if (idx !== hoveredSegmentIdx) {
+      if (hoveredSegmentIdx !== null && hoveredSegmentIdx !== clickedSegmentIdx) {
+        map.setFeatureState(
+          { source: 'route-segments', id: hoveredSegmentIdx },
+          { hover: false },
+        );
+      }
+      hoveredSegmentIdx = idx;
+      map.setFeatureState(
+        { source: 'route-segments', id: idx },
+        { hover: true },
+      );
+    }
+
+    map.getCanvas().style.cursor = 'pointer';
+
+    const html = buildRouteSegmentPopupHTML(feat.properties);
+    if (!hoverPopup) {
+      hoverPopup = new maplibregl.Popup({
+        closeButton: false,
+        closeOnClick: false,
+        offset: 8,
+        maxWidth: '320px',
+      })
+        .setLngLat(e.lngLat)
+        .setHTML(html)
+        .addTo(map);
+    } else {
+      hoverPopup.setLngLat(e.lngLat).setHTML(html);
+    }
+  });
+
+  map.on('mouseleave', 'route-segments-hitarea', clearHoverState);
+
+  map.on('click', 'route-segments-hitarea', (e) => {
+    if (!e.features.length) return;
+    const feat = e.features[0];
+    const idx = feat.id;
+
+    // Tear down hover popup so it doesn't overlap the pinned popup.
+    if (hoverPopup) { hoverPopup.remove(); hoverPopup = null; }
+    hoveredSegmentIdx = null;
+
+    // Drop any previously pinned popup; a new one replaces it.
+    if (clickPopup) {
+      if (clickedSegmentIdx !== null && clickedSegmentIdx !== idx) {
+        map.setFeatureState(
+          { source: 'route-segments', id: clickedSegmentIdx },
+          { hover: false },
+        );
+      }
+      clickPopup.remove();
+    }
+
+    clickPopup = new maplibregl.Popup({
+      closeButton: true,
+      closeOnClick: false,  // we close it ourselves; closeOnClick fires on the
+                            // same click that opened it inside the same map click handler
+      offset: 8,
+      maxWidth: '320px',
+    })
+      .setLngLat(e.lngLat)
+      .setHTML(buildRouteSegmentPopupHTML(feat.properties))
+      .addTo(map);
+    clickedSegmentIdx = idx;
+
+    clickPopup.on('close', () => {
+      if (clickedSegmentIdx !== null) {
+        map.setFeatureState(
+          { source: 'route-segments', id: clickedSegmentIdx },
+          { hover: false },
+        );
+      }
+      clickedSegmentIdx = null;
+      clickPopup = null;
+    });
+
+    map.setFeatureState(
+      { source: 'route-segments', id: idx },
+      { hover: true },
+    );
+  });
+
+  // Clicking the map background while a route-segment popup is pinned
+  // should dismiss it. We do this by listening to all map clicks and
+  // checking that they didn't land on a route segment.
+  map.on('click', (e) => {
+    if (!clickPopup) return;
+    const onSegment = map.queryRenderedFeatures(e.point, {
+      layers: ['route-segments-hitarea'],
+    }).length > 0;
+    if (!onSegment) {
+      clickPopup.remove();  // close handler clears state
+    }
+  });
+}
+
 // ── Route: log to API Gateway ────────────────────────────
 function logRouteRequest(data) {
   if (!CONFIG.log_endpoint) return;
+
+  // Reconstruct a single coordinate list from segments for logging
+  // compatibility (logs already record route_geometry as a LineString).
+  const allCoords = [];
+  for (const seg of data.segments) {
+    if (allCoords.length === 0) {
+      allCoords.push(...seg.coordinates);
+    } else {
+      // Skip the first coordinate of each subsequent segment to avoid
+      // duplicating shared endpoints between consecutive segments.
+      allCoords.push(...seg.coordinates.slice(1));
+    }
+  }
 
   const payload = {
     timestamp: new Date().toISOString(),
@@ -1616,7 +1934,7 @@ function logRouteRequest(data) {
     destination: { lng: routeDestination[0], lat: routeDestination[1] },
     total_length_m: data.total_length_m,
     total_cost: data.total_cost,
-    route_geometry: { type: 'LineString', coordinates: data.coordinates },
+    route_geometry: { type: 'LineString', coordinates: allCoords },
     user_agent: navigator.userAgent,
     screen: { width: screen.width, height: screen.height },
     viewport: { width: window.innerWidth, height: window.innerHeight },

--- a/infra/modules/bike-map/lambda/handler.py
+++ b/infra/modules/bike-map/lambda/handler.py
@@ -26,6 +26,7 @@ Response:
     }
 """
 
+import decimal
 import gzip
 import json
 import logging
@@ -46,6 +47,13 @@ _graph = None
 _kdtree = None
 _node_ids = None
 _api_key = None
+
+
+class _DecimalEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            return float(o)
+        return super().default(o)
 
 
 def _load_graph():
@@ -167,5 +175,5 @@ def lambda_handler(event: dict, context) -> dict:
     return {
         "statusCode": 200,
         "headers": {"Content-Type": "application/json"},
-        "body": json.dumps(result),
+        "body": json.dumps(result, cls=_DecimalEncoder),
     }

--- a/platform/airflow/dags/dag_files/dbt_build_dag.py
+++ b/platform/airflow/dags/dag_files/dbt_build_dag.py
@@ -13,7 +13,7 @@ def install_dependencies() -> str:
 
 @task
 def alt_build() -> str:
-    return run_dbt("build", "--select", "+chicago_bike_stress_weighted_edges")
+    return run_dbt("build", "--select", "+chicago_bike_stress_weighted_segments")
 
 
 @dag(

--- a/platform/airflow/dags/dag_files/osm/update_chicago_osm_bike_newtork_edges.py
+++ b/platform/airflow/dags/dag_files/osm/update_chicago_osm_bike_newtork_edges.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.sources.update_configs import CHICAGO_OSM_BIKE_NETWORK_EDGES_UC as UPDATE_CONFIG
+from loci.tasks.osm_tasks import update_osm_table
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["osm", "chicago", "biking", "network"],
+)
+def update_chicago_osm_bike_newtork_edges():
+    update_osm_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_chicago_osm_bike_newtork_edges()

--- a/platform/airflow/dags/dag_files/osm/update_chicago_osm_bike_newtork_nodes.py
+++ b/platform/airflow/dags/dag_files/osm/update_chicago_osm_bike_newtork_nodes.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.sources.update_configs import CHICAGO_OSM_BIKE_NETWORK_NODES_UC as UPDATE_CONFIG
+from loci.tasks.osm_tasks import update_osm_table
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["osm", "chicago", "biking", "network"],
+)
+def update_chicago_osm_bike_newtork_nodes():
+    update_osm_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_chicago_osm_bike_newtork_nodes()

--- a/platform/airflow/dags/loci/collectors/osm/client.py
+++ b/platform/airflow/dags/loci/collectors/osm/client.py
@@ -212,6 +212,7 @@ def _element_to_row(element: dict, spec: OSMDatasetSpec) -> dict[str, Any]:
     Missing tags become None.
     """
     tags = element.get("tags") or {}
+    nodes = element.get("nodes")
 
     row: dict[str, Any] = {
         "osm_type": element.get("type"),
@@ -220,6 +221,7 @@ def _element_to_row(element: dict, spec: OSMDatasetSpec) -> dict[str, Any]:
         "osm_timestamp": element.get("timestamp"),
         "geom": element_to_wkt(element),
         "tags": tags,
+        "node_ids": _format_pg_bigint_array(nodes),
     }
 
     # Promoted columns: look up each original tag key, write under its
@@ -228,3 +230,15 @@ def _element_to_row(element: dict, spec: OSMDatasetSpec) -> dict[str, Any]:
         row[column_name] = tags.get(original_key)
 
     return row
+
+
+def _format_pg_bigint_array(values: list[int] | None) -> str | None:
+    """
+    Format a Python list of ints as a Postgres array literal for COPY.
+
+    Returns None for None or empty input (so the column gets NULL via
+    the NULL '\\N' marker that StagedIngest already handles).
+    """
+    if not values:
+        return None
+    return "{" + ",".join(str(v) for v in values) + "}"

--- a/platform/airflow/dags/loci/collectors/osm/collector.py
+++ b/platform/airflow/dags/loci/collectors/osm/collector.py
@@ -53,7 +53,7 @@ HASH_EXCLUDE_COLUMNS: set[str] = METADATA_COLUMNS | {
 
 
 # Default flush threshold for batched ingestion.
-DEFAULT_BATCH_SIZE = 5000
+DEFAULT_BATCH_SIZE = 50000
 
 
 class OSMCollector:
@@ -312,6 +312,7 @@ def _build_ddl(spec: OSMDatasetSpec) -> str:
         '    "osm_timestamp" timestamptz',
         '    "geom" geometry(Geometry, 4326)',
         '    "tags" jsonb',
+        '    "node_ids" bigint[]',
     ]
 
     for column_name in spec.promoted_columns:

--- a/platform/airflow/dags/loci/exports/graph_export.py
+++ b/platform/airflow/dags/loci/exports/graph_export.py
@@ -39,17 +39,29 @@ class RoutingGraphExporter:
         Weakly connected components smaller than this are dropped.
     """
 
+    # Must match crash_weight in chicago_bike_stress_weighted_segments.sql.
+    # Recomputed here because the SQL model doesn't expose crash_penalty as a column.
+    _CRASH_WEIGHT = 24.0
+
     _SEGMENT_QUERY = """
         select
             segment_id,
-            way_id,
             start_node_id,
             end_node_id,
             direction,
             name,
             highway,
+            infra_type,
             length_m,
             stress_cost,
+            speed_factor,
+            road_type_factor,
+            infrastructure_factor,
+            tunnel_factor,
+            surface_factor,
+            lighting_factor,
+            traffic_control_penalty,
+            crash_score_per_meter,
             ST_AsGeoJSON(ST_Simplify(geom, 0.00005)) as geom_geojson,
             ST_X(ST_StartPoint(geom)) as start_lon,
             ST_Y(ST_StartPoint(geom)) as start_lat,
@@ -105,20 +117,37 @@ class RoutingGraphExporter:
         return output_path
 
     @staticmethod
-    def _parse_geojson_coords(geom_geojson: str | None) -> list | None:
+    def _parse_geojson_coords(geom_geojson: str | None) -> tuple | None:
+        """Parse a GeoJSON LineString's coordinates as a tuple of (lon, lat) tuples.
+
+        Tuples are used instead of lists for memory efficiency: each tuple is
+        smaller than a list of equal length and uses no over-allocation.
+        """
         if not geom_geojson:
             return None
         try:
             geom = json.loads(geom_geojson)
-            return geom.get("coordinates")
-        except (json.JSONDecodeError, TypeError):
+            coords = geom.get("coordinates")
+            if coords is None:
+                return None
+            return tuple((c[0], c[1]) for c in coords)
+        except (json.JSONDecodeError, TypeError, IndexError):
             return None
 
     def _build_graph(self) -> nx.DiGraph:
-        """Stream segments and expand into directed edges."""
+        """Stream segments and expand into directed edges.
+
+        To save memory in the routing Lambda, geometry is stored once per
+        undirected segment in G.graph['segment_geometry'] (keyed by
+        segment_id). Edges carry segment_id + a 'forward' bool so the
+        routing layer can look up and orient geometry at response time.
+        """
         query = self._SEGMENT_QUERY.format(city=self.city, marts_schema=self.marts_schema)
 
         G = nx.DiGraph()
+        segment_geometry: dict[int, tuple] = {}
+        G.graph["segment_geometry"] = segment_geometry
+
         segment_count = 0
         edge_count = 0
 
@@ -127,50 +156,61 @@ class RoutingGraphExporter:
                 start_node = row["start_node_id"]
                 end_node = row["end_node_id"]
                 direction = row["direction"]
-                geom_coords = self._parse_geojson_coords(row["geom_geojson"])
+                segment_id = row["segment_id"]
 
-                # Add nodes (idempotent — duplicate add_node calls are no-ops
-                # if attributes match, but x/y are stable so this is fine).
+                geom_coords = self._parse_geojson_coords(row["geom_geojson"])
+                if geom_coords is not None:
+                    segment_geometry[segment_id] = geom_coords
+
                 if start_node not in G:
                     G.add_node(start_node, x=row["start_lon"], y=row["start_lat"])
                 if end_node not in G:
                     G.add_node(end_node, x=row["end_lon"], y=row["end_lat"])
 
+                def _f(v):
+                    """Coerce numeric DB values (Decimal/None) to native float.
+
+                    Decimal values from psycopg are ~4x larger than floats and
+                    aren't JSON-serializable. Floats are also faster to compare in
+                    A* edge relaxation.
+                    """
+                    return float(v) if v is not None else None
+
                 base_attrs = {
-                    "segment_id": row["segment_id"],
-                    "way_id": row["way_id"],
-                    "length_m": row["length_m"],
-                    "stress_cost": row["stress_cost"],
+                    "segment_id": segment_id,
+                    "length_m": _f(row["length_m"]),
+                    "stress_cost": _f(row["stress_cost"]),
                     "name": row["name"],
                     "highway": row["highway"],
+                    "infra_type": row["infra_type"],
+                    "speed_factor": _f(row["speed_factor"]),
+                    "road_type_factor": _f(row["road_type_factor"]),
+                    "infrastructure_factor": _f(row["infrastructure_factor"]),
+                    "tunnel_factor": _f(row["tunnel_factor"]),
+                    "surface_factor": _f(row["surface_factor"]),
+                    "lighting_factor": _f(row["lighting_factor"]),
+                    "traffic_control_penalty": _f(row["traffic_control_penalty"]),
+                    "crash_penalty": (
+                        float(row["crash_score_per_meter"] or 0.0)
+                        * float(row["length_m"] or 0.0)
+                        * self._CRASH_WEIGHT
+                    ),
                 }
 
-                # Forward edge: geometry runs start_node → end_node.
+                # Forward edge: geometry runs start_node -> end_node
                 if direction in ("forward", "bidirectional"):
-                    G.add_edge(
-                        start_node,
-                        end_node,
-                        geometry_coords=geom_coords,
-                        **base_attrs,
-                    )
+                    G.add_edge(start_node, end_node, forward=True, **base_attrs)
                     edge_count += 1
 
-                # Backward edge: reverse the geometry coords so the edge's
-                # geometry flows from from_node → to_node.
+                # Backward edge: orientation flag tells routing to reverse
                 if direction in ("backward", "bidirectional"):
-                    reversed_coords = list(reversed(geom_coords)) if geom_coords else None
-                    G.add_edge(
-                        end_node,
-                        start_node,
-                        geometry_coords=reversed_coords,
-                        **base_attrs,
-                    )
+                    G.add_edge(end_node, start_node, forward=False, **base_attrs)
                     edge_count += 1
 
                 segment_count += 1
 
             logger.info(
-                "Loaded %d segments → %d directed edges so far",
+                "Loaded %d segments -> %d directed edges so far",
                 segment_count,
                 edge_count,
             )
@@ -186,10 +226,10 @@ class RoutingGraphExporter:
             G.graph["crs"] = crs_row["srtext"].iloc[0]
 
         logger.info(
-            "Graph complete: %d nodes, %d edges (from %d segments)",
+            "Graph complete: %d nodes, %d edges, %d unique segment geometries",
             G.number_of_nodes(),
             G.number_of_edges(),
-            segment_count,
+            len(segment_geometry),
         )
         return G
 
@@ -204,6 +244,13 @@ class RoutingGraphExporter:
         small = [c for c in components if len(c) < self.min_component_size]
         nodes_to_remove = set().union(*small) if small else set()
         G.remove_nodes_from(nodes_to_remove)
+
+        # Prune geometries for segments no longer referenced by any edge
+        referenced = {data["segment_id"] for _, _, data in G.edges(data=True)}
+        seg_geom = G.graph.get("segment_geometry", {})
+        for sid in list(seg_geom):
+            if sid not in referenced:
+                del seg_geom[sid]
 
         logger.info(
             "Component filtering: removed %d components (%d nodes, %d edges) "

--- a/platform/airflow/dags/loci/exports/graph_export.py
+++ b/platform/airflow/dags/loci/exports/graph_export.py
@@ -2,21 +2,13 @@
 """
 Export a stress-weighted routing graph to a gzip-pickled NetworkX DiGraph file.
 
-Queries mart__chicago_bike_stress_weighted_edges and chicago_osmnx_bike_network_nodes from
-the marts schema, builds a NetworkX DiGraph, serializes it with gzip pickle,
-and writes it to a local path.
+Reads chicago_bike_stress_weighted_segments (one row per undirected segment)
+and expands each segment into one or two directed edges based on its
+direction column.
 
 The graph stores only what the Lambda routing function needs:
     - Node attributes: lat (y), lon (x)
-    - Edge attributes: key, length_m, stress_cost, name, highway,
-      geometry_coords
-
-Usage from an Airflow task:
-
-    from loci.exports.graph_export import RoutingGraphExporter
-
-    exporter = RoutingGraphExporter(engine, marts_schema="dbt_loci_marts")
-    output_path = exporter.export(output_path=Path("/tmp/routing_graph.pkl.gz"))
+    - Edge attributes: length_m, stress_cost, name, highway, geometry_coords
 """
 
 from __future__ import annotations
@@ -39,43 +31,45 @@ class RoutingGraphExporter:
     Parameters
     ----------
     engine : PostgresEngine
+    city : str
     marts_schema : str
-        dbt marts schema name. Caller is responsible for determining this
-        from the target environment.
+        Schema where chicago_bike_stress_weighted_segments lives.
     batch_size : int
-        Rows per batch when streaming edges from the database.
     min_component_size : int
-        Weakly connected components smaller than this are dropped before
-        serialization. This removes isolated subgraphs (parking lots,
-        dead-end service roads, tile boundary fragments) that are
-        unreachable from the main network and would never appear in a
-        real route. Default is 75. Set to 1 to disable filtering.
+        Weakly connected components smaller than this are dropped.
     """
 
-    _EDGE_QUERY = """
+    _SEGMENT_QUERY = """
         select
-            e.u, e.v, e.key, e.name, e.highway, e.length_m, e.stress_cost,
-            ST_AsGeoJSON(ST_Simplify(e.geom, 0.00005)) as geom_geojson,
-            n_u.latitude  as u_lat,
-            n_u.longitude as u_lon,
-            n_v.latitude  as v_lat,
-            n_v.longitude as v_lon
-        from {marts_schema}.{city}_bike_stress_weighted_edges e
-        join raw_data.{city}_osmnx_bike_network_nodes n_u
-            on n_u.osmid = e.u
-            and n_u.valid_to is null
-        join raw_data.{city}_osmnx_bike_network_nodes n_v
-            on n_v.osmid = e.v
-            and n_v.valid_to is null
-        where e.stress_cost is not null
-        order by e.u, e.v, e.key """
+            segment_id,
+            way_id,
+            start_node_id,
+            end_node_id,
+            direction,
+            name,
+            highway,
+            length_m,
+            stress_cost,
+            ST_AsGeoJSON(ST_Simplify(geom, 0.00005)) as geom_geojson,
+            ST_X(ST_StartPoint(geom)) as start_lon,
+            ST_Y(ST_StartPoint(geom)) as start_lat,
+            ST_X(ST_EndPoint(geom)) as end_lon,
+            ST_Y(ST_EndPoint(geom)) as end_lat
+        from {marts_schema}.{city}_bike_stress_weighted_segments
+        where stress_cost is not null
+        order by way_id, start_position
+    """
 
     _CRS_QUERY = """
         select srtext
         from spatial_ref_sys
         where srid = (
-            select Find_SRID('{marts_schema}', '{city}_bike_stress_weighted_edges', 'geom')
-        ) """
+            select ST_SRID(geom) as srid
+            from {marts_schema}.{city}_bike_stress_weighted_segments
+            where geom is not null
+            limit 1
+        )
+    """
 
     def __init__(
         self,
@@ -92,17 +86,6 @@ class RoutingGraphExporter:
         self.min_component_size = min_component_size
 
     def export(self, output_path: Path) -> Path:
-        """Build the routing graph and write it to output_path as a gzip pickle.
-
-        Parameters
-        ----------
-        output_path : Path
-            Destination file path. Parent directory must exist.
-
-        Returns
-        -------
-        Path to the written file.
-        """
         output_path = Path(output_path)
         logger.info("Building routing graph → %s", output_path)
 
@@ -115,7 +98,6 @@ class RoutingGraphExporter:
             G.number_of_edges(),
         )
         compressed = gzip.compress(pickle.dumps(G, protocol=pickle.HIGHEST_PROTOCOL))
-
         output_path.write_bytes(compressed)
         size_mb = output_path.stat().st_size / 1_048_576
         logger.info("Wrote %s (%.1f MB compressed)", output_path, size_mb)
@@ -124,12 +106,6 @@ class RoutingGraphExporter:
 
     @staticmethod
     def _parse_geojson_coords(geom_geojson: str | None) -> list | None:
-        """Parse a GeoJSON geometry string into a coordinate list.
-
-        Returns the coordinates array from the GeoJSON (e.g. [[lon, lat], ...])
-        or None if the input is null or unparseable. Parsing at export time
-        avoids repeated json.loads calls at request time in the Lambda.
-        """
         if not geom_geojson:
             return None
         try:
@@ -139,53 +115,85 @@ class RoutingGraphExporter:
             return None
 
     def _build_graph(self) -> nx.DiGraph:
-        """Stream edges from the database and build a NetworkX DiGraph."""
-        query = self._EDGE_QUERY.format(city=self.city, marts_schema=self.marts_schema)
+        """Stream segments and expand into directed edges."""
+        query = self._SEGMENT_QUERY.format(city=self.city, marts_schema=self.marts_schema)
 
         G = nx.DiGraph()
+        segment_count = 0
         edge_count = 0
 
         for batch in self.engine.query_batches(query, batch_size=self.batch_size):
             for row in batch:
-                u, v = row["u"], row["v"]
+                start_node = row["start_node_id"]
+                end_node = row["end_node_id"]
+                direction = row["direction"]
+                geom_coords = self._parse_geojson_coords(row["geom_geojson"])
 
-                if u not in G:
-                    G.add_node(u, x=row["u_lon"], y=row["u_lat"])  # x=lon, y=lat
-                if v not in G:
-                    G.add_node(v, x=row["v_lon"], y=row["v_lat"])
+                # Add nodes (idempotent — duplicate add_node calls are no-ops
+                # if attributes match, but x/y are stable so this is fine).
+                if start_node not in G:
+                    G.add_node(start_node, x=row["start_lon"], y=row["start_lat"])
+                if end_node not in G:
+                    G.add_node(end_node, x=row["end_lon"], y=row["end_lat"])
 
-                G.add_edge(
-                    u,
-                    v,
-                    key=row["key"],
-                    length_m=row["length_m"],
-                    stress_cost=row["stress_cost"],
-                    name=row["name"],
-                    highway=row["highway"],
-                    geometry_coords=self._parse_geojson_coords(row["geom_geojson"]),
-                )
-                edge_count += 1
+                base_attrs = {
+                    "segment_id": row["segment_id"],
+                    "way_id": row["way_id"],
+                    "length_m": row["length_m"],
+                    "stress_cost": row["stress_cost"],
+                    "name": row["name"],
+                    "highway": row["highway"],
+                }
 
-            logger.info("Loaded %d edges", edge_count)
+                # Forward edge: geometry runs start_node → end_node.
+                if direction in ("forward", "bidirectional"):
+                    G.add_edge(
+                        start_node,
+                        end_node,
+                        geometry_coords=geom_coords,
+                        **base_attrs,
+                    )
+                    edge_count += 1
+
+                # Backward edge: reverse the geometry coords so the edge's
+                # geometry flows from from_node → to_node.
+                if direction in ("backward", "bidirectional"):
+                    reversed_coords = list(reversed(geom_coords)) if geom_coords else None
+                    G.add_edge(
+                        end_node,
+                        start_node,
+                        geometry_coords=reversed_coords,
+                        **base_attrs,
+                    )
+                    edge_count += 1
+
+                segment_count += 1
+
+            logger.info(
+                "Loaded %d segments → %d directed edges so far",
+                segment_count,
+                edge_count,
+            )
 
         crs_row = self.engine.query(
             self._CRS_QUERY.format(city=self.city, marts_schema=self.marts_schema)
         )
-        G.graph["crs"] = crs_row["srtext"][0]
+        if crs_row.empty:
+            logger.warning(
+                "Could not look up CRS srtext; graph will be exported without CRS metadata"
+            )
+        else:
+            G.graph["crs"] = crs_row["srtext"].iloc[0]
 
         logger.info(
-            "Graph complete: %d nodes, %d edges",
+            "Graph complete: %d nodes, %d edges (from %d segments)",
             G.number_of_nodes(),
             G.number_of_edges(),
+            segment_count,
         )
         return G
 
     def _filter_small_components(self, G: nx.DiGraph) -> nx.DiGraph:
-        """Remove weakly connected components smaller than min_component_size.
-
-        Uses weak connectivity (ignores edge direction) so that subgraphs
-        reachable only in one direction are still considered connected.
-        """
         if self.min_component_size <= 1:
             return G
 

--- a/platform/airflow/dags/loci/routing.py
+++ b/platform/airflow/dags/loci/routing.py
@@ -320,7 +320,6 @@ def find_route(
         edge_cost = edge_data.get("stress_cost", 0.0)
         total_length_m += edge_data.get("length_m", 0.0)
 
-        # Include turn penalty in the reported total_cost
         turn_penalty = 0.0
         if prev_node is not None:
             turn_penalty = compute_left_turn_penalty(
@@ -335,16 +334,12 @@ def find_route(
 
         edge_coords = edge_data.get("geometry_coords")
         if edge_coords:
-            u_data = G.nodes[u]
-            first = edge_coords[0]
-            last = edge_coords[-1]
-            dist_to_first = (first[0] - u_data["x"]) ** 2 + (first[1] - u_data["y"]) ** 2
-            dist_to_last = (last[0] - u_data["x"]) ** 2 + (last[1] - u_data["y"]) ** 2
-            oriented = edge_coords if dist_to_first <= dist_to_last else list(reversed(edge_coords))
-
+            # Geometry is pre-oriented at export time: coords[0] is at u,
+            # coords[-1] is at v. No runtime reorientation needed.
             if coordinates:
-                oriented = oriented[1:]
-            coordinates.extend(oriented)
+                coordinates.extend(edge_coords[1:])
+            else:
+                coordinates.extend(edge_coords)
         else:
             if coordinates:
                 coordinates.append([G.nodes[v]["x"], G.nodes[v]["y"]])

--- a/platform/airflow/dags/loci/routing.py
+++ b/platform/airflow/dags/loci/routing.py
@@ -1,3 +1,4 @@
+# loci_platform/platform/airflow/dags/loci/routing.py
 """
 Core bike-stress routing logic.
 
@@ -310,49 +311,122 @@ def find_route(
 
     path = _astar_with_turn_costs(G, origin_node, dest_node, heuristic)
 
+    segment_geometry = G.graph.get("segment_geometry", {})
+    segments = []
     total_cost = 0.0
     total_length_m = 0.0
-    coordinates = []
 
     prev_node = None
     for u, v in zip(path[:-1], path[1:], strict=True):
         edge_data = G[u][v]
         edge_cost = edge_data.get("stress_cost", 0.0)
-        total_length_m += edge_data.get("length_m", 0.0)
+        edge_length = edge_data.get("length_m", 0.0)
 
-        turn_penalty = 0.0
+        left_turn_penalty = 0.0
         if prev_node is not None:
-            turn_penalty = compute_left_turn_penalty(
+            left_turn_penalty = compute_left_turn_penalty(
                 G,
                 prev_node,
                 u,
                 v,
                 edge_data,
             )
-        total_cost += edge_cost + turn_penalty
-        prev_node = u
 
-        edge_coords = edge_data.get("geometry_coords")
-        if edge_coords:
-            # Geometry is pre-oriented at export time: coords[0] is at u,
-            # coords[-1] is at v. No runtime reorientation needed.
-            if coordinates:
-                coordinates.extend(edge_coords[1:])
-            else:
-                coordinates.extend(edge_coords)
+        total_cost += edge_cost + left_turn_penalty
+        total_length_m += edge_length
+
+        # Reconstruct geometry: stored once per undirected segment, reversed
+        # if this is the backward direction.
+        sid = edge_data.get("segment_id")
+        base_geom = segment_geometry.get(sid) if sid is not None else None
+        if base_geom:
+            coords = (
+                list(base_geom) if edge_data.get("forward", True) else list(reversed(base_geom))
+            )
+            # Convert tuple pairs back to list pairs for JSON.
+            coords = [[c[0], c[1]] for c in coords]
         else:
-            if coordinates:
-                coordinates.append([G.nodes[v]["x"], G.nodes[v]["y"]])
-            else:
-                coordinates.append([G.nodes[u]["x"], G.nodes[u]["y"]])
-                coordinates.append([G.nodes[v]["x"], G.nodes[v]["y"]])
+            coords = [
+                [G.nodes[u]["x"], G.nodes[u]["y"]],
+                [G.nodes[v]["x"], G.nodes[v]["y"]],
+            ]
+
+        segments.append(
+            {
+                "coordinates": coords,
+                "length_m": round(edge_length, 1),
+                "stress_cost": round(edge_cost, 4),
+                "name": edge_data.get("name"),
+                "highway": edge_data.get("highway"),
+                "infra_type": edge_data.get("infra_type"),
+                "cost_components": {
+                    "length_m": round(edge_length, 1),
+                    "speed_factor": edge_data.get("speed_factor"),
+                    "road_type_factor": edge_data.get("road_type_factor"),
+                    "infrastructure_factor": edge_data.get("infrastructure_factor"),
+                    "tunnel_factor": edge_data.get("tunnel_factor"),
+                    "surface_factor": edge_data.get("surface_factor"),
+                    "lighting_factor": edge_data.get("lighting_factor"),
+                    "crash_penalty": round(edge_data.get("crash_penalty", 0.0), 4),
+                    "traffic_control_penalty": round(
+                        edge_data.get("traffic_control_penalty", 0.0), 4
+                    ),
+                    "left_turn_penalty": round(left_turn_penalty, 4),
+                },
+            }
+        )
+
+        prev_node = u
 
     return {
         "total_cost": round(total_cost, 4),
         "total_length_m": round(total_length_m, 1),
         "nodes": path,
-        "coordinates": coordinates,
+        "segments": segments,
     }
+    # total_cost = 0.0
+    # total_length_m = 0.0
+    # coordinates = []
+
+    # prev_node = None
+    # for u, v in zip(path[:-1], path[1:], strict=True):
+    #     edge_data = G[u][v]
+    #     edge_cost = edge_data.get("stress_cost", 0.0)
+    #     total_length_m += edge_data.get("length_m", 0.0)
+
+    #     turn_penalty = 0.0
+    #     if prev_node is not None:
+    #         turn_penalty = compute_left_turn_penalty(
+    #             G,
+    #             prev_node,
+    #             u,
+    #             v,
+    #             edge_data,
+    #         )
+    #     total_cost += edge_cost + turn_penalty
+    #     prev_node = u
+
+    #     edge_coords = edge_data.get("geometry_coords")
+    #     if edge_coords:
+    #         # Geometry is pre-oriented at export time: coords[0] is at u,
+    #         # coords[-1] is at v. No runtime reorientation needed.
+    #         if coordinates:
+    #             coordinates.extend(edge_coords[1:])
+    #         else:
+    #             coordinates.extend(edge_coords)
+    #     else:
+    #         if coordinates:
+    #             coordinates.append([G.nodes[v]["x"], G.nodes[v]["y"]])
+    #         else:
+    #             coordinates.append([G.nodes[u]["x"], G.nodes[u]["y"]])
+    #             coordinates.append([G.nodes[v]["x"], G.nodes[v]["y"]])
+
+    # return {
+    #     "total_cost": round(total_cost, 4),
+    #     "total_length_m": round(total_length_m, 1),
+    #     "nodes": path,
+    #     "coordinates": coordinates,
+    # }
 
 
 def get_route_street_names(G: nx.DiGraph, nodes: list) -> set[str]:

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -335,6 +335,97 @@ SEATTLE_BBOX = BBox(47.47, -122.48, 47.78, -122.04)
 TORONTO_BBOX = BBox(43.48, -79.79, 43.95, -78.84)
 
 
+# ----------------------------------------------------------------------
+# OSM Spec Generators
+# ----------------------------------------------------------------------
+
+
+def generate_osm_bike_network_edges_spec(city: str, bbox: BBox) -> OSMDatasetSpec:
+    """Build a bikeable-ways spec for a given city."""
+    return OSMDatasetSpec(
+        name=f"{city}_osm_bike_network_edges",
+        target_table=f"{city}_osm_bike_network_edges",
+        target_schema="raw_data",
+        query=OverpassAPIQuery(
+            element_types=["way"],
+            tag_filters=[
+                {
+                    "highway": [
+                        "residential",
+                        "tertiary",
+                        "secondary",
+                        "primary",
+                        "unclassified",
+                        "service",
+                        "living_street",
+                        "unclassified",
+                        "pedestrian",
+                        "track",
+                        "path",
+                        "cycleway",
+                        "footway",
+                        "bridleway",
+                        "road",
+                        "busway",
+                    ]
+                },
+                {"bicycle": ["yes", "designated", "permissive"]},
+            ],
+            bbox=bbox,
+        ),
+        promoted_tags=[
+            "highway",
+            "name",
+            "bicycle",
+            "cycleway",
+            "cycleway:left",
+            "cycleway:right",
+            "surface",
+            "maxspeed",
+            "oneway",
+        ],
+    )
+
+
+def generate_osm_bike_network_nodes_spec(city: str, bbox: BBox) -> OSMDatasetSpec:
+    """Build a bike-routing point-features spec for a given city."""
+    return OSMDatasetSpec(
+        name=f"{city}_osm_bike_network_nodes",
+        target_table=f"{city}_osm_bike_network_nodes",
+        target_schema="raw_data",
+        query=OverpassAPIQuery(
+            element_types=["node"],
+            tag_filters=[
+                {
+                    "highway": [
+                        "traffic_signals",
+                        "stop",
+                        "give_way",
+                        "crossing",
+                        "mini_roundabout",
+                        "turning_circle",
+                        "turning_loop",
+                    ]
+                },
+                {"crossing": None},
+                {"traffic_calming": None},
+                {"barrier": None},
+            ],
+            bbox=bbox,
+        ),
+        promoted_tags=[
+            "highway",
+            "crossing",
+            "traffic_calming",
+            "barrier",
+            "bicycle",
+            "name",
+            "button_operated",
+            "tactile_paving",
+        ],
+    )
+
+
 # ====================================================================================
 #    OSM Overpass Queries
 # ====================================================================================
@@ -497,6 +588,14 @@ OSM_TRANSIT_QUERY = OverpassAPIQuery(
 # *****************
 #    OSM Specs
 # *****************
+
+CHICAGO_OSM_BIKE_NETWORK_EDGES_SPEC = generate_osm_bike_network_edges_spec(
+    city="chicago", bbox=CHICAGO_BBOX
+)
+CHICAGO_OSM_BIKE_NETWORK_NODES_SPEC = generate_osm_bike_network_nodes_spec(
+    city="chicago", bbox=CHICAGO_BBOX
+)
+
 BOSTON_OSM_BIKE_PARKING_SPEC = OSMDatasetSpec(
     name="boston_osm_bike_parking",
     target_table="boston_osm_bike_parking",

--- a/platform/airflow/dags/loci/sources/update_configs.py
+++ b/platform/airflow/dags/loci/sources/update_configs.py
@@ -703,23 +703,21 @@ MADISON_OSM_TRANSIT_UC = DatasetUpdateConfig(
     full_update_mode="api",
 )
 
-# OSM_WAYS_UPDATE_CONFIG = DatasetUpdateConfig(
-#     spec=specs.OSM_WAYS_SPEC,
-#     update_cron="0 5 1-7 2,5,8,11 *",
-#     full_update_week_of_month=1,
-#     full_update_day_of_week=4,
-#     full_update_months=(2, 5, 8, 11),
-#     full_update_mode="file_download",
-# )
+CHICAGO_OSM_BIKE_NETWORK_EDGES_UC = DatasetUpdateConfig(
+    spec=specs.CHICAGO_OSM_BIKE_NETWORK_EDGES_SPEC,
+    update_cron="0 1 * * 3",
+    full_update_week_of_month=1,
+    full_update_day_of_week=4,
+    full_update_mode="api",
+)
 
-# OSM_RELATIONS_UPDATE_CONFIG = DatasetUpdateConfig(
-#     spec=specs.OSM_RELATIONS_SPEC,
-#     update_cron="30 5 1-7 2,5,8,11 *",
-#     full_update_week_of_month=1,
-#     full_update_day_of_week=4,
-#     full_update_months=(2, 5, 8, 11),
-#     full_update_mode="file_download",
-# )
+CHICAGO_OSM_BIKE_NETWORK_NODES_UC = DatasetUpdateConfig(
+    spec=specs.CHICAGO_OSM_BIKE_NETWORK_NODES_SPEC,
+    update_cron="0 3 * * 3",
+    full_update_week_of_month=1,
+    full_update_day_of_week=4,
+    full_update_mode="api",
+)
 
 #######################################################################################
 #    OSMnx                                                                            #

--- a/platform/airflow/dags/loci/tasks/testing/deployment_smoke_test.py
+++ b/platform/airflow/dags/loci/tasks/testing/deployment_smoke_test.py
@@ -112,18 +112,30 @@ def smoke_test_deployed_routing(
 
     if resp.status_code != 200:
         raise RuntimeError(
-            f"Smoke test failed: {resp.status_code} from {api_url} — {resp.text[:300]}"
+            f"Smoke test failed: {resp.status_code} from {api_url} — {resp.text[:500]}"
         )
 
     data = resp.json()
-    if not data.get("coordinates"):
-        raise RuntimeError(f"Routing returned no coordinates: {data}")
+    segments = data.get("segments")
+    if not segments:
+        raise RuntimeError(f"Routing returned no segments: {data}")
     if data.get("total_length_m", 0) <= 0:
         raise RuntimeError(f"Routing returned zero length: {data}")
 
+    # Sanity: every segment should have at least one coordinate pair and a
+    # stress_cost. Catches malformed responses where the shape is right but
+    # the contents are empty.
+    for i, seg in enumerate(segments):
+        if not seg.get("coordinates"):
+            raise RuntimeError(f"Segment {i} has no coordinates: {seg}")
+        if seg.get("stress_cost") is None:
+            raise RuntimeError(f"Segment {i} missing stress_cost: {seg}")
+
+    total_points = sum(len(seg["coordinates"]) for seg in segments)
     logger.info(
-        "Smoke test OK: %.0fm route, %d points",
+        "Smoke test OK: %.0fm route, %d segments, %d total points",
         data["total_length_m"],
-        len(data["coordinates"]),
+        len(segments),
+        total_points,
     )
     return data

--- a/platform/dbt/models/_osm_sources.yml
+++ b/platform/dbt/models/_osm_sources.yml
@@ -1,0 +1,10 @@
+sources:
+  - name: osm
+    database: loci
+    schema: raw_data
+    tags:
+      - raw
+    tables:
+      - name: chicago_osm_bike_network_edges
+      - name: chicago_osm_bike_network_nodes
+

--- a/platform/dbt/models/marts/cycling/_marts_cycling.yml
+++ b/platform/dbt/models/marts/cycling/_marts_cycling.yml
@@ -64,7 +64,7 @@ models:
             other_model: "ref('chicago_bike_crash_hotspots')"
             this_model_agg: "sum(crash_count)"
             other_model_agg: "count(distinct crash_record_id)"
-            assertion: "this_model_agg / other_model_agg::float between 0.99 and 1.0"
+            assertion: "this_model_agg / other_model_agg::float between 0.98 and 1.0"
 
     columns:
       - name: u

--- a/platform/dbt/models/marts/cycling/chicago/chicago_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/chicago/chicago_bike_stress_weighted_segments.sql
@@ -1,0 +1,252 @@
+-- chicago_bike_stress_weighted_segments.sql
+-- Assigns a stress cost to each bike network segment for use in
+-- stress-weighted routing.
+--
+-- Cost formula:
+--   stress_cost = length_m
+--               * speed_factor
+--               * road_type_factor
+--               * infrastructure_factor
+--               * tunnel_factor
+--               * surface_factor
+--               * lighting_factor
+--               + crash_penalty
+--               + traffic_control_penalty
+--
+-- Grain: one row per segment (way_id, start_position, end_position).
+-- Direction-symmetric: forward and backward traversal of a segment
+-- share the same stress_cost. The graph exporter handles direction.
+
+{{ config(
+    materialized='table',
+    pre_hook=["SET work_mem = '256MB'"],
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (segment_id)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "RESET work_mem"
+    ]
+) }}
+
+{% set crash_weight = 24.0 %}
+{% set crash_decay_lambda = 0.4 %}
+{% set crash_buffer_degrees = 0.0002 %}
+
+with segments as (
+    select * from {{ ref('stg_chicago_bike_segments') }}
+),
+crashes as (
+    select * from {{ ref('chicago_bike_crash_hotspots') }}
+),
+
+-- Crash deduplication: assign each crash to exactly one segment.
+-- Priority: nearest by distance, then most dangerous highway class.
+crash_nearest as (
+    select distinct on (c.crash_record_id)
+        c.crash_record_id,
+        c.severity_score,
+        c.crash_date,
+        s.segment_id
+    from crashes c
+    inner join segments s
+        on s.geom && ST_Expand(c.geom, {{ crash_buffer_degrees }})
+        and ST_DWithin(c.geom, s.geom, {{ crash_buffer_degrees }})
+    order by c.crash_record_id,
+        ST_Distance(c.geom, s.geom),
+        case
+            when s.highway in ('primary', 'primary_link')       then 1
+            when s.highway like '%primary%'                     then 1
+            when s.highway in ('secondary', 'secondary_link')   then 2
+            when s.highway like '%secondary%'                   then 2
+            when s.highway in ('tertiary', 'tertiary_link')     then 3
+            when s.highway like '%tertiary%'                    then 3
+            when s.highway in ('unclassified')                  then 4
+            when s.highway in ('residential')                   then 5
+            when s.highway like '%residential%'                 then 5
+            when s.highway in ('service')                       then 6
+            else 7
+        end
+),
+crash_scores as (
+    select
+        cn.segment_id,
+        count(*) as crash_count,
+        sum(
+            power(cn.severity_score, 2) * exp(
+                -{{ crash_decay_lambda }}
+                * extract(epoch from (current_date - cn.crash_date))
+                / (365.25 * 86400)
+            )
+        ) as crash_score
+    from crash_nearest cn
+    group by cn.segment_id
+),
+
+factors as (
+    select
+        s.*,
+
+        coalesce(cs.crash_count, 0) as crash_count,
+        coalesce(cs.crash_score, 0) as crash_score,
+        case
+            when s.length_m > 0
+            then coalesce(cs.crash_score, 0) / s.length_m
+            else 0
+        end as crash_score_per_meter,
+
+        -- Speed factor
+        case
+            when s.maxspeed is null                                         then 1.4
+            when regexp_replace(s.maxspeed, '[^0-9].*', '') ~ '^\d+$'
+                and regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 20  then 1.0
+            when regexp_replace(s.maxspeed, '[^0-9].*', '') ~ '^\d+$'
+                and regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 25  then 1.3
+            when regexp_replace(s.maxspeed, '[^0-9].*', '') ~ '^\d+$'
+                and regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 30  then 1.6
+            when regexp_replace(s.maxspeed, '[^0-9].*', '') ~ '^\d+$'
+                and regexp_replace(s.maxspeed, '[^0-9].*', '')::int  > 30  then 2.0
+            else 1.4
+        end as speed_factor,
+
+        -- Road type factor
+        case
+            when s.highway in ('cycleway')                      then 0.3
+            when s.highway like '%cycleway%'                    then 0.3
+            when s.highway in ('path', 'footway', 'bridleway')  then 0.4
+            when s.highway like '%path%'                        then 0.4
+            when s.highway in ('pedestrian')                    then 0.5
+            when s.highway in ('living_street')                 then 0.9
+            when s.highway in ('service')                       then 1.0
+            when s.highway in ('residential')                   then 1.1
+            when s.highway like '%residential%'                 then 1.1
+            when s.highway in ('unclassified')                  then 1.4
+            when s.highway in ('busway')                        then 1.4
+            when s.highway in ('tertiary', 'tertiary_link')     then 1.7
+            when s.highway like '%tertiary%'                    then 1.7
+            when s.highway in ('secondary', 'secondary_link')   then 2.2
+            when s.highway like '%secondary%'                   then 2.2
+            when s.highway in ('primary', 'primary_link')       then 2.7
+            when s.highway like '%primary%'                     then 2.7
+            else 1.3
+        end as road_type_factor,
+
+        -- Infrastructure factor (no Socrata fallback in segment-grain pipeline)
+        case
+            when s.infra_type = 'protected_lane'    then 0.4
+            when s.infra_type = 'track'             then 0.5
+            when s.infra_type = 'shared_path'       then 0.6
+            when s.infra_type = 'buffered_lane'     then 0.7
+            when s.infra_type = 'designated_path'   then 0.7
+            when s.infra_type = 'bicycle_road'      then 0.8
+            when s.infra_type = 'bike_lane'         then 0.85
+            when s.infra_type = 'share_busway'      then 0.9
+            when s.infra_type = 'sharrow'           then 0.95
+            else 1.0
+        end as infrastructure_factor,
+
+        -- Tunnel factor
+        case
+            when s.tunnel = 'yes'
+                and coalesce(s.infra_type, '') not in (
+                    'protected_lane', 'track', 'shared_path', 'buffered_lane'
+                )
+            then 2.5
+            else 1.0
+        end as tunnel_factor,
+
+        -- Surface factor
+        case
+            when s.surface in ('asphalt', 'paved', 'concrete',
+                               'concrete:plates', 'concrete:lanes') then 1.0
+            when s.surface in ('paving_stones', 'sett',
+                               'cobblestone', 'unhewn_cobblestone') then 1.3
+            when s.surface in ('unpaved', 'gravel', 'fine_gravel',
+                               'compacted', 'dirt', 'grass',
+                               'ground', 'mud', 'sand')             then 1.5
+            when s.surface is null                                  then 1.0
+            else 1.0
+        end as surface_factor,
+
+        -- Lighting factor
+        case
+            when s.lit = 'yes' then 1.0
+            when s.lit = 'no'  then 1.2
+            else                    1.1
+        end as lighting_factor,
+
+        coalesce(ntc.traffic_control_penalty, 0) as traffic_control_penalty
+
+    from segments s
+    left join crash_scores cs on cs.segment_id = s.segment_id
+    left join {{ ref('stg__chicago_traffic_control_nodes') }} ntc
+        on ntc.osmid = s.end_node_id
+)
+
+select
+    -- Identity
+    segment_id,
+    way_id,
+    start_position,
+    end_position,
+
+    -- Topology
+    start_node_id,
+    end_node_id,
+    direction,
+
+    -- Geometry and length
+    geom,
+    length_m,
+
+    -- Identification
+    name,
+    highway,
+
+    -- Bike infrastructure
+    infra_category,
+    infra_type,
+    has_buffer,
+
+    -- Physical conditions
+    surface,
+    lit,
+    bridge,
+    tunnel,
+    maxspeed,
+
+    -- Raw cycleway tags
+    cycleway,
+    cycleway_left,
+    cycleway_right,
+
+    -- Crash features
+    crash_count,
+    crash_score,
+    crash_score_per_meter,
+
+    -- Intermediate stress factors (preserved for tuning)
+    speed_factor,
+    road_type_factor,
+    infrastructure_factor,
+    tunnel_factor,
+    surface_factor,
+    lighting_factor,
+    traffic_control_penalty,
+
+    crash_score_per_meter * length_m * {{ crash_weight }} as crash_penalty,
+
+    greatest(
+        length_m
+            * speed_factor
+            * road_type_factor
+            * infrastructure_factor
+            * tunnel_factor
+            * surface_factor
+            * lighting_factor
+            + (crash_score_per_meter * length_m * {{ crash_weight }})
+            + traffic_control_penalty,
+        0
+    ) as stress_cost
+
+from factors

--- a/platform/dbt/models/staging/cycling/chicago/_stg_chicago_cycling.yml
+++ b/platform/dbt/models/staging/cycling/chicago/_stg_chicago_cycling.yml
@@ -1,0 +1,72 @@
+# models/staging/_staging.yml
+version: 2
+
+models:
+  - name: stg_chicago_bike_ways
+    columns:
+      - name: osm_id
+        data_tests:
+          - not_null
+          - unique  # one current row per way after the valid_to filter
+      - name: geom
+        data_tests:
+          - not_null
+      - name: node_ids
+        data_tests:
+          - not_null
+      - name: node_count
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 2  # a way with <2 nodes isn't a real way
+      - name: highway
+        data_tests:
+          - dbt_utils.not_empty_string
+
+  - name: stg_chicago_way_nodes
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [way_id, position]
+    columns:
+      - name: way_id
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_chicago_bike_ways')
+                field: osm_id
+      - name: position
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1  # ordinality is 1-indexed
+      - name: node_id
+        tests:
+          - not_null
+
+  - name: stg_chicago_intersection_nodes
+    tests:
+      - intersection_node_count_in_range:
+          arguments:
+            way_nodes_model: ref('stg_chicago_way_nodes')
+    columns:
+      - name: node_id
+        tests:
+          - not_null
+          - unique
+
+
+  - name: stg_chicago_way_segments
+    tests:
+      - segment_endpoints_match_node_ids:
+          arguments:
+            ways_model: ref('stg_chicago_bike_ways')
+      - segments_cover_full_ways:
+          arguments:
+            way_nodes_model: ref('stg_chicago_way_nodes')
+            intersection_nodes_model: ref('stg_chicago_intersection_nodes')
+      - segment_geom_endpoints_match_node_positions:
+          arguments:
+            ways_model: ref('stg_chicago_bike_ways')

--- a/platform/dbt/models/staging/cycling/chicago/stg_chicago_bike_segments.sql
+++ b/platform/dbt/models/staging/cycling/chicago/stg_chicago_bike_segments.sql
@@ -1,0 +1,70 @@
+-- models/staging/cycling/chicago/stg_chicago_bike_segments.sql
+-- Bike network segments, one row per intersection-to-intersection
+-- portion of a way, with bike infrastructure classification and
+-- physical conditions joined in.
+--
+-- Source: stg_chicago_way_segments + stg_chicago_osm_bike_infra
+-- Grain: one row per segment (way_id, start_position, end_position).
+--
+-- Direction handling: each segment carries a `direction` column
+-- ('forward', 'backward', 'bidirectional') indicating which directions
+-- of travel are legal. The graph exporter expands these into one or
+-- two directed edges per segment.
+
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (way_id, start_position, end_position)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+select
+    -- Identity
+    {{ dbt_utils.generate_surrogate_key(['s.way_id', 's.start_position', 's.end_position']) }}
+        as segment_id,
+    s.way_id,
+    s.start_position,
+    s.end_position,
+
+    -- Topology
+    s.start_node_id,
+    s.end_node_id,
+    s.direction,
+
+    -- Geometry
+    s.geom,
+    ST_Length(s.geom::geography) as length_m,
+
+    -- Identification
+    s.name,
+    s.highway,
+
+    -- Bike infrastructure (NULL when no bike infra on this segment)
+    i.infra_category,
+    i.infra_type,
+    i.has_buffer,
+
+    -- Stress factor inputs
+    s.surface,
+    s.lit,
+    s.bridge,
+    s.tunnel,
+    s.maxspeed,
+    s.bicycle,
+
+    -- Raw cycleway tags preserved for downstream refinement
+    s.cycleway,
+    s.cycleway_left,
+    s.cycleway_right,
+
+    s.tags
+
+from {{ ref('stg_chicago_way_segments') }} s
+left join {{ ref('stg_chicago_osm_bike_infra') }} i
+    on i.way_id = s.way_id
+   and i.start_position = s.start_position
+   and i.end_position = s.end_position

--- a/platform/dbt/models/staging/cycling/chicago/stg_chicago_bike_ways.sql
+++ b/platform/dbt/models/staging/cycling/chicago/stg_chicago_bike_ways.sql
@@ -1,0 +1,66 @@
+-- models/staging/cycling/chicago/stg_chicago_bike_ways.sql
+{{ config(materialized='view') }}
+
+select
+    osm_id,
+    osm_version,
+    osm_timestamp,
+    geom,
+    node_ids,
+    array_length(node_ids, 1) as node_count,
+
+    -- Promoted columns (from the spec)
+    highway,
+    name,
+    bicycle,
+    cycleway,
+    cycleway_left,
+    cycleway_right,
+    surface,
+    maxspeed,
+
+    -- Physical conditions for stress weighting
+    tags->>'lit' as lit,
+    tags->>'bridge' as bridge,
+    tags->>'tunnel' as tunnel,
+
+    -- Cycleway sub-tags for infra classification
+    tags->>'cycleway:buffer'             as cycleway_buffer,
+    tags->>'cycleway:left:buffer'        as cycleway_left_buffer,
+    tags->>'cycleway:right:buffer'       as cycleway_right_buffer,
+    tags->>'cycleway:both:buffer'        as cycleway_both_buffer,
+    tags->>'cycleway:separation'         as cycleway_separation,
+    tags->>'cycleway:left:separation'    as cycleway_left_separation,
+    tags->>'cycleway:right:separation'   as cycleway_right_separation,
+    tags->>'cycleway:both:separation'    as cycleway_both_separation,
+    tags->>'cycleway:shared_lane'        as cycleway_shared_lane,
+    tags->>'cycleway:left:shared_lane'   as cycleway_left_shared_lane,
+    tags->>'cycleway:right:shared_lane'  as cycleway_right_shared_lane,
+    tags->>'cycleway:both:shared_lane'   as cycleway_both_shared_lane,
+    tags->>'cycleway:both'               as cycleway_both,
+    tags->>'class:bicycle'               as class_bicycle,
+    tags->>'bicycle_road'                as bicycle_road,
+    tags->>'cyclestreet'                 as cyclestreet,
+
+    -- Canonical bike-routing direction
+    case
+        when coalesce(tags->>'oneway:bicycle', oneway) in ('yes', 'true', '1') then 'forward'
+        when coalesce(tags->>'oneway:bicycle', oneway) = '-1' then 'backward'
+        when coalesce(tags->>'oneway:bicycle', oneway) in ('no', 'false', '0') then 'bidirectional'
+        when coalesce(tags->>'oneway:bicycle', oneway) is null then 'bidirectional'
+        else 'bidirectional'
+    end as direction,
+    oneway,
+
+    tags,
+    ingested_at
+
+from {{ source('osm', 'chicago_osm_bike_network_edges') }}
+where
+    valid_to is null
+    and osm_type = 'way'
+    and geometrytype(geom) = 'LINESTRING'
+    and (
+        highway != 'footway'
+        or bicycle in ('yes', 'designated', 'permissive')
+    )

--- a/platform/dbt/models/staging/cycling/chicago/stg_chicago_intersection_nodes.sql
+++ b/platform/dbt/models/staging/cycling/chicago/stg_chicago_intersection_nodes.sql
@@ -1,0 +1,20 @@
+{{ config(materialized='table') }}
+
+with node_way_counts as (
+    select
+        node_id,
+        count(distinct way_id) as way_count
+    from {{ ref('stg_chicago_way_nodes') }}
+    group by node_id
+),
+endpoints as (
+    select node_id
+    from {{ ref('stg_chicago_way_nodes') }}
+    where position = 1 or position = way_length
+)
+select distinct node_id
+from (
+    select node_id from node_way_counts where way_count >= 2
+    union
+    select node_id from endpoints
+) t

--- a/platform/dbt/models/staging/cycling/chicago/stg_chicago_osm_bike_infra.sql
+++ b/platform/dbt/models/staging/cycling/chicago/stg_chicago_osm_bike_infra.sql
@@ -1,0 +1,129 @@
+-- models/staging/cycling/chicago/stg_chicago_osm_bike_infra.sql
+-- Classifies bike network segments into infrastructure categories
+-- using the full set of cycleway/bicycle tags.
+--
+-- Source: stg_chicago_way_segments
+-- Grain: one row per segment with bike infrastructure present.
+--
+-- Infrastructure taxonomy:
+--   infra_category: 'separated', 'on_road', 'shared', 'path'
+--   infra_type:     'protected_lane', 'track', 'buffered_lane',
+--                   'bike_lane', 'sharrow', 'bicycle_road',
+--                   'share_busway', 'shared_path', 'designated_path'
+--
+-- The classification logic resolves left/right/both cycleway tags into
+-- a single per-segment classification. When left and right differ, we
+-- use the higher-quality side (separated > on_road > shared).
+
+{{ config(materialized='table') }}
+
+with segments as (
+    select * from {{ ref('stg_chicago_way_segments') }}
+),
+
+resolved as (
+    select
+        *,
+        coalesce(cycleway_left, cycleway_both, cycleway) as eff_cycleway_left,
+        coalesce(cycleway_right, cycleway_both, cycleway) as eff_cycleway_right,
+        coalesce(
+            cycleway_left_buffer,
+            cycleway_right_buffer,
+            cycleway_both_buffer,
+            cycleway_buffer
+        ) is not null as has_any_buffer,
+        coalesce(
+            cycleway_left_separation,
+            cycleway_right_separation,
+            cycleway_both_separation,
+            cycleway_separation
+        ) as eff_separation,
+        coalesce(
+            cycleway_left_shared_lane,
+            cycleway_right_shared_lane,
+            cycleway_both_shared_lane,
+            cycleway_shared_lane
+        ) as eff_shared_lane
+    from segments
+),
+
+classified as (
+    select
+        way_id,
+        start_position,
+        end_position,
+        start_node_id,
+        end_node_id,
+
+        case
+            when highway in ('cycleway', 'path', 'pedestrian')
+                then 'separated'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('track', 'separate')
+                then 'separated'
+            when eff_separation is not null
+                and eff_separation not in ('no', 'none')
+                then 'separated'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('lane', 'exclusive')
+                then 'on_road'
+            when has_any_buffer
+                then 'on_road'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in (
+                'shared_lane', 'shared', 'share_busway'
+            )
+                then 'shared'
+            when eff_shared_lane is not null
+                then 'shared'
+            when bicycle_road = 'yes' or cyclestreet = 'yes'
+                then 'shared'
+            when highway in ('footway', 'bridleway', 'steps')
+                and bicycle in ('yes', 'designated', 'permissive')
+                then 'path'
+            when bicycle in ('designated', 'yes')
+                then 'shared'
+            else null
+        end as infra_category,
+
+        case
+            when eff_separation is not null
+                and eff_separation not in ('no', 'none')
+                and coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('track', 'lane', 'separate')
+                then 'protected_lane'
+            when highway = 'cycleway'
+                then 'track'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('track', 'separate')
+                then 'track'
+            when has_any_buffer
+                then 'buffered_lane'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('lane', 'exclusive')
+                then 'bike_lane'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('shared_lane', 'shared')
+                then 'sharrow'
+            when eff_shared_lane is not null
+                then 'sharrow'
+            when bicycle_road = 'yes' or cyclestreet = 'yes'
+                then 'bicycle_road'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') = 'share_busway'
+                then 'share_busway'
+            when highway in ('path', 'footway', 'bridleway', 'pedestrian', 'steps')
+                then 'shared_path'
+            when bicycle = 'designated'
+                then 'designated_path'
+            else null
+        end as infra_type,
+
+        has_any_buffer as has_buffer
+
+    from resolved
+)
+
+select
+    way_id,
+    start_position,
+    end_position,
+    start_node_id,
+    end_node_id,
+    infra_category,
+    infra_type,
+    has_buffer
+from classified
+where infra_category is not null

--- a/platform/dbt/models/staging/cycling/chicago/stg_chicago_way_nodes.sql
+++ b/platform/dbt/models/staging/cycling/chicago/stg_chicago_way_nodes.sql
@@ -1,0 +1,9 @@
+{{ config(materialized='view') }}
+
+select
+    osm_id as way_id,
+    ordinality as position,
+    node_id,
+    array_length(node_ids, 1) as way_length
+from {{ ref('stg_chicago_bike_ways') }},
+     unnest(node_ids) with ordinality as t(node_id, ordinality)

--- a/platform/dbt/models/staging/cycling/chicago/stg_chicago_way_segments.sql
+++ b/platform/dbt/models/staging/cycling/chicago/stg_chicago_way_segments.sql
@@ -1,0 +1,88 @@
+-- models/intermediate/cycling/chicago/stg_chicago_way_segments.sql
+{{ config(materialized='table') }}
+
+with way_cuts as (
+    select
+        wn.way_id,
+        wn.position,
+        wn.node_id
+    from {{ ref('stg_chicago_way_nodes') }} wn
+    inner join {{ ref('stg_chicago_intersection_nodes') }} i
+        on wn.node_id = i.node_id
+),
+segments as (
+    select
+        way_id,
+        node_id as start_node_id,
+        position as start_position,
+        lead(node_id) over (partition by way_id order by position) as end_node_id,
+        lead(position) over (partition by way_id order by position) as end_position
+    from way_cuts
+),
+way_points as (
+    -- Dump every vertex of every way with its position. Use this to
+    -- reconstruct segment geometries vertex-by-vertex rather than via
+    -- length-fraction interpolation.
+    select
+        osm_id as way_id,
+        (dp).path[1] as position,
+        (dp).geom as point_geom
+    from (
+        select osm_id, ST_DumpPoints(geom) as dp
+        from {{ ref('stg_chicago_bike_ways') }}
+    ) t
+),
+segment_geoms as (
+    select
+        s.way_id,
+        s.start_node_id,
+        s.end_node_id,
+        s.start_position,
+        s.end_position,
+        ST_MakeLine(wp.point_geom order by wp.position) as geom
+    from segments s
+    inner join way_points wp
+        on wp.way_id = s.way_id
+       and wp.position between s.start_position and s.end_position
+    where s.end_node_id is not null
+    group by s.way_id, s.start_node_id, s.end_node_id, s.start_position, s.end_position
+)
+select
+    sg.way_id,
+    sg.start_node_id,
+    sg.end_node_id,
+    sg.start_position,
+    sg.end_position,
+    sg.geom,
+    w.highway,
+    w.name,
+    w.bicycle,
+    w.cycleway,
+    w.cycleway_left,
+    w.cycleway_right,
+    w.surface,
+    w.lit,
+    w.bridge,
+    w.tunnel,
+    w.cycleway_buffer,
+    w.cycleway_left_buffer,
+    w.cycleway_right_buffer,
+    w.cycleway_both_buffer,
+    w.cycleway_separation,
+    w.cycleway_left_separation,
+    w.cycleway_right_separation,
+    w.cycleway_both_separation,
+    w.cycleway_shared_lane,
+    w.cycleway_left_shared_lane,
+    w.cycleway_right_shared_lane,
+    w.cycleway_both_shared_lane,
+    w.cycleway_both,
+    w.class_bicycle,
+    w.bicycle_road,
+    w.cyclestreet,
+    w.maxspeed,
+    w.direction,
+    w.oneway,
+    w.tags
+from segment_geoms sg
+inner join {{ ref('stg_chicago_bike_ways') }} w on sg.way_id = w.osm_id

--- a/platform/dbt/tests/generic/network/test_intersection_node_count_in_range.sql
+++ b/platform/dbt/tests/generic/network/test_intersection_node_count_in_range.sql
@@ -1,0 +1,16 @@
+-- tests/generic/test_intersection_node_count_in_range.sql
+{% test intersection_node_count_in_range(model, way_nodes_model, min_ratio=0.05, max_ratio=0.9) %}
+-- Intersection nodes should be a meaningful fraction of all nodes,
+-- but not most of them. Catches a future bug where the
+-- intersection-detection logic produces 0 or ~all nodes.
+with stats as (
+    select
+        (select count(*) from {{ model }}) as intersections,
+        (select count(distinct node_id) from {{ way_nodes_model }}) as total_nodes
+)
+select *
+from stats
+where
+    intersections::float / total_nodes < {{ min_ratio }}
+    or intersections::float / total_nodes > {{ max_ratio }}
+{% endtest %}

--- a/platform/dbt/tests/generic/network/test_segment_endpoints_match_node_ids.sql
+++ b/platform/dbt/tests/generic/network/test_segment_endpoints_match_node_ids.sql
@@ -1,0 +1,19 @@
+-- tests/generic/test_segment_endpoints_match_node_ids.sql
+{% test segment_endpoints_match_node_ids(model, ways_model) %}
+-- Each segment's start/end node IDs should match the node IDs at
+-- start_position and end_position in the parent way's node_ids array.
+select
+    s.way_id,
+    s.start_position,
+    s.end_position,
+    s.start_node_id as segment_start,
+    s.end_node_id as segment_end,
+    w.node_ids[s.start_position] as way_start,
+    w.node_ids[s.end_position] as way_end
+from {{ model }} as s
+inner join {{ ways_model }} as w
+    on s.way_id = w.osm_id
+where
+    s.start_node_id != w.node_ids[s.start_position]
+    or s.end_node_id != w.node_ids[s.end_position]
+{% endtest %}

--- a/platform/dbt/tests/generic/network/test_segment_geom_endpoints_match_node_positions.sql
+++ b/platform/dbt/tests/generic/network/test_segment_geom_endpoints_match_node_positions.sql
@@ -1,0 +1,26 @@
+-- tests/generic/test_segment_geom_endpoints_match_node_positions.sql
+{% test segment_geom_endpoints_match_node_positions(model, ways_model, max_drift_meters=5) %}
+-- Sanity check on the ST_LineSubstring approximation: the start/end
+-- points of each segment's geometry should be close to the way's
+-- vertex at the corresponding position.
+--
+-- "Close" because ST_LineSubstring interpolates by length, not
+-- vertex index, so non-uniform shape-point spacing causes some drift.
+-- If this fails on a meaningful number of segments, switch to
+-- vertex-indexed reconstruction.
+select
+    s.way_id,
+    s.start_position,
+    ST_Distance(
+        ST_StartPoint(s.geom)::geography,
+        ST_PointN(w.geom, s.start_position::integer)::geography
+    ) as start_drift_m,
+    ST_Distance(
+        ST_EndPoint(s.geom)::geography,
+        ST_PointN(w.geom, s.end_position::integer)::geography
+    ) as end_drift_m
+from {{ model }} s
+inner join {{ ways_model }} w on s.way_id = w.osm_id
+where ST_Distance(ST_StartPoint(s.geom)::geography, ST_PointN(w.geom, s.start_position::integer)::geography) > {{ max_drift_meters }}
+   or ST_Distance(ST_EndPoint(s.geom)::geography, ST_PointN(w.geom, s.end_position::integer)::geography) > {{ max_drift_meters }}
+{% endtest %}

--- a/platform/dbt/tests/generic/network/test_segments_cover_full_ways.sql
+++ b/platform/dbt/tests/generic/network/test_segments_cover_full_ways.sql
@@ -1,0 +1,33 @@
+-- tests/generic/test_segments_cover_full_ways.sql
+{% test segments_cover_full_ways(model, way_nodes_model, intersection_nodes_model) %}
+-- For each way, the number of segments should equal (number of
+-- intersection nodes in that way) - 1. If a way's segments don't
+-- collectively cover its full intersection-to-intersection structure,
+-- this catches it.
+with way_intersection_positions as (
+    select
+        wn.way_id,
+        wn.position
+    from {{ way_nodes_model }} wn
+    inner join {{ intersection_nodes_model }} i on wn.node_id = i.node_id
+),
+expected_segment_count as (
+    select way_id, count(*) - 1 as expected
+    from way_intersection_positions
+    group by way_id
+    having count(*) >= 2
+),
+actual_segment_count as (
+    select way_id, count(*) as actual
+    from {{ model }}
+    group by way_id
+)
+select
+    e.way_id,
+    e.expected,
+    coalesce(a.actual, 0) as actual
+from expected_segment_count as e
+left join actual_segment_count as a
+    on e.way_id = a.way_id
+where coalesce(a.actual, 0) != e.expected
+{% endtest %}

--- a/platform/migrations/postgres/V44__add_new_osm_chicago_bike_network_tables.sql
+++ b/platform/migrations/postgres/V44__add_new_osm_chicago_bike_network_tables.sql
@@ -1,0 +1,63 @@
+create table if not exists raw_data.chicago_osm_bike_network_edges (
+    "osm_type" text not null,
+    "osm_id" bigint not null,
+    "osm_version" integer,
+    "osm_timestamp" timestamptz,
+    "geom" geometry(Geometry, 4326),
+    "tags" jsonb,
+    "node_ids" bigint[],
+    "highway" text,
+    "name" text,
+    "bicycle" text,
+    "cycleway" text,
+    "cycleway_left" text,
+    "cycleway_right" text,
+    "surface" text,
+    "maxspeed" text,
+    "oneway" text,
+    "ingested_at" timestamptz not null,
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.chicago_osm_bike_network_edges
+    add constraint uq_chicago_osm_bike_network_edges_entity_hash
+    unique ("osm_type", "osm_id", "record_hash");
+create index if not exists ix_chicago_osm_bike_network_edges_current
+    on raw_data.chicago_osm_bike_network_edges ("osm_type", "osm_id")
+    where valid_to is null;
+create index if not exists ix_chicago_osm_bike_network_edges_geom
+    on raw_data.chicago_osm_bike_network_edges using gist (geom)
+    where valid_to is null;
+
+
+create table if not exists raw_data.chicago_osm_bike_network_nodes (
+    "osm_type" text not null,
+    "osm_id" bigint not null,
+    "osm_version" integer,
+    "osm_timestamp" timestamptz,
+    "geom" geometry(Geometry, 4326),
+    "tags" jsonb,
+    "node_ids" bigint[],
+    "highway" text,
+    "crossing" text,
+    "traffic_calming" text,
+    "barrier" text,
+    "bicycle" text,
+    "name" text,
+    "button_operated" text,
+    "tactile_paving" text,
+    "ingested_at" timestamptz not null,
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.chicago_osm_bike_network_nodes
+    add constraint uq_chicago_osm_bike_network_nodes_entity_hash
+    unique ("osm_type", "osm_id", "record_hash");
+create index if not exists ix_chicago_osm_bike_network_nodes_current
+    on raw_data.chicago_osm_bike_network_nodes ("osm_type", "osm_id")
+    where valid_to is null;
+create index if not exists ix_chicago_osm_bike_network_nodes_geom
+    on raw_data.chicago_osm_bike_network_nodes using gist (geom)
+    where valid_to is null;


### PR DESCRIPTION
Changes:
* Reimplements the bike network datasets using my new OSM collector tooling (closes #162)
    * Also reimplements the stress-weight pipeline using the newly collected ways as well as reimplementing the graph_exporter and router to work with the new form of the edges. This significantly simplifies the network building process and rather eliminates the need for the `osmnx` package (although I haven't removed it yet, nor have I stripped out all of the other stress_weighting pipeline based on the osmnx edge network yet, although that cleanup will be forthcoming).
* Refactors the graph_export and routing Lambda func to show the costs of each segment as well as color coding the segments. (closes #162)

<img width="3342" height="2166" alt="3391A807-6AFF-43F5-B6DD-5DC199521ACC" src="https://github.com/user-attachments/assets/8ce3a88b-5ffa-457c-8c74-5370a9c247fd" />

Also I'm going to start using the dev, staging, and main branches for different envs. I've deployed to the dev env, so you can see the updated site at [chicago.dev.bikeinfra.com/](https://chicago.dev.bikeinfra.com/)