### PR TITLE
Sets entity key on dataset to fix ingestion issue.

### DIFF
--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -1320,7 +1320,7 @@ COOK_COUNTY_NEIGHBORHOOD_BOUNDARIES_SPEC = SocrataDatasetSpec(
     dataset_id="pcdw-pxtg",
     target_table="cook_county_neighborhood_boundaries",
     target_schema="raw_data",
-    entity_key=None,
+    entity_key=["town_nbhd"],
     full_update_mode="api",
 )
 


### PR DESCRIPTION
Changes:
* Sets entity key to bring the Cook County neighborhood boundary dataset into alignment with the applied migrations. (Closes #164)