### PR TITLE
Adds random suffixes to bucket names

### DIFF
--- a/infra/modules/bike-map/main.tf
+++ b/infra/modules/bike-map/main.tf
@@ -9,8 +9,17 @@ locals {
 # S3 — static site bucket
 # -----------------------------------------------------------------------------
 
+resource "random_string" "site_suffix" {
+  length  = 6
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
+}
+
+# Update the two bucket declarations:
 resource "aws_s3_bucket" "site" {
-  bucket = local.resource_name
+  bucket = "${local.resource_name}-${random_string.site_suffix.result}"
 }
 
 resource "aws_s3_bucket_public_access_block" "site" {
@@ -26,8 +35,16 @@ resource "aws_s3_bucket_public_access_block" "site" {
 # S3 — routing graph bucket (Parquet export for Lambda)
 # -----------------------------------------------------------------------------
 
+resource "random_string" "routing_graph_suffix" {
+  length  = 6
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
+}
+
 resource "aws_s3_bucket" "routing_graph" {
-  bucket = "${local.resource_name}-routing-graph"
+  bucket = "${local.resource_name}-routing-graph-${random_string.routing_graph_suffix.result}"
 }
 
 resource "aws_s3_bucket_public_access_block" "routing_graph" {

--- a/infra/modules/route-logger/main.tf
+++ b/infra/modules/route-logger/main.tf
@@ -7,8 +7,19 @@
 # Each request is stored as a JSON object in S3 keyed by timestamp + request ID.
 # The IP address is injected server-side via the mapping template.
 
+resource "random_string" "route_logs_suffix" {
+  length  = 6
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
+}
+
 locals {
-  log_bucket_name = coalesce(var.log_bucket_name, "${var.basename}-${var.environment}-${var.city}-route-logs")
+  log_bucket_name = coalesce(
+    var.log_bucket_name,
+    "${var.basename}-${var.environment}-${var.city}-route-logs-${random_string.route_logs_suffix.result}"
+  )
   resource_prefix = "${var.basename}-${var.environment}-${var.city}-route-logger"
 }
 


### PR DESCRIPTION
Changes:
* Appends a random suffix to bucket names to prevent collisions in names for people who fork the repo and run defaults. (Closes #198)

Did:
1. Removed buckets from `tofu state`, then applied the new IAC config so `tofu` created the new buckets.
2. Deployed Chicago, Detroit, and SF bike maps up through dev, staging, and prod.
3. Sync'd data from old buckets to new buckets, confirmed sync'd data is present in the new bucket.
4. Manually removed the prior buckets (which aren't in `tofu state` anymore so `state` is still accurate)