### PR TITLE
Extracts core logic into macros and builds Detroit pipeline.

### DIFF
--- a/platform/airflow/dags/dag_files/dbt_build_dag.py
+++ b/platform/airflow/dags/dag_files/dbt_build_dag.py
@@ -13,7 +13,7 @@ def install_dependencies() -> str:
 
 @task
 def alt_build() -> str:
-    return run_dbt("build", "--select", "+chicago_bike_stress_weighted_segments")
+    return run_dbt("build", "--select", "+detroit_bike_stress_weighted_segments")
 
 
 @dag(

--- a/platform/dbt/README.md
+++ b/platform/dbt/README.md
@@ -1,15 +1,31 @@
-Welcome to your new dbt project!
+# Data Transformations via `dbt`
 
-### Using the starter project
+## Dev Notes
 
-Try running the following commands:
-- dbt run
-- dbt test
+The (quite opinionated) notes below assume you are using `uv` for local dev purposes and that you're `ssh`'d into the machine you're developing on.
+
+### Generating and serving the docs site (shows lineage and all models/tests/macros)
+
+To generate the `dbt docs` site, run the commands below to set the required env-vars and generate the docs asset.
+
+```console
+export DBT_PG_HOST=localhost
+export DBT_PG_PORT=54321
+uv run dbt docs generate --profiles-dir ..
+```
+
+Then, to serve the docs
+
+```console
+uv run dbt docs serve --host 0.0.0.0 --port <any_free_port_number>
+```
+
+Then the site will be accessible via your browser at http://<dev_machine_ip_addr>:<port_number_from_above>. You can use `hostname -I` or `ip addr` to find your machine's IP address.
 
 
-### Resources:
+## `dbt` Resources:
 - Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
 - Check out [Discourse](https://discourse.getdbt.com/) for commonly asked questions and answers
 - Join the [chat](https://community.getdbt.com/) on Slack for live discussions and support
 - Find [dbt events](https://events.getdbt.com) near you
-- Check out [the blog](https://blog.getdbt.com/) for the latest news on dbt's development and best practices
+- Check out [the blog](https://blog.getdbt.com/) for the latest news on `dbt`'s development and best practices

--- a/platform/dbt/macros/osm/generate_city_segment_costs_model.sql
+++ b/platform/dbt/macros/osm/generate_city_segment_costs_model.sql
@@ -1,0 +1,174 @@
+{#
+    Per-segment intrinsic stress costs derived from the physical attributes of
+    the segment (highway class, infrastructure, surface, etc).
+    Only OSM data required.
+
+    Source: stg_<city>_bike_segments
+    Grain: one row per segment (segment_id).
+
+    Outputs:
+      - All segment passthrough columns from stg_<city>_bike_segments
+      - Six factor columns (preserved for tuning visibility):
+          speed_factor, road_type_factor, infrastructure_factor,
+          tunnel_factor, surface_factor, lighting_factor
+      - physical_cost = length_m * product of the six factors
+
+    Parameters:
+      city: city name; used to resolve stg_<city>_bike_segments.
+#}
+{% macro generate_city_segment_costs_model(city) %}
+
+with factors as (
+    select
+        s.*,
+
+        -- Speed factor
+        case
+            when s.highway in ('cycleway', 'path', 'footway', 'bridleway',
+                               'pedestrian', 'living_street')                  then 1.0
+            when s.highway like '%cycleway%' or s.highway like '%path%'        then 1.0
+            when s.maxspeed is not null
+                and regexp_replace(s.maxspeed, '[^0-9].*', '') ~ '^\d+$'
+            then case
+                when regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 20 then 1.0
+                when regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 25 then 1.3
+                when regexp_replace(s.maxspeed, '[^0-9].*', '')::int <= 30 then 1.6
+                else 2.0
+            end
+            when s.highway in ('service', 'residential', 'unclassified')       then 1.3
+            when s.highway like '%residential%'                                then 1.3
+            when s.highway in ('tertiary', 'tertiary_link')                    then 1.5
+            when s.highway like '%tertiary%'                                   then 1.5
+            when s.highway in ('secondary', 'secondary_link', 'busway')        then 1.7
+            when s.highway like '%secondary%'                                  then 1.7
+            when s.highway in ('primary', 'primary_link')                      then 2.0
+            when s.highway like '%primary%'                                    then 2.0
+            else 1.4
+        end as speed_factor,
+
+        -- Road type factor
+        case
+            when s.highway in ('cycleway')                      then 1.0
+            when s.highway like '%cycleway%'                    then 1.0
+            when s.highway in ('path', 'footway', 'bridleway')  then 1.2
+            when s.highway like '%path%'                        then 1.2
+            when s.highway in ('pedestrian')                    then 1.5
+            when s.highway in ('living_street')                 then 3.0
+            when s.highway in ('residential')                   then 3.0
+            when s.highway like '%residential%'                 then 3.0
+            when s.highway in ('unclassified')                  then 3.5
+            when s.highway in ('busway')                        then 3.5
+            when s.highway in ('service')                       then 6.0
+            when s.highway in ('tertiary', 'tertiary_link')     then 5.5
+            when s.highway like '%tertiary%'                    then 5.5
+            when s.highway in ('secondary', 'secondary_link')   then 7.3
+            when s.highway like '%secondary%'                   then 7.3
+            when s.highway in ('primary', 'primary_link')       then 9.0
+            when s.highway like '%primary%'                     then 9.0
+            else 1.3
+        end as road_type_factor,
+
+        -- Infrastructure factor
+        case
+            when s.infra_type = 'protected_lane'    then 1.0
+            when s.infra_type = 'track'             then 1.0
+            when s.infra_type = 'shared_path'       then 1.3
+            when s.infra_type = 'buffered_lane'     then 1.5
+            when s.infra_type = 'designated_path'   then 1.5
+            when s.infra_type = 'bicycle_road'      then 1.7
+            when s.infra_type = 'bike_lane'         then 1.85
+            when s.infra_type = 'share_busway'      then 2.0
+            when s.infra_type = 'sharrow'           then 2.0
+            else 2.5
+        end as infrastructure_factor,
+
+        -- Tunnel factor
+        case
+            when s.tunnel = 'yes'
+                and coalesce(s.infra_type, '') not in (
+                    'protected_lane', 'track', 'shared_path', 'buffered_lane'
+                )
+            then 2.5
+            else 1.0
+        end as tunnel_factor,
+
+        -- Surface factor
+        case
+            when s.surface in ('asphalt', 'paved', 'concrete',
+                               'concrete:plates', 'concrete:lanes') then 1.0
+            when s.surface in ('paving_stones', 'sett',
+                               'cobblestone', 'unhewn_cobblestone') then 1.3
+            when s.surface in ('unpaved', 'gravel', 'fine_gravel',
+                               'compacted', 'dirt', 'grass',
+                               'ground', 'mud', 'sand')             then 1.5
+            when s.surface is null                                  then 1.0
+            else 1.0
+        end as surface_factor,
+
+        -- Lighting factor
+        case
+            when s.lit = 'yes' then 1.0
+            when s.lit = 'no'  then 1.2
+            else                    1.1
+        end as lighting_factor
+
+    from {{ ref('stg_' ~ city ~ '_bike_segments') }} s
+)
+
+select
+    -- Identity
+    segment_id,
+    way_id,
+    start_position,
+    end_position,
+
+    -- Topology
+    start_node_id,
+    end_node_id,
+    direction,
+
+    -- Geometry and length
+    geom,
+    length_m,
+
+    -- Identification
+    name,
+    highway,
+
+    -- Bike infrastructure
+    infra_category,
+    infra_type,
+    has_buffer,
+
+    -- Physical conditions
+    surface,
+    lit,
+    bridge,
+    tunnel,
+    maxspeed,
+
+    -- Raw cycleway tags
+    cycleway,
+    cycleway_left,
+    cycleway_right,
+
+    -- Factors (preserved for tuning)
+    speed_factor,
+    road_type_factor,
+    infrastructure_factor,
+    tunnel_factor,
+    surface_factor,
+    lighting_factor,
+
+    length_m
+        * speed_factor
+        * road_type_factor
+        * infrastructure_factor
+        * tunnel_factor
+        * surface_factor
+        * lighting_factor
+        as physical_cost
+
+from factors
+
+{% endmacro %}

--- a/platform/dbt/macros/osm/generate_city_segment_crash_costs_model.sql
+++ b/platform/dbt/macros/osm/generate_city_segment_crash_costs_model.sql
@@ -1,0 +1,93 @@
+{#
+    Per-segment crash-derived stress cost.
+    Built only for cities with a bike-crash data source.
+
+    Sources: stg_<city>_bike_segments + <city>_bike_crash_hotspots
+    Grain: one row per segment that has at least one nearby crash.
+
+    Crash deduplication: each crash is assigned to exactly one segment
+    via DISTINCT ON, prioritizing nearest distance, breaking ties by
+    most-dangerous highway class.
+
+    Crash score: severity-squared, exponentially decayed by crash age.
+    Crash cost: crash_score * crash_weight.
+
+    Note: the previous formulation computed crash_score / length_m and
+    then multiplied back by length_m * crash_weight. That algebraically
+    equals crash_score * crash_weight, so the per-meter normalization
+    is dropped here. A future refactor may reintroduce nonlinear scaling
+    in crash density to better capture short-segment crash clusters vs.
+    long-segment dispersed crashes.
+
+    Parameters:
+      city: city name.
+      crash_weight: scalar multiplier applied to crash_score.
+      crash_decay_lambda: exponential decay rate per year of crash age.
+      crash_buffer_degrees: spatial buffer (degrees) for matching
+        crashes to segments.
+#}
+{% macro generate_city_segment_crash_costs_model(
+    city,
+    crash_weight=24.0,
+    crash_decay_lambda=0.4,
+    crash_buffer_degrees=0.0002
+) %}
+
+with segments as (
+    select * from {{ ref('stg_' ~ city ~ '_bike_segments') }}
+),
+crashes as (
+    select * from {{ ref(city ~ '_bike_crash_hotspots') }}
+),
+
+-- Crash deduplication: assign each crash to exactly one segment.
+-- Priority: nearest by distance, then most dangerous highway class.
+crash_nearest as (
+    select distinct on (c.crash_record_id)
+        c.crash_record_id,
+        c.severity_score,
+        c.crash_date,
+        s.segment_id
+    from crashes c
+    inner join segments s
+        on s.geom && ST_Expand(c.geom, {{ crash_buffer_degrees }})
+        and ST_DWithin(c.geom, s.geom, {{ crash_buffer_degrees }})
+    order by c.crash_record_id,
+        ST_Distance(c.geom, s.geom),
+        case
+            when s.highway in ('primary', 'primary_link')
+                or s.highway like '%primary%'         then 1
+            when s.highway in ('secondary', 'secondary_link')
+                or s.highway like '%secondary%'       then 2
+            when s.highway in ('tertiary', 'tertiary_link')
+                or s.highway like '%tertiary%'        then 3
+            when s.highway = 'unclassified'           then 4
+            when s.highway = 'residential'
+                or s.highway like '%residential%'     then 5
+            when s.highway = 'service'                then 6
+            else 7
+        end
+),
+crash_scores as (
+    select
+        cn.segment_id,
+        count(*) as crash_count,
+        sum(
+            power(cn.severity_score, 2) * exp(
+                -{{ crash_decay_lambda }}
+                * extract(epoch from (current_date - cn.crash_date))
+                / (365.25 * 86400)
+            )
+        ) as crash_score
+    from crash_nearest cn
+    group by cn.segment_id
+)
+
+select
+    segment_id,
+    crash_count,
+    crash_score,
+    crash_score * {{ crash_weight }} as crash_cost
+from crash_scores
+
+{% endmacro %}

--- a/platform/dbt/macros/osm/generate_stg_city_bike_segments_model.sql
+++ b/platform/dbt/macros/osm/generate_stg_city_bike_segments_model.sql
@@ -1,0 +1,65 @@
+{#
+    Bike network segments, one row per intersection-to-intersection
+    portion of a way, with bike infrastructure classification and
+    physical conditions joined in.
+
+    Source: stg_<city>_way_segments + stg_<city>_osm_bike_infra
+    Grain: one row per segment (way_id, start_position, end_position).
+
+    Direction handling: each segment carries a `direction` column
+    ('forward', 'backward', 'bidirectional') indicating which directions
+    of travel are legal. The graph exporter expands these into one or
+    two directed edges per segment.
+
+    Parameters:
+      city: city name; used to resolve upstream stg_<city>_* refs.
+#}
+{% macro generate_stg_city_bike_segments_model(city) %}
+
+select
+    -- Identity
+    s.way_id || '_' || s.start_node_id || '_' || s.end_node_id as segment_id,
+    s.way_id,
+    s.start_position,
+    s.end_position,
+
+    -- Topology
+    s.start_node_id,
+    s.end_node_id,
+    s.direction,
+
+    -- Geometry
+    s.geom,
+    ST_Length(s.geom::geography) as length_m,
+
+    -- Identification
+    s.name,
+    s.highway,
+
+    -- Bike infrastructure (NULL when no bike infra on this segment)
+    i.infra_category,
+    i.infra_type,
+    i.has_buffer,
+
+    -- Stress factor inputs
+    s.surface,
+    s.lit,
+    s.bridge,
+    s.tunnel,
+    s.maxspeed,
+    s.bicycle,
+
+    -- Raw cycleway tags preserved for downstream refinement
+    s.cycleway,
+    s.cycleway_left,
+    s.cycleway_right,
+
+    s.tags
+
+from {{ ref('stg_' ~ city ~ '_way_segments') }} s
+left join {{ ref('stg_' ~ city ~ '_osm_bike_infra') }} i
+    on i.way_id = s.way_id
+   and i.start_position = s.start_position
+   and i.end_position = s.end_position
+
+{% endmacro %}

--- a/platform/dbt/macros/osm/generate_stg_city_bike_ways_model.sql
+++ b/platform/dbt/macros/osm/generate_stg_city_bike_ways_model.sql
@@ -1,0 +1,76 @@
+{% macro generate_stg_city_bike_ways_model(city, include_all_sidewalks=false) %}
+
+select
+    osm_id,
+    osm_version,
+    osm_timestamp,
+    geom,
+    node_ids,
+    array_length(node_ids, 1) as node_count,
+
+    -- Promoted columns (from the spec)
+    highway,
+    name,
+    bicycle,
+    cycleway,
+    cycleway_left,
+    cycleway_right,
+    surface,
+    maxspeed,
+
+    -- Physical conditions for stress weighting
+    tags->>'lit' as lit,
+    tags->>'bridge' as bridge,
+    tags->>'tunnel' as tunnel,
+
+    -- Cycleway sub-tags for infra classification
+    tags->>'cycleway:buffer'             as cycleway_buffer,
+    tags->>'cycleway:left:buffer'        as cycleway_left_buffer,
+    tags->>'cycleway:right:buffer'       as cycleway_right_buffer,
+    tags->>'cycleway:both:buffer'        as cycleway_both_buffer,
+    tags->>'cycleway:separation'         as cycleway_separation,
+    tags->>'cycleway:left:separation'    as cycleway_left_separation,
+    tags->>'cycleway:right:separation'   as cycleway_right_separation,
+    tags->>'cycleway:both:separation'    as cycleway_both_separation,
+    tags->>'cycleway:shared_lane'        as cycleway_shared_lane,
+    tags->>'cycleway:left:shared_lane'   as cycleway_left_shared_lane,
+    tags->>'cycleway:right:shared_lane'  as cycleway_right_shared_lane,
+    tags->>'cycleway:both:shared_lane'   as cycleway_both_shared_lane,
+    tags->>'cycleway:both'               as cycleway_both,
+    tags->>'class:bicycle'               as class_bicycle,
+    tags->>'bicycle_road'                as bicycle_road,
+    tags->>'cyclestreet'                 as cyclestreet,
+    tags->>'service'                     as service,
+    tags->>'access'                      as access,
+
+    -- Canonical bike-routing direction
+    case
+        when coalesce(tags->>'oneway:bicycle', oneway) in ('yes', 'true', '1') then 'forward'
+        when coalesce(tags->>'oneway:bicycle', oneway) = '-1' then 'backward'
+        when coalesce(tags->>'oneway:bicycle', oneway) in ('no', 'false', '0') then 'bidirectional'
+        when coalesce(tags->>'oneway:bicycle', oneway) is null then 'bidirectional'
+        else 'bidirectional'
+    end as direction,
+    oneway,
+
+    tags,
+    ingested_at
+
+from {{ source('osm', city ~ '_osm_bike_network_edges') }}
+where
+    valid_to is null
+    and osm_type = 'way'
+    and geometrytype(geom) = 'LINESTRING'
+    and (
+        highway != 'footway'
+        {% if include_all_sidewalks %}
+        or highway = 'footway'
+        {% else %}
+        or bicycle in ('yes', 'designated', 'permissive')
+        {% endif %}
+    ) and (
+        (tags->>'access' is null)
+        or (tags->>'access' not in ('private', 'no', 'customers', 'permit'))
+    )
+
+{% endmacro %}

--- a/platform/dbt/macros/osm/generate_stg_city_intersection_costs_model.sql
+++ b/platform/dbt/macros/osm/generate_stg_city_intersection_costs_model.sql
@@ -1,0 +1,168 @@
+{#
+    Identifies "logical intersections" in a city's bike network and assigns each
+    one a stress penalty representing the cost of a cyclist traversing it.
+
+    A "logical intersection" is a node where at least two distinct OSM ways meet
+    AND at least one of those ways carries cars. This captures the places where a
+    cyclist's path crosses or merges with car traffic, which is the underlying
+    stressor we want to penalize.
+
+    Explicitly excluded:
+      - Mid-block pedestrian crossings (only one way touches the node)
+      - Cycleway-to-cycleway or path-to-path junctions (no car traffic)
+      - Cul-de-sac endpoints, turning circles, turning loops
+      - Mid-segment graph-split nodes
+
+    Penalty design:
+      - Direction-symmetric: the penalty is a property of the node, not
+          the path through it. Turn-specific costs are handled separately
+          in the routing algorithm.
+      - Higher road class -> higher penalty (more/faster cars to cross).
+      - Better traffic control -> lower penalty.
+
+    Joined into <city>_bike_stress_weighted_segments on end_node_id.
+
+#}
+{% macro generate_stg_city_intersection_costs_model(city) %}
+-- =====================================================================
+-- Ways meeting at each node, with each way's highway class and a flag
+-- for whether it carries cars. Distinct on (node, way) so a self-loop
+-- counts a way only once.
+-- =====================================================================
+with ways_at_node as (
+    select distinct
+        wn.node_id,
+        wn.way_id,
+        w.highway,
+        case
+            when w.highway in (
+                'primary', 'primary_link',
+                'secondary', 'secondary_link',
+                'tertiary', 'tertiary_link',
+                'unclassified', 'residential', 'service', 'busway'
+            ) then true
+            when w.highway like '%primary%'     then true
+            when w.highway like '%secondary%'   then true
+            when w.highway like '%tertiary%'    then true
+            when w.highway like '%residential%' then true
+            else false
+        end as is_car_carrying
+    from {{ ref('stg_' ~ city ~ '_way_nodes') }} as wn
+    inner join {{ ref('stg_' ~ city ~ '_bike_ways') }} as w
+        on w.osm_id = wn.way_id
+),
+-- =====================================================================
+-- Per-node summary: how many distinct ways meet, and the worst road
+-- class among the *car-carrying* ways. Nodes with no car-carrying way
+-- get max_road_rank = NULL and are filtered out next.
+-- =====================================================================
+node_summary as (
+    select
+        node_id,
+        count(*) as way_count,
+        max(case when is_car_carrying then
+            case
+                when highway in ('primary', 'primary_link')
+                    or highway like '%primary%'         then 4
+                when highway in ('secondary', 'secondary_link')
+                    or highway like '%secondary%'       then 3
+                when highway in ('tertiary', 'tertiary_link')
+                    or highway like '%tertiary%'        then 2
+                else                                         1
+            end
+        end) as max_road_rank
+    from ways_at_node
+    group by node_id
+),
+-- =====================================================================
+-- Logical intersections: 2+ distinct ways AND >= 1 carries cars.
+-- =====================================================================
+logical_intersections as (
+    select
+        node_id,
+        max_road_rank,
+        case max_road_rank
+            when 4 then 'primary'
+            when 3 then 'secondary'
+            when 2 then 'tertiary'
+            else        'minor'
+        end as max_road_class
+    from node_summary
+    where way_count >= 2
+      and max_road_rank is not null
+),
+-- =====================================================================
+-- Attach traffic control tag from the raw OSM nodes source.
+-- Nodes missing from the source get NULL -> treated as uncontrolled.
+-- =====================================================================
+nodes_with_control as (
+    select
+        li.node_id as osmid,
+        n.tags->>'highway' as traffic_control,
+        li.max_road_rank,
+        li.max_road_class
+    from logical_intersections as li
+    left join {{ source('osm', city ~ '_osm_bike_network_nodes') }} as n
+        on n.osm_type = 'node'
+        and n.osm_id = li.node_id
+        and n.valid_to is null
+)
+
+select
+    osmid,
+    traffic_control,
+    max_road_rank,
+    max_road_class,
+    case
+        when traffic_control = 'traffic_signals' then
+            case max_road_class
+                when 'primary'   then 200.0
+                when 'secondary' then 100.0
+                when 'tertiary'  then 50.0
+                else                  25.0
+            end
+
+        when traffic_control = 'stop' then
+            case max_road_class
+                when 'primary'   then 250.0
+                when 'secondary' then 150.0
+                when 'tertiary'  then 75.0
+                else                  50.0
+            end
+
+        when traffic_control = 'mini_roundabout' then
+            case max_road_class
+                when 'primary'   then 250.0
+                when 'secondary' then 150.0
+                when 'tertiary'  then 75.0
+                else                  50.0
+            end
+
+        when traffic_control = 'give_way' then
+            case max_road_class
+                when 'primary'   then 325.0
+                when 'secondary' then 175.0
+                when 'tertiary'  then 100.0
+                else                  75.0
+            end
+
+        when traffic_control = 'crossing' then
+            case max_road_class
+                when 'primary'   then 350.0
+                when 'secondary' then 200.0
+                when 'tertiary'  then 125.0
+                else                  90.0
+            end
+
+        else
+            case max_road_class
+                when 'primary'   then 450.0
+                when 'secondary' then 250.0
+                when 'tertiary'  then 150.0
+                else                  100.0
+            end
+    end as intersection_cost
+
+from nodes_with_control
+
+{% endmacro %}

--- a/platform/dbt/macros/osm/generate_stg_city_intersection_nodes_model.sql
+++ b/platform/dbt/macros/osm/generate_stg_city_intersection_nodes_model.sql
@@ -1,0 +1,22 @@
+{% macro generate_stg_city_intersection_nodes_model(city) %}
+
+with node_way_counts as (
+    select
+        node_id,
+        count(distinct way_id) as way_count
+    from {{ ref('stg_' ~ city ~ '_way_nodes') }}
+    group by node_id
+),
+endpoints as (
+    select node_id
+    from {{ ref('stg_' ~ city ~ '_way_nodes') }}
+    where position = 1 or position = way_length
+)
+select distinct node_id
+from (
+    select node_id from node_way_counts where way_count >= 2
+    union
+    select node_id from endpoints
+) t
+
+{% endmacro %}

--- a/platform/dbt/macros/osm/generate_stg_city_osm_bike_infra_model.sql
+++ b/platform/dbt/macros/osm/generate_stg_city_osm_bike_infra_model.sql
@@ -1,0 +1,142 @@
+{#
+    Classifies bike network segments into infrastructure categories
+    using the full set of cycleway/bicycle tags.
+
+    Source: stg_<city>_way_segments
+    Grain: one row per segment with bike infrastructure present.
+
+    Infrastructure taxonomy:
+      infra_category: 'separated', 'on_road', 'shared', 'path'
+      infra_type:     'protected_lane', 'track', 'buffered_lane',
+                      'bike_lane', 'sharrow', 'bicycle_road',
+                      'share_busway', 'shared_path', 'designated_path'
+
+    The classification logic resolves left/right/both cycleway tags into
+    a single per-segment classification. When left and right differ, we
+    use the higher-quality side (separated > on_road > shared).
+
+    Parameters:
+      city: city name; used to resolve the upstream stg_<city>_way_segments ref.
+      include_all_sidewalks: when true, plain (untagged) footways are
+        classified as 'path' infrastructure. Use for cities where
+        sidewalk riding is legal. When false (default), only footways
+        with an explicit bicycle=yes/designated/permissive tag are
+        included.
+#}
+{% macro generate_stg_city_osm_bike_infra_model(city, include_all_sidewalks=false) %}
+
+with segments as (
+    select * from {{ ref('stg_' ~ city ~ '_way_segments') }}
+),
+
+resolved as (
+    select
+        *,
+        coalesce(cycleway_left, cycleway_both, cycleway) as eff_cycleway_left,
+        coalesce(cycleway_right, cycleway_both, cycleway) as eff_cycleway_right,
+        coalesce(
+            cycleway_left_buffer,
+            cycleway_right_buffer,
+            cycleway_both_buffer,
+            cycleway_buffer
+        ) is not null as has_any_buffer,
+        coalesce(
+            cycleway_left_separation,
+            cycleway_right_separation,
+            cycleway_both_separation,
+            cycleway_separation
+        ) as eff_separation,
+        coalesce(
+            cycleway_left_shared_lane,
+            cycleway_right_shared_lane,
+            cycleway_both_shared_lane,
+            cycleway_shared_lane
+        ) as eff_shared_lane
+    from segments
+),
+
+classified as (
+    select
+        way_id,
+        start_position,
+        end_position,
+        start_node_id,
+        end_node_id,
+
+        case
+            when highway in ('cycleway', 'path', 'pedestrian')
+                then 'separated'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('track', 'separate')
+                then 'separated'
+            when eff_separation is not null
+                and eff_separation not in ('no', 'none')
+                then 'separated'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('lane', 'exclusive')
+                then 'on_road'
+            when has_any_buffer
+                then 'on_road'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in (
+                'shared_lane', 'shared', 'share_busway'
+            )
+                then 'shared'
+            when eff_shared_lane is not null
+                then 'shared'
+            when bicycle_road = 'yes' or cyclestreet = 'yes'
+                then 'shared'
+            when highway in ('footway', 'bridleway', 'steps')
+                and (
+                    bicycle in ('yes', 'designated', 'permissive')
+                    {% if include_all_sidewalks %}or bicycle is null{% endif %}
+                )
+                then 'path'
+            when bicycle in ('designated', 'yes')
+                then 'shared'
+            else null
+        end as infra_category,
+
+        case
+            when eff_separation is not null
+                and eff_separation not in ('no', 'none')
+                and coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('track', 'lane', 'separate')
+                then 'protected_lane'
+            when highway = 'cycleway'
+                then 'track'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('track', 'separate')
+                then 'track'
+            when has_any_buffer
+                then 'buffered_lane'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('lane', 'exclusive')
+                then 'bike_lane'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') in ('shared_lane', 'shared')
+                then 'sharrow'
+            when eff_shared_lane is not null
+                then 'sharrow'
+            when bicycle_road = 'yes' or cyclestreet = 'yes'
+                then 'bicycle_road'
+            when coalesce(eff_cycleway_right, eff_cycleway_left, '') = 'share_busway'
+                then 'share_busway'
+            when highway in ('path', 'footway', 'bridleway', 'pedestrian', 'steps')
+                then 'shared_path'
+            when bicycle = 'designated'
+                then 'designated_path'
+            else null
+        end as infra_type,
+
+        has_any_buffer as has_buffer
+
+    from resolved
+)
+
+select
+    way_id,
+    start_position,
+    end_position,
+    start_node_id,
+    end_node_id,
+    infra_category,
+    infra_type,
+    has_buffer
+from classified
+where infra_category is not null
+
+{% endmacro %}

--- a/platform/dbt/macros/osm/generate_stg_city_way_nodes_model.sql
+++ b/platform/dbt/macros/osm/generate_stg_city_way_nodes_model.sql
@@ -1,0 +1,11 @@
+{% macro generate_stg_city_way_nodes_model(city) %}
+
+select
+    osm_id as way_id,
+    ordinality as position,
+    node_id,
+    array_length(node_ids, 1) as way_length
+from {{ ref('stg_' ~ city ~ '_bike_ways') }},
+     unnest(node_ids) with ordinality as t(node_id, ordinality)
+
+{% endmacro %}

--- a/platform/dbt/macros/osm/generate_stg_city_way_segments_model.sql
+++ b/platform/dbt/macros/osm/generate_stg_city_way_segments_model.sql
@@ -1,0 +1,89 @@
+{% macro generate_stg_city_way_segments_model(city) %}
+
+with way_cuts as (
+    select
+        wn.way_id,
+        wn.position,
+        wn.node_id
+    from {{ ref('stg_' ~ city ~ '_way_nodes') }} wn
+    inner join {{ ref('stg_' ~ city ~'_intersection_nodes') }} i
+        on wn.node_id = i.node_id
+),
+segments as (
+    select
+        way_id,
+        node_id as start_node_id,
+        position as start_position,
+        lead(node_id) over (partition by way_id order by position) as end_node_id,
+        lead(position) over (partition by way_id order by position) as end_position
+    from way_cuts
+),
+way_points as (
+    -- Dump every vertex of every way with its position. Use this to
+    -- reconstruct segment geometries vertex-by-vertex rather than via
+    -- length-fraction interpolation.
+    select
+        osm_id as way_id,
+        (dp).path[1] as position,
+        (dp).geom as point_geom
+    from (
+        select osm_id, ST_DumpPoints(geom) as dp
+        from {{ ref('stg_' ~ city ~ '_bike_ways') }}
+    ) t
+),
+segment_geoms as (
+    select
+        s.way_id,
+        s.start_node_id,
+        s.end_node_id,
+        s.start_position,
+        s.end_position,
+        ST_MakeLine(wp.point_geom order by wp.position) as geom
+    from segments s
+    inner join way_points wp
+        on wp.way_id = s.way_id
+       and wp.position between s.start_position and s.end_position
+    where s.end_node_id is not null
+    group by s.way_id, s.start_node_id, s.end_node_id, s.start_position, s.end_position
+)
+select
+    sg.way_id,
+    sg.start_node_id,
+    sg.end_node_id,
+    sg.start_position,
+    sg.end_position,
+    sg.geom,
+    w.highway,
+    w.name,
+    w.bicycle,
+    w.cycleway,
+    w.cycleway_left,
+    w.cycleway_right,
+    w.surface,
+    w.lit,
+    w.bridge,
+    w.tunnel,
+    w.cycleway_buffer,
+    w.cycleway_left_buffer,
+    w.cycleway_right_buffer,
+    w.cycleway_both_buffer,
+    w.cycleway_separation,
+    w.cycleway_left_separation,
+    w.cycleway_right_separation,
+    w.cycleway_both_separation,
+    w.cycleway_shared_lane,
+    w.cycleway_left_shared_lane,
+    w.cycleway_right_shared_lane,
+    w.cycleway_both_shared_lane,
+    w.cycleway_both,
+    w.class_bicycle,
+    w.bicycle_road,
+    w.cyclestreet,
+    w.maxspeed,
+    w.direction,
+    w.oneway,
+    w.tags
+from segment_geoms sg
+inner join {{ ref('stg_' ~ city ~ '_bike_ways') }} w on sg.way_id = w.osm_id
+
+{% endmacro %}

--- a/platform/dbt/models/_osm_sources.yml
+++ b/platform/dbt/models/_osm_sources.yml
@@ -5,6 +5,24 @@ sources:
     tags:
       - raw
     tables:
+      - name: boston_osm_bike_network_edges
+      - name: boston_osm_bike_network_nodes
       - name: chicago_osm_bike_network_edges
       - name: chicago_osm_bike_network_nodes
+      - name: dc_osm_bike_network_edges
+      - name: dc_osm_bike_network_nodes
+      - name: denver_osm_bike_network_edges
+      - name: denver_osm_bike_network_nodes
+      - name: detroit_osm_bike_network_edges
+      - name: detroit_osm_bike_network_nodes
+      - name: madison_osm_bike_network_edges
+      - name: madison_osm_bike_network_nodes
+      - name: new_orleans_osm_bike_network_edges
+      - name: new_orleans_osm_bike_network_nodes
+      - name: portland_osm_bike_network_edges
+      - name: portland_osm_bike_network_nodes
+      - name: sf_osm_bike_network_edges
+      - name: sf_osm_bike_network_nodes
+      - name: toronto_osm_bike_network_edges
+      - name: toronto_osm_bike_network_nodes
 

--- a/platform/dbt/models/marts/cycling/detroit/detroit_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/detroit/detroit_bike_stress_weighted_segments.sql
@@ -1,0 +1,76 @@
+{{ config(
+    materialized='table',
+    pre_hook=["SET work_mem = '256MB'"],
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (segment_id)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "RESET work_mem"
+    ]
+) }}
+
+with segment_costs as (
+    select * from {{ ref('detroit_segment_costs') }}
+),
+intersection_costs as (
+    select * from {{ ref('detroit_intersection_costs') }}
+)
+
+select
+    -- Identity
+    sc.segment_id,
+    sc.way_id,
+    sc.start_position,
+    sc.end_position,
+
+    -- Topology
+    sc.start_node_id,
+    sc.end_node_id,
+    sc.direction,
+
+    -- Geometry and length
+    sc.geom,
+    sc.length_m,
+
+    -- Identification
+    sc.name,
+    sc.highway,
+
+    -- Bike infrastructure
+    sc.infra_category,
+    sc.infra_type,
+    sc.has_buffer,
+
+    -- Physical conditions
+    sc.surface,
+    sc.lit,
+    sc.bridge,
+    sc.tunnel,
+    sc.maxspeed,
+
+    -- Raw cycleway tags
+    sc.cycleway,
+    sc.cycleway_left,
+    sc.cycleway_right,
+
+    -- Physical factors (preserved for tuning)
+    sc.speed_factor,
+    sc.road_type_factor,
+    sc.infrastructure_factor,
+    sc.tunnel_factor,
+    sc.surface_factor,
+    sc.lighting_factor,
+
+    -- Cost components
+    sc.physical_cost,
+    coalesce(ic.intersection_cost, 0) as intersection_cost,
+
+    -- Final composition
+    sc.physical_cost
+        + coalesce(ic.intersection_cost, 0)
+        as stress_cost
+
+from segment_costs as sc
+left join intersection_costs as ic
+    on ic.osmid = sc.end_node_id

--- a/platform/dbt/models/marts/cycling/detroit/detroit_intersection_costs.sql
+++ b/platform/dbt/models/marts/cycling/detroit/detroit_intersection_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_intersection_costs_model('detroit') }}

--- a/platform/dbt/models/marts/cycling/detroit/detroit_segment_costs.sql
+++ b/platform/dbt/models/marts/cycling/detroit/detroit_segment_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_costs_model('detroit') }}

--- a/platform/dbt/models/staging/cycling/detroit/stg_detroit_bike_segments.sql
+++ b/platform/dbt/models/staging/cycling/detroit/stg_detroit_bike_segments.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (way_id, start_position, end_position)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+
+{{ generate_stg_city_bike_segments_model('detroit') }}

--- a/platform/dbt/models/staging/cycling/detroit/stg_detroit_bike_ways.sql
+++ b/platform/dbt/models/staging/cycling/detroit/stg_detroit_bike_ways.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_bike_ways_model('detroit', include_all_sidewalks=true) }}

--- a/platform/dbt/models/staging/cycling/detroit/stg_detroit_intersection_nodes.sql
+++ b/platform/dbt/models/staging/cycling/detroit/stg_detroit_intersection_nodes.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_intersection_nodes_model('detroit') }}

--- a/platform/dbt/models/staging/cycling/detroit/stg_detroit_osm_bike_infra.sql
+++ b/platform/dbt/models/staging/cycling/detroit/stg_detroit_osm_bike_infra.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_osm_bike_infra_model('detroit', include_all_sidewalks=true) }}

--- a/platform/dbt/models/staging/cycling/detroit/stg_detroit_way_nodes.sql
+++ b/platform/dbt/models/staging/cycling/detroit/stg_detroit_way_nodes.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_way_nodes_model('detroit') }}

--- a/platform/dbt/models/staging/cycling/detroit/stg_detroit_way_segments.sql
+++ b/platform/dbt/models/staging/cycling/detroit/stg_detroit_way_segments.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_way_segments_model('detroit') }}

--- a/platform/profiles.yml
+++ b/platform/profiles.yml
@@ -3,10 +3,10 @@ loci:
   outputs:
     dev:
       type: postgres
-      host: postgis
+      host: "{{ env_var('DBT_PG_HOST', 'postgis') }}"
       user: loci
       password: loci
-      port: 5432
+      port: "{{ env_var('DBT_PG_PORT', '5432') | int }}"
       dbname: loci
       schema: staging
       threads: 12


### PR DESCRIPTION
Changes:
* Refactors `dbt` models that build the Chicago stress-weighted-edges into `macros` that make it easy to stand up pipelines for new cities.
* Uses those macros to stand up a pipeline to make a Detroit stress-weighted-edges model (that doesn't factor in crashes, as I haven't built out such a dataset yet).

Closes #178

The model built successfully. I think it's legal to ride on sidewalks in Detroit but the number of segments in the detroit-stress-weighted-segments model (924680 per the `dbt build` output) makes me think I might want to generally exclude sidewalks or the graph will end up being about 30% larger than Chicago's.

<img width="1426" height="1322" alt="image" src="https://github.com/user-attachments/assets/3e2ac15a-7b9a-4a57-89ff-8f7e23885f10" />
