### PR TITLE
Makes memory configurable per city.

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -47,12 +47,13 @@ module "bike_map" {
     aws.dns       = aws.admin_mgmt
   }
 
-  basename           = var.basename
-  environment        = var.environment
-  city               = each.key
-  zone_id            = local.zone_id
-  zone_name          = local.zone_name
-  extra_cors_origins = var.extra_cors_origins
+  basename                 = var.basename
+  environment              = var.environment
+  city                     = each.key
+  zone_id                  = local.zone_id
+  zone_name                = local.zone_name
+  extra_cors_origins       = var.extra_cors_origins
+  routing_lambda_memory_mb = var.routing_lambda_memory_by_city[each.key]
 }
 
 module "route_logger" {

--- a/infra/modules/bike-map/main.tf
+++ b/infra/modules/bike-map/main.tf
@@ -471,7 +471,7 @@ resource "aws_lambda_function" "routing_api" {
   handler          = "bootstrap"
   architectures    = ["arm64"]
   timeout          = 30
-  memory_size      = 2048
+  memory_size      = var.routing_lambda_memory_mb
 
   environment {
     variables = {

--- a/infra/modules/bike-map/variables.tf
+++ b/infra/modules/bike-map/variables.tf
@@ -51,3 +51,12 @@ variable "extra_cors_origins" {
   type        = list(string)
   default     = []
 }
+
+variable "routing_lambda_memory_mb" {
+  description = "Memory (in MB) allocated to the routing Lambda. Lambda accepts 128–10240 in 1 MB increments."
+  type        = number
+  validation {
+    condition     = var.routing_lambda_memory_mb >= 128 && var.routing_lambda_memory_mb <= 10240
+    error_message = "routing_lambda_memory_mb must be between 128 and 10240."
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -41,3 +41,13 @@ variable "extra_cors_origins" {
   type        = list(string)
   default     = []
 }
+
+variable "routing_lambda_memory_by_city" {
+  description = "Per-city memory (MB) for the routing Lambda. Must include every city in var.cities."
+  type        = map(number)
+  default = {
+    chicago = 512
+    detroit = 512
+    sf      = 1024
+  }
+}


### PR DESCRIPTION
Changes:
* Makes Lambda memory allocation configurable on a per-city basis. (Closes #201)

There are defaults set in OpenTofu and they can be overridden in `<env>.tfvars` files.