### PR TITLE
Increased costs to make the A* heuristic valid (so that it never unde…

### DIFF
--- a/infra/modules/bike-map/lambda/handler.py
+++ b/infra/modules/bike-map/lambda/handler.py
@@ -32,9 +32,10 @@ import json
 import logging
 import os
 import pickle
+import time
 
 import boto3
-from routing import build_kdtree, find_route
+from routing import build_kdtree, find_route, get_intersection_nodes
 
 log = logging.getLogger()
 log.setLevel(logging.INFO)
@@ -72,6 +73,12 @@ def _load_graph():
 
     kdtree, node_ids = build_kdtree(G)
     log.info("KD-tree built over %d nodes", len(node_ids))
+
+    # Pre-compute intersections so the first routing request doesn't pay
+    # the cost. get_intersection_nodes caches on G.graph, so subsequent
+    # find_route calls just hit the cache.
+    intersections = get_intersection_nodes(G)
+    log.info("Intersection set computed: %d intersections", len(intersections))
 
     return G, kdtree, node_ids
 
@@ -149,7 +156,7 @@ def lambda_handler(event: dict, context) -> dict:
             "body": json.dumps({"error": f"Invalid request: {e}"}),
         }
 
-    # Route
+    t0 = time.perf_counter()
     try:
         result = find_route(
             _graph,
@@ -172,6 +179,13 @@ def lambda_handler(event: dict, context) -> dict:
             "body": json.dumps({"error": "Routing failed"}),
         }
 
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    log.info(
+        "Routed %.0fm in %.0fms (%d segments)",
+        result["total_length_m"],
+        elapsed_ms,
+        len(result["segments"]),
+    )
     return {
         "statusCode": 200,
         "headers": {"Content-Type": "application/json"},

--- a/main.py
+++ b/main.py
@@ -1,0 +1,113 @@
+"""Profile find_route on a real graph file.
+
+Usage:
+    # Download the graph file from S3 first:
+    aws s3 cp s3://loci-infra-dev-chicago-bike-map-routing-graph/graph/routing_graph.pkl.gz /tmp/
+
+    # Then run:
+    python profile_routing.py /tmp/routing_graph.pkl.gz
+
+The script routes between a few origin/destination pairs of varying
+distance and prints a cProfile summary for each. Compare two builds of
+the graph file by running this script twice (renaming each .prof file
+between runs) to see what got faster or slower.
+"""
+
+import cProfile
+import gzip
+import pickle
+import pstats
+import sys
+import time
+from pathlib import Path
+
+# Make the routing module importable. Adjust if your layout differs.
+sys.path.insert(0, str(Path(__file__).parent / "platform/airflow/dags/loci"))
+from routing import build_kdtree, find_route  # noqa: E402
+
+# A handful of routes spanning short / medium / long distances.
+# Pick coordinates that are realistic for your city. Lat/lon pairs.
+TEST_ROUTES = [
+    # (label, origin_lat, origin_lon, dest_lat, dest_lon)
+    ("short_2mi", 41.8781, -87.6298, 41.9050, -87.6350),  # Loop -> near North side
+    ("medium_8mi", 41.8500, -87.6500, 41.9700, -87.7000),  # SW -> NW
+    ("long_20mi", 41.6800, -87.6500, 41.9900, -87.6700),  # Far south -> Far north
+    ("pre_change_long_route", 41.9471, -87.6562, 41.7978, -87.6648),
+    ("post_change_long_route", 41.9637, -87.6559, 41.7655, -87.6926),
+]
+
+
+def load_graph(path: str):
+    print(f"Loading graph from {path}...")
+    t0 = time.perf_counter()
+    with open(path, "rb") as f:
+        compressed = f.read()
+    G = pickle.loads(gzip.decompress(compressed))
+    elapsed = time.perf_counter() - t0
+    print(f"  loaded {G.number_of_nodes()} nodes, {G.number_of_edges()} edges in {elapsed:.2f}s")
+    print(f"  heuristic_floor = {G.graph.get('heuristic_floor', 'NOT SET')}")
+    return G
+
+
+def time_route(G, kdtree, node_ids, label, o_lat, o_lon, d_lat, d_lon, runs=3):
+    """Run a route a few times and report the median wall time."""
+    # Warm up first (ensures any lazy attribute caching has happened).
+    find_route(G, kdtree, node_ids, o_lat, o_lon, d_lat, d_lon)
+
+    times = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        result = find_route(G, kdtree, node_ids, o_lat, o_lon, d_lat, d_lon)
+        times.append(time.perf_counter() - t0)
+    times.sort()
+    median = times[len(times) // 2]
+    print(
+        f"  {label}: median {median * 1000:.0f}ms across {runs} runs "
+        f"({result['total_length_m']:.0f}m route, {len(result['segments'])} segments)"
+    )
+    return median
+
+
+def profile_route(G, kdtree, node_ids, label, o_lat, o_lon, d_lat, d_lon):
+    """Run a single route under cProfile and dump a .prof file."""
+    # Warm up
+    find_route(G, kdtree, node_ids, o_lat, o_lon, d_lat, d_lon)
+
+    profile_path = f"profile_{label}.prof"
+    profiler = cProfile.Profile()
+    profiler.enable()
+    find_route(G, kdtree, node_ids, o_lat, o_lon, d_lat, d_lon)
+    profiler.disable()
+
+    profiler.dump_stats(profile_path)
+    print(f"\nProfile for {label} (saved to {profile_path}):")
+    stats = pstats.Stats(profiler).sort_stats("cumulative")
+    stats.print_stats(20)  # Top 20 functions by cumulative time
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: python profile_routing.py <path-to-graph.pkl.gz>")
+        sys.exit(1)
+
+    G = load_graph(sys.argv[1])
+    print("\nBuilding KD-tree...")
+    t0 = time.perf_counter()
+    kdtree, node_ids = build_kdtree(G)
+    print(f"  built in {time.perf_counter() - t0:.2f}s\n")
+
+    print("=" * 60)
+    print("Wall-time medians (3 runs each):")
+    print("=" * 60)
+    for route in TEST_ROUTES:
+        time_route(G, kdtree, node_ids, *route)
+
+    print()
+    print("=" * 60)
+    print("cProfile of long_20mi route:")
+    print("=" * 60)
+    profile_route(G, kdtree, node_ids, *TEST_ROUTES[-1])
+
+
+if __name__ == "__main__":
+    main()

--- a/platform/airflow/dags/dag_files/refresh_bike_map_chicago.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_chicago.py
@@ -27,7 +27,7 @@ CHICAGO_SPEC = CityBuildSpec(
         # which references chicago_bike_crash_hotspots but isn't built yet.
         ("--select", "+chicago_bike_crash_hotspots", "--indirect-selection=cautious"),
     ],
-    weights_dbt_select="+chicago_bike_stress_weighted_edges",
+    weights_dbt_select="+chicago_bike_stress_weighted_segments",
 )
 
 

--- a/platform/airflow/dags/loci/exports/graph_export.py
+++ b/platform/airflow/dags/loci/exports/graph_export.py
@@ -83,6 +83,12 @@ class RoutingGraphExporter:
         )
     """
 
+    _HEURISTIC_FLOOR_QUERY = """
+        select min(stress_cost / length_m) as floor
+        from {marts_schema}.{city}_bike_stress_weighted_segments
+        where length_m > 0 and stress_cost is not null
+    """
+
     def __init__(
         self,
         engine: PostgresEngine,
@@ -224,6 +230,30 @@ class RoutingGraphExporter:
             )
         else:
             G.graph["crs"] = crs_row["srtext"].iloc[0]
+
+        floor_row = self.engine.query(
+            self._HEURISTIC_FLOOR_QUERY.format(
+                city=self.city,
+                marts_schema=self.marts_schema,
+            )
+        )
+        if floor_row.empty or floor_row["floor"].iloc[0] is None:
+            logger.warning(
+                "Could not compute heuristic floor; routing will use a "
+                "conservative default and may be slower than necessary"
+            )
+            G.graph["heuristic_floor"] = 0.0
+        else:
+            # Multiply by 0.95 for a small safety margin so the heuristic
+            # stays admissible even if the cost formula changes slightly
+            # (e.g. dbt rebuild between graph export and lambda load).
+            raw_floor = float(floor_row["floor"].iloc[0])
+            G.graph["heuristic_floor"] = raw_floor * 0.95
+            logger.info(
+                "Heuristic floor: %.4f cost-per-meter (raw min: %.4f)",
+                G.graph["heuristic_floor"],
+                raw_floor,
+            )
 
         logger.info(
             "Graph complete: %d nodes, %d edges, %d unique segment geometries",

--- a/platform/airflow/dags/loci/routing.py
+++ b/platform/airflow/dags/loci/routing.py
@@ -60,7 +60,7 @@ _DEFAULT_ROAD_MULTIPLIER = 1.0
 
 
 # =====================================================================
-# KD-tree helpers (unchanged)
+# KD-tree helpers
 # =====================================================================
 def build_kdtree(G: nx.DiGraph) -> tuple[KDTree, list]:
     """Build a KD-tree over node coordinates for fast nearest-node lookup.
@@ -125,6 +125,7 @@ def compute_left_turn_penalty(
     curr: int,
     next_node: int,
     next_edge_data: dict,
+    intersection_nodes: set[int],
 ) -> float:
     """Return the left-turn penalty (in virtual stress-cost meters) for
     the transition prev → curr → next_node.
@@ -136,7 +137,7 @@ def compute_left_turn_penalty(
       - the target road has no oncoming motor traffic
     """
     # Only penalize actual intersections, not road bends
-    if G.degree(curr) < 3:
+    if curr not in intersection_nodes:
         return 0.0
 
     bearing_in = _bearing(G, prev, curr)
@@ -161,6 +162,24 @@ def compute_left_turn_penalty(
         return 0.0
 
     return _LEFT_TURN_BASE_PENALTY * multiplier
+
+
+# =====================================================================
+# Efficiency helpers
+# =====================================================================
+def get_intersection_nodes(G: nx.DiGraph) -> set[int]:
+    """Return the set of node IDs that are intersections (degree >= 3).
+
+    Cached on G.graph after first call so subsequent routing calls are
+    free. Centralized here so both routing and turn-cost code use the
+    same definition.
+    """
+    cached = G.graph.get("intersection_nodes")
+    if cached is not None:
+        return cached
+    intersections = {n for n in G.nodes if G.degree(n) >= 3}
+    G.graph["intersection_nodes"] = intersections
+    return intersections
 
 
 # =====================================================================
@@ -203,18 +222,14 @@ def _astar_with_turn_costs(
     """
     # Priority queue entries: (f_score, counter, current_node, prev_node)
     # prev_node is None for the source.
+    intersection_nodes = get_intersection_nodes(G)
+
     counter = 0
     open_set: list[tuple[float, int, int, int | None]] = []
     heapq.heappush(open_set, (heuristic(source, target), counter, source, None))
 
-    # Best known g_score for (node, prev_node) states.
-    # For non-intersection nodes we collapse prev to None to save memory.
     g_score: dict[tuple[int, int | None], float] = {(source, None): 0.0}
-
-    # Track predecessors for path reconstruction.
     came_from: dict[tuple[int, int | None], tuple[int, int | None]] = {}
-
-    # Track which (node, prev) states have been fully processed.
     closed: set[tuple[int, int | None]] = set()
 
     while open_set:
@@ -222,7 +237,6 @@ def _astar_with_turn_costs(
 
         state = (curr, prev)
         if curr == target:
-            # Reconstruct path
             path = [curr]
             s = state
             while s in came_from:
@@ -238,9 +252,8 @@ def _astar_with_turn_costs(
         curr_g = g_score[state]
 
         for _, next_node, edge_data in G.edges(curr, data=True):
-            edge_cost = edge_data.get("stress_cost", 0.0)
+            edge_cost = edge_data["stress_cost"]  # always present, drop .get
 
-            # Compute turn penalty if we have a predecessor
             turn_penalty = 0.0
             if prev is not None:
                 turn_penalty = compute_left_turn_penalty(
@@ -249,12 +262,13 @@ def _astar_with_turn_costs(
                     curr,
                     next_node,
                     edge_data,
+                    intersection_nodes,
                 )
 
             tentative_g = curr_g + edge_cost + turn_penalty
 
-            # State key for the next node: track prev only at intersections
-            next_prev = curr if G.degree(next_node) >= 3 else None
+            next_is_intersection = next_node in intersection_nodes
+            next_prev = curr if next_is_intersection else None
             next_state = (next_node, next_prev)
 
             if next_state in closed:
@@ -265,10 +279,7 @@ def _astar_with_turn_costs(
                 came_from[next_state] = state
                 f_score = tentative_g + heuristic(next_node, target)
                 counter += 1
-                heapq.heappush(
-                    open_set,
-                    (f_score, counter, next_node, curr if G.degree(next_node) >= 3 else None),
-                )
+                heapq.heappush(open_set, (f_score, counter, next_node, next_prev))
 
     raise ValueError(f"No route found between {source} and {target}")
 
@@ -304,13 +315,16 @@ def find_route(
             "coordinates": [[node_data["x"], node_data["y"]]],
         }
 
+    floor = G.graph.get("heuristic_floor", 0.0)
+
     def heuristic(u, v):
         u_data = G.nodes[u]
         v_data = G.nodes[v]
-        return haversine_m(u_data["y"], u_data["x"], v_data["y"], v_data["x"])
+        return floor * haversine_m(u_data["y"], u_data["x"], v_data["y"], v_data["x"])
 
     path = _astar_with_turn_costs(G, origin_node, dest_node, heuristic)
 
+    intersection_nodes = get_intersection_nodes(G)
     segment_geometry = G.graph.get("segment_geometry", {})
     segments = []
     total_cost = 0.0
@@ -330,6 +344,7 @@ def find_route(
                 u,
                 v,
                 edge_data,
+                intersection_nodes,
             )
 
         total_cost += edge_cost + left_turn_penalty

--- a/platform/airflow/dags/loci/tasks/testing/route_tests.py
+++ b/platform/airflow/dags/loci/tasks/testing/route_tests.py
@@ -93,13 +93,13 @@ TEST_CASES = [
         destination=(41.9295, -87.7080),  # Logan Square monument
         must_avoid=["Western Avenue", "North Western Avenue"],
     ),
-    # RouteTestCase(
-    #     name="Belmont under the Kennedy should just use the cycleway",
-    #     origin=(41.9394, -87.7117),  # West of Kennedy
-    #     destination=(41.9393, -87.7051),  # East of Kennedy
-    #     must_use=["Belmont Avenue Bikeway"],
-    #     must_avoid=["North Avondale Avenue", "North Kedzie Avenue"],
-    # ),
+    RouteTestCase(
+        name="Belmont under the Kennedy should just use the cycleway",
+        origin=(41.9394, -87.7117),  # West of Kennedy
+        destination=(41.9393, -87.7051),  # East of Kennedy
+        must_use=["Belmont Avenue Bikeway"],
+        must_avoid=["North Avondale Avenue", "North Kedzie Avenue"],
+    ),
     RouteTestCase(
         name="Avoid the northbound underpass on Ashland above Cortland",
         origin=(41.9157, -87.6678),  # South of the underpass

--- a/platform/dbt/models/marts/cycling/chicago/chicago_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/chicago/chicago_bike_stress_weighted_segments.sql
@@ -97,52 +97,62 @@ factors as (
 
         -- Speed factor
         case
-            when s.maxspeed is null                                         then 1.4
-            when regexp_replace(s.maxspeed, '[^0-9].*', '') ~ '^\d+$'
-                and regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 20  then 1.0
-            when regexp_replace(s.maxspeed, '[^0-9].*', '') ~ '^\d+$'
-                and regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 25  then 1.3
-            when regexp_replace(s.maxspeed, '[^0-9].*', '') ~ '^\d+$'
-                and regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 30  then 1.6
-            when regexp_replace(s.maxspeed, '[^0-9].*', '') ~ '^\d+$'
-                and regexp_replace(s.maxspeed, '[^0-9].*', '')::int  > 30  then 2.0
+            when s.highway in ('cycleway', 'path', 'footway', 'bridleway',
+                               'pedestrian', 'living_street')                  then 1.0
+            when s.highway like '%cycleway%' or s.highway like '%path%'        then 1.0
+            when s.maxspeed is not null
+                and regexp_replace(s.maxspeed, '[^0-9].*', '') ~ '^\d+$'
+            then case
+                when regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 20 then 1.0
+                when regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 25 then 1.3
+                when regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 30 then 1.6
+                else 2.0
+            end
+            when s.highway in ('service', 'residential', 'unclassified')       then 1.3
+            when s.highway like '%residential%'                                then 1.3
+            when s.highway in ('tertiary', 'tertiary_link')                    then 1.5
+            when s.highway like '%tertiary%'                                   then 1.5
+            when s.highway in ('secondary', 'secondary_link', 'busway')        then 1.7
+            when s.highway like '%secondary%'                                  then 1.7
+            when s.highway in ('primary', 'primary_link')                      then 2.0
+            when s.highway like '%primary%'                                    then 2.0
             else 1.4
         end as speed_factor,
 
         -- Road type factor
         case
-            when s.highway in ('cycleway')                      then 0.3
-            when s.highway like '%cycleway%'                    then 0.3
-            when s.highway in ('path', 'footway', 'bridleway')  then 0.4
-            when s.highway like '%path%'                        then 0.4
-            when s.highway in ('pedestrian')                    then 0.5
-            when s.highway in ('living_street')                 then 0.9
-            when s.highway in ('service')                       then 1.0
-            when s.highway in ('residential')                   then 1.1
-            when s.highway like '%residential%'                 then 1.1
-            when s.highway in ('unclassified')                  then 1.4
-            when s.highway in ('busway')                        then 1.4
-            when s.highway in ('tertiary', 'tertiary_link')     then 1.7
-            when s.highway like '%tertiary%'                    then 1.7
-            when s.highway in ('secondary', 'secondary_link')   then 2.2
-            when s.highway like '%secondary%'                   then 2.2
-            when s.highway in ('primary', 'primary_link')       then 2.7
-            when s.highway like '%primary%'                     then 2.7
+            when s.highway in ('cycleway')                      then 1.0
+            when s.highway like '%cycleway%'                    then 1.0
+            when s.highway in ('path', 'footway', 'bridleway')  then 1.2
+            when s.highway like '%path%'                        then 1.2
+            when s.highway in ('pedestrian')                    then 1.5
+            when s.highway in ('living_street')                 then 3.0
+            when s.highway in ('residential')                   then 3.0
+            when s.highway like '%residential%'                 then 3.0
+            when s.highway in ('unclassified')                  then 3.5
+            when s.highway in ('busway')                        then 3.5
+            when s.highway in ('service')                       then 6.0
+            when s.highway in ('tertiary', 'tertiary_link')     then 5.5
+            when s.highway like '%tertiary%'                    then 5.5
+            when s.highway in ('secondary', 'secondary_link')   then 7.3
+            when s.highway like '%secondary%'                   then 7.3
+            when s.highway in ('primary', 'primary_link')       then 9.0
+            when s.highway like '%primary%'                     then 9.0
             else 1.3
         end as road_type_factor,
 
         -- Infrastructure factor (no Socrata fallback in segment-grain pipeline)
         case
-            when s.infra_type = 'protected_lane'    then 0.4
-            when s.infra_type = 'track'             then 0.5
-            when s.infra_type = 'shared_path'       then 0.6
-            when s.infra_type = 'buffered_lane'     then 0.7
-            when s.infra_type = 'designated_path'   then 0.7
-            when s.infra_type = 'bicycle_road'      then 0.8
-            when s.infra_type = 'bike_lane'         then 0.85
-            when s.infra_type = 'share_busway'      then 0.9
-            when s.infra_type = 'sharrow'           then 0.95
-            else 1.0
+            when s.infra_type = 'protected_lane'    then 1.0
+            when s.infra_type = 'track'             then 1.0
+            when s.infra_type = 'shared_path'       then 1.3
+            when s.infra_type = 'buffered_lane'     then 1.5
+            when s.infra_type = 'designated_path'   then 1.5
+            when s.infra_type = 'bicycle_road'      then 1.7
+            when s.infra_type = 'bike_lane'         then 1.85
+            when s.infra_type = 'share_busway'      then 2.0
+            when s.infra_type = 'sharrow'           then 2.0
+            else 2.5
         end as infrastructure_factor,
 
         -- Tunnel factor

--- a/platform/dbt/models/staging/cycling/chicago/stg_chicago_bike_ways.sql
+++ b/platform/dbt/models/staging/cycling/chicago/stg_chicago_bike_ways.sql
@@ -41,6 +41,8 @@ select
     tags->>'class:bicycle'               as class_bicycle,
     tags->>'bicycle_road'                as bicycle_road,
     tags->>'cyclestreet'                 as cyclestreet,
+    tags->>'service'                     as service,
+    tags->>'access'                      as access,
 
     -- Canonical bike-routing direction
     case
@@ -63,4 +65,7 @@ where
     and (
         highway != 'footway'
         or bicycle in ('yes', 'designated', 'permissive')
+    ) and (
+        (tags->>'access' is null)
+        or (tags->>'access' not in ('private', 'no', 'customers', 'permit'))
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pandas>=3.0.0",
     "psycopg2-binary>=2.9.11",
     "pymysql>=1.1.2",
+    "scipy>=1.17.1",
     "shapely>=2.1.2",
     "tenacity>=9.1.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -506,6 +506,7 @@ dependencies = [
     { name = "pandas" },
     { name = "psycopg2-binary" },
     { name = "pymysql" },
+    { name = "scipy" },
     { name = "shapely" },
     { name = "tenacity" },
 ]
@@ -528,6 +529,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=3.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pymysql", specifier = ">=1.1.2" },
+    { name = "scipy", specifier = ">=1.17.1" },
     { name = "shapely", specifier = ">=2.1.2" },
     { name = "tenacity", specifier = ">=9.1.4" },
 ]
@@ -1261,6 +1263,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
     { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
     { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Changes:
* Makes the A* routing heuristic valid by scaling up costs so that the `stress_cost >= length_m` is true for every segment. Previously, I thought the cost just had to be nonnegative, but it actually has to never underestimate the base cost, so for 2D linear distance, the haversine heuristic will underestimate if a weighted length was less than its unweighted length, which will make the algorithm waste more time exploring unlikely paths before more plausible ones.
* Adds profiling tooling (e.g. the `main.py` file that `uv` provided and I lazily stuffed profiling code in) and profiling logging statements in the handler.
* Caches intersection checking.
* Switches to use the new stress-weighting model based on the network collected with the new OSM tooling.
 
Anecdotally, the routing latency for very long routes has been substantially lower for my checks after adopting the change, but I'll analyze this more comprehensively if it still seems laggy.
 
Closes #166

I'll definitely need to do more tuning of the weights, and I need to update the traffic control device module, and I'm not sure if I need to do more to account for the different tagging types, but things are progressing. Routing will always be deterministic now (and it nearly always was before, although sometimes route_tests would intermittently fail then pass on successive runs without any change to data or code).