### PR TITLE
Iss212 add landing page

### DIFF
--- a/apps/bike-map-landing/config/dev.json
+++ b/apps/bike-map-landing/config/dev.json
@@ -1,0 +1,9 @@
+{
+  "title": "Bike Map",
+  "tagline": "Cycling data, route suggestions, and infrastructure maps for the cities below.",
+  "about_paragraphs": [
+    "Bike Map is a personal project that publishes cycling-focused maps and route suggestions for the cities below. Each city map shows where crashes, thefts, and bike parking are concentrated based on recent public data, and the routing engine prefers streets with better bike infrastructure, lower speed limits, and less severe recent crash history.",
+    "Data comes from OpenStreetMap contributors and from each city's open data portals. This project does not independently verify the accuracy or completeness of any of these sources, and the route suggestions are informational — no substitute for your own judgment while riding."
+  ],
+  "cities": "<cities>"
+}

--- a/apps/bike-map-landing/config/dev.json
+++ b/apps/bike-map-landing/config/dev.json
@@ -1,5 +1,5 @@
 {
-  "title": "Bike Map",
+  "title": "Bike Infrastructure Maps",
   "tagline": "Cycling data, route suggestions, and infrastructure maps for the cities below.",
   "about_paragraphs": [
     "Bike Map is a personal project that publishes cycling-focused maps and route suggestions for the cities below. Each city map shows where crashes, thefts, and bike parking are concentrated based on recent public data, and the routing engine prefers streets with better bike infrastructure, lower speed limits, and less severe recent crash history.",

--- a/apps/bike-map-landing/index.html
+++ b/apps/bike-map-landing/index.html
@@ -1,0 +1,348 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Bike Map</title>
+
+  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+    rel="stylesheet"
+  />
+
+  <style>
+    :root {
+      --bg: #f6f3ec;
+      --paper: #fbf8f1;
+      --ink: #1a1814;
+      --muted: #6b6660;
+      --rule: #d9d3c5;
+      --accent: #2d5a3f;
+      --accent-soft: #e8efe9;
+    }
+
+    * { box-sizing: border-box; }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: "IBM Plex Sans", system-ui, sans-serif;
+      font-size: 16px;
+      line-height: 1.55;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .page {
+      max-width: 880px;
+      margin: 0 auto;
+      padding: 3rem 1.5rem 4rem;
+    }
+
+    header {
+      border-bottom: 1px solid var(--rule);
+      padding-bottom: 1.75rem;
+      margin-bottom: 2.25rem;
+    }
+
+    h1 {
+      font-family: "Instrument Serif", Georgia, serif;
+      font-weight: 400;
+      font-size: clamp(2.6rem, 6vw, 4.25rem);
+      line-height: 1;
+      margin: 0 0 0.5rem 0;
+      letter-spacing: -0.01em;
+    }
+
+    .tagline {
+      color: var(--muted);
+      font-size: 1.05rem;
+      margin: 0;
+      max-width: 38em;
+    }
+
+    section.about {
+      margin-bottom: 2.5rem;
+    }
+
+    section.about p {
+      margin: 0 0 1rem 0;
+      max-width: 38em;
+    }
+
+    section.about p:last-child {
+      margin-bottom: 0;
+    }
+
+    h2 {
+      font-family: "Instrument Serif", Georgia, serif;
+      font-weight: 400;
+      font-style: italic;
+      font-size: 1.6rem;
+      margin: 0 0 1rem 0;
+      color: var(--ink);
+    }
+
+    .map-wrap {
+      position: relative;
+      background: var(--paper);
+      border: 1px solid var(--rule);
+      border-radius: 4px;
+      overflow: hidden;
+      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+    }
+
+    #map {
+      width: 100%;
+      height: 540px;
+    }
+
+    .map-empty {
+      display: none;
+      padding: 4rem 2rem;
+      text-align: center;
+      color: var(--muted);
+      font-style: italic;
+    }
+
+    .map-empty.show {
+      display: block;
+    }
+
+    .map-empty.show + #map {
+      display: none;
+    }
+
+    /* City pin: a small dot at the geographic point, with an always-visible
+       label to the right. The whole thing is an anchor — clicking navigates
+       to the city's bike-map site. */
+    .city-pin {
+      position: relative;
+      display: block;
+      width: 14px;
+      height: 14px;
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    .city-pin .dot {
+      position: absolute;
+      inset: 0;
+      background: var(--accent);
+      border: 2px solid #ffffff;
+      border-radius: 50%;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+      transition: transform 0.12s ease-out;
+    }
+
+    .city-pin .label {
+      position: absolute;
+      left: calc(100% + 6px);
+      top: 50%;
+      transform: translateY(-50%);
+      background: var(--paper);
+      color: var(--ink);
+      padding: 2px 8px;
+      border: 1px solid var(--rule);
+      border-radius: 3px;
+      font-size: 0.85rem;
+      font-weight: 500;
+      white-space: nowrap;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+      transition: background 0.12s ease-out, border-color 0.12s ease-out;
+    }
+
+    .city-pin:hover .dot {
+      transform: scale(1.2);
+    }
+
+    .city-pin:hover .label {
+      background: var(--accent-soft);
+      border-color: var(--accent);
+    }
+
+    .city-list-section {
+      margin-top: 2.25rem;
+    }
+
+    .city-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 0;
+    }
+
+    .city-list li {
+      padding-right: 1.25rem;
+      margin-right: 1.25rem;
+      border-right: 1px solid var(--rule);
+    }
+
+    .city-list li:last-child {
+      border-right: none;
+    }
+
+    .city-list a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .city-list a:hover {
+      text-decoration: underline;
+    }
+
+    footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--rule);
+      color: var(--muted);
+      font-size: 0.85rem;
+    }
+
+    @media (max-width: 600px) {
+      .page { padding: 2rem 1.1rem 3rem; }
+      #map { height: 380px; }
+      .city-list li {
+        padding-right: 0.75rem;
+        margin-right: 0.75rem;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="page">
+    <header>
+      <h1 id="title">Bike Map</h1>
+      <p class="tagline" id="tagline">
+        Cycling data, route suggestions, and infrastructure maps for the cities below.
+      </p>
+    </header>
+
+    <section class="about" id="about" aria-label="About this project"></section>
+
+    <h2>Pick a city</h2>
+    <div class="map-wrap">
+      <div class="map-empty" id="map-empty">No cities are deployed yet.</div>
+      <div id="map" role="region" aria-label="Map of available city bike map sites"></div>
+    </div>
+
+    <section class="city-list-section" aria-label="Available cities">
+      <ul class="city-list" id="city-list"></ul>
+    </section>
+
+    <footer>
+      Map tiles &copy; OpenStreetMap contributors.
+    </footer>
+  </div>
+
+  <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
+  <script>
+    async function init() {
+      const cfg = await fetch("config.json").then((r) => r.json());
+
+      // Title + tagline
+      if (cfg.title) {
+        document.getElementById("title").textContent = cfg.title;
+        document.title = cfg.title;
+      }
+      if (cfg.tagline) {
+        document.getElementById("tagline").textContent = cfg.tagline;
+      }
+
+      // About paragraphs
+      const aboutEl = document.getElementById("about");
+      (cfg.about_paragraphs || []).forEach((text) => {
+        const p = document.createElement("p");
+        p.textContent = text;
+        aboutEl.appendChild(p);
+      });
+
+      // Cities array is injected at deploy time. If it's still a string
+      // (the unreplaced placeholder), treat it as empty so the page
+      // degrades gracefully when opened from a non-deployed copy.
+      const cities = Array.isArray(cfg.cities) ? cfg.cities : [];
+
+      // Fallback / accessibility list
+      const listEl = document.getElementById("city-list");
+      cities.forEach((city) => {
+        const li = document.createElement("li");
+        const a = document.createElement("a");
+        a.href = city.url;
+        a.textContent = city.name;
+        li.appendChild(a);
+        listEl.appendChild(li);
+      });
+
+      // Map
+      if (cities.length === 0) {
+        document.getElementById("map-empty").classList.add("show");
+        return;
+      }
+
+      const map = new maplibregl.Map({
+        container: "map",
+        style: {
+          version: 8,
+          sources: {
+            osm: {
+              type: "raster",
+              tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+              tileSize: 256,
+              attribution: "&copy; OpenStreetMap contributors",
+            },
+          },
+          layers: [{ id: "osm", type: "raster", source: "osm" }],
+        },
+        center: cfg.map_center || [-98.5795, 39.8283],
+        zoom: cfg.map_zoom != null ? cfg.map_zoom : 3,
+      });
+
+      map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "top-right");
+
+      cities.forEach((city) => {
+        const el = document.createElement("a");
+        el.href = city.url;
+        el.className = "city-pin";
+        el.setAttribute("aria-label", `${city.name} bike map`);
+        el.innerHTML = `<span class="dot"></span><span class="label">${escapeHTML(city.name)}</span>`;
+        new maplibregl.Marker({ element: el, anchor: "center" })
+          .setLngLat(city.center)
+          .addTo(map);
+      });
+
+      // Auto-fit bounds to the cities when there's more than one and
+      // the config didn't pin a specific view.
+      if (cities.length > 1 && cfg.map_zoom == null) {
+        const bounds = new maplibregl.LngLatBounds();
+        cities.forEach((c) => bounds.extend(c.center));
+        map.fitBounds(bounds, { padding: 80, maxZoom: 7, duration: 0 });
+      } else if (cities.length === 1 && cfg.map_zoom == null) {
+        map.setCenter(cities[0].center);
+        map.setZoom(10);
+      }
+    }
+
+    function escapeHTML(s) {
+      return String(s).replace(/[&<>"']/g, (c) => ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      }[c]));
+    }
+
+    init().catch((err) => {
+      console.error("Failed to initialize landing page:", err);
+    });
+  </script>
+</body>
+</html>

--- a/apps/bike-map-landing/index.html
+++ b/apps/bike-map-landing/index.html
@@ -1,348 +1,532 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Bike Map</title>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Bike Infrastructure Maps</title>
+<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.20.0/dist/maplibre-gl.css" />
+<script src="https://unpkg.com/maplibre-gl@5.20.0/dist/maplibre-gl.js"></script>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap');
 
-  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
-    rel="stylesheet"
-  />
+  * { margin: 0; padding: 0; box-sizing: border-box; }
 
-  <style>
-    :root {
-      --bg: #f6f3ec;
-      --paper: #fbf8f1;
-      --ink: #1a1814;
-      --muted: #6b6660;
-      --rule: #d9d3c5;
-      --accent: #2d5a3f;
-      --accent-soft: #e8efe9;
-    }
+  html, body {
+    height: 100%;
+    overflow: hidden;
+  }
 
-    * { box-sizing: border-box; }
+  body {
+    font-family: 'DM Sans', sans-serif;
+    background: #0a0a0a;
+    color: #e8e4df;
+  }
 
-    html, body {
-      margin: 0;
-      padding: 0;
-      background: var(--bg);
-      color: var(--ink);
-      font-family: "IBM Plex Sans", system-ui, sans-serif;
-      font-size: 16px;
-      line-height: 1.55;
-      -webkit-font-smoothing: antialiased;
-    }
+  /* ── Top nav bar ──────────────────────────────────────── */
+  #nav {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 56px;
+    z-index: 50;
+    background: rgba(18, 18, 20, 0.92);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+  }
 
-    .page {
-      max-width: 880px;
-      margin: 0 auto;
-      padding: 3rem 1.5rem 4rem;
-    }
+  .nav-brand {
+    font-size: 16px;
+    font-weight: 700;
+    color: #e8e4df;
+    letter-spacing: -0.01em;
+  }
 
-    header {
-      border-bottom: 1px solid var(--rule);
-      padding-bottom: 1.75rem;
-      margin-bottom: 2.25rem;
-    }
+  .nav-menu-btn {
+    width: 36px;
+    height: 36px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    color: rgba(255, 255, 255, 0.7);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: color 0.15s, background 0.15s;
+  }
 
-    h1 {
-      font-family: "Instrument Serif", Georgia, serif;
-      font-weight: 400;
-      font-size: clamp(2.6rem, 6vw, 4.25rem);
-      line-height: 1;
-      margin: 0 0 0.5rem 0;
-      letter-spacing: -0.01em;
-    }
+  .nav-menu-btn:hover {
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+  }
 
-    .tagline {
-      color: var(--muted);
-      font-size: 1.05rem;
-      margin: 0;
-      max-width: 38em;
-    }
+  .nav-menu-btn svg {
+    width: 18px;
+    height: 18px;
+  }
 
-    section.about {
-      margin-bottom: 2.5rem;
-    }
+  /* ── Map ──────────────────────────────────────────────── */
+  #map {
+    position: absolute;
+    top: 56px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
 
-    section.about p {
-      margin: 0 0 1rem 0;
-      max-width: 38em;
-    }
+  /* Nudge MapLibre controls below the nav bar so they don't fight it. */
+  .maplibregl-ctrl-top-right { top: 12px; }
 
-    section.about p:last-child {
-      margin-bottom: 0;
-    }
+  /* ── Empty state ─────────────────────────────────────── */
+  .empty-state {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 5;
+    background: rgba(18, 18, 20, 0.92);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 20px 28px;
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 14px;
+    text-align: center;
+    display: none;
+  }
 
-    h2 {
-      font-family: "Instrument Serif", Georgia, serif;
-      font-weight: 400;
-      font-style: italic;
-      font-size: 1.6rem;
-      margin: 0 0 1rem 0;
-      color: var(--ink);
-    }
+  .empty-state.visible { display: block; }
 
-    .map-wrap {
-      position: relative;
-      background: var(--paper);
-      border: 1px solid var(--rule);
-      border-radius: 4px;
-      overflow: hidden;
-      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
-    }
+  /* ── Overlay (welcome + info) ────────────────────────── */
+  .overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
 
-    #map {
-      width: 100%;
-      height: 540px;
-    }
+  .overlay.visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
 
-    .map-empty {
-      display: none;
-      padding: 4rem 2rem;
-      text-align: center;
-      color: var(--muted);
-      font-style: italic;
-    }
+  .overlay-card {
+    background: rgba(18, 18, 20, 0.96);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 14px;
+    padding: 28px 28px 24px;
+    max-width: 440px;
+    max-height: calc(100vh - 48px);
+    overflow-y: auto;
+    width: calc(100% - 32px);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  }
 
-    .map-empty.show {
-      display: block;
-    }
+  .overlay-card h1 {
+    font-size: 20px;
+    font-weight: 700;
+    color: #e8e4df;
+    margin-bottom: 16px;
+    letter-spacing: -0.01em;
+  }
 
-    .map-empty.show + #map {
-      display: none;
-    }
+  .overlay-card p {
+    font-size: 14px;
+    line-height: 1.65;
+    color: rgba(255, 255, 255, 0.55);
+    margin-bottom: 10px;
+  }
 
-    /* City pin: a small dot at the geographic point, with an always-visible
-       label to the right. The whole thing is an anchor — clicking navigates
-       to the city's bike-map site. */
-    .city-pin {
-      position: relative;
-      display: block;
-      width: 14px;
-      height: 14px;
-      text-decoration: none;
-      cursor: pointer;
-    }
+  .overlay-card p:last-of-type { margin-bottom: 0; }
 
-    .city-pin .dot {
-      position: absolute;
-      inset: 0;
-      background: var(--accent);
-      border: 2px solid #ffffff;
-      border-radius: 50%;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
-      transition: transform 0.12s ease-out;
-    }
+  .overlay-card a {
+    color: #6366f1;
+    text-decoration: none;
+  }
 
-    .city-pin .label {
-      position: absolute;
-      left: calc(100% + 6px);
-      top: 50%;
-      transform: translateY(-50%);
-      background: var(--paper);
-      color: var(--ink);
-      padding: 2px 8px;
-      border: 1px solid var(--rule);
-      border-radius: 3px;
-      font-size: 0.85rem;
-      font-weight: 500;
-      white-space: nowrap;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
-      transition: background 0.12s ease-out, border-color 0.12s ease-out;
-    }
+  .overlay-card a:hover { color: #818cf8; }
 
-    .city-pin:hover .dot {
-      transform: scale(1.2);
-    }
+  /* CTA sits visually separate from the welcome paragraphs */
+  .welcome-cta {
+    margin-top: 14px !important;
+    padding-top: 14px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    color: #e8e4df !important;
+    font-weight: 500 !important;
+  }
 
-    .city-pin:hover .label {
-      background: var(--accent-soft);
-      border-color: var(--accent);
-    }
+  .overlay-close {
+    display: block;
+    width: 100%;
+    margin-top: 20px;
+    padding: 9px 0;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    color: rgba(255, 255, 255, 0.7);
+    font-family: 'DM Sans', sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+  }
 
-    .city-list-section {
-      margin-top: 2.25rem;
-    }
+  .overlay-close:hover {
+    background: rgba(255, 255, 255, 0.14);
+    color: #fff;
+  }
 
-    .city-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem 0;
-    }
+  .overlay-links {
+    display: flex;
+    gap: 16px;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+  }
 
-    .city-list li {
-      padding-right: 1.25rem;
-      margin-right: 1.25rem;
-      border-right: 1px solid var(--rule);
-    }
+  .overlay-links a {
+    font-size: 12px;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.35);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
 
-    .city-list li:last-child {
-      border-right: none;
-    }
+  .overlay-links a:hover { color: rgba(255, 255, 255, 0.7); }
 
-    .city-list a {
-      color: var(--accent);
-      text-decoration: none;
-      font-weight: 500;
-    }
+  /* ── GitHub link ─────────────────────────────────────── */
+  .github-link {
+    position: absolute;
+    bottom: 16px;
+    left: 16px;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    background: rgba(18, 18, 20, 0.75);
+    backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    padding: 6px 12px;
+    color: rgba(255, 255, 255, 0.6);
+    text-decoration: none;
+    font-size: 12px;
+    font-weight: 500;
+    transition: color 0.2s, background 0.2s;
+  }
 
-    .city-list a:hover {
-      text-decoration: underline;
-    }
+  .github-link:hover {
+    color: rgba(255, 255, 255, 0.9);
+    background: rgba(18, 18, 20, 0.88);
+  }
 
-    footer {
-      margin-top: 3rem;
-      padding-top: 1.5rem;
-      border-top: 1px solid var(--rule);
-      color: var(--muted);
-      font-size: 0.85rem;
-    }
-
-    @media (max-width: 600px) {
-      .page { padding: 2rem 1.1rem 3rem; }
-      #map { height: 380px; }
-      .city-list li {
-        padding-right: 0.75rem;
-        margin-right: 0.75rem;
-      }
-    }
-  </style>
+  .github-link svg {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+  }
+</style>
 </head>
-
 <body>
-  <div class="page">
-    <header>
-      <h1 id="title">Bike Map</h1>
-      <p class="tagline" id="tagline">
-        Cycling data, route suggestions, and infrastructure maps for the cities below.
-      </p>
-    </header>
 
-    <section class="about" id="about" aria-label="About this project"></section>
+<header id="nav">
+  <div class="nav-brand" id="nav-brand">Bike Infrastructure Maps</div>
+  <button class="nav-menu-btn" id="info-btn" aria-label="About this project" title="About">
+    <svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+      <line x1="3" y1="5"  x2="15" y2="5"/>
+      <line x1="3" y1="9"  x2="15" y2="9"/>
+      <line x1="3" y1="13" x2="15" y2="13"/>
+    </svg>
+  </button>
+</header>
 
-    <h2>Pick a city</h2>
-    <div class="map-wrap">
-      <div class="map-empty" id="map-empty">No cities are deployed yet.</div>
-      <div id="map" role="region" aria-label="Map of available city bike map sites"></div>
-    </div>
+<div id="map"></div>
 
-    <section class="city-list-section" aria-label="Available cities">
-      <ul class="city-list" id="city-list"></ul>
-    </section>
+<div class="empty-state" id="empty-state">No cities are deployed in this environment yet.</div>
 
-    <footer>
-      Map tiles &copy; OpenStreetMap contributors.
-    </footer>
+<!-- ── Welcome overlay (auto-shown on load) ────────────── -->
+<div class="overlay visible" id="welcome-overlay">
+  <div class="overlay-card">
+    <h1 id="welcome-title">Bike Map</h1>
+    <div id="welcome-body"></div>
+    <p class="welcome-cta" id="welcome-cta">Click any highlighted area on the map to explore that city's data.</p>
+    <button class="overlay-close" id="welcome-close">Got it</button>
   </div>
+</div>
 
-  <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-  <script>
-    async function init() {
-      const cfg = await fetch("config.json").then((r) => r.json());
+<!-- ── Info overlay (hamburger) ────────────────────────── -->
+<div class="overlay" id="info-overlay">
+  <div class="overlay-card">
+    <h1 id="info-title">About</h1>
+    <div id="info-body"></div>
+    <div class="overlay-links">
+      <a href="https://github.com/MattTriano/loci_platform" target="_blank" rel="noopener">Source on GitHub</a>
+    </div>
+    <button class="overlay-close" id="info-close">Close</button>
+  </div>
+</div>
 
-      // Title + tagline
-      if (cfg.title) {
-        document.getElementById("title").textContent = cfg.title;
-        document.title = cfg.title;
-      }
-      if (cfg.tagline) {
-        document.getElementById("tagline").textContent = cfg.tagline;
-      }
+<a class="github-link" href="https://github.com/MattTriano/loci_platform" target="_blank" rel="noopener">
+  <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.64 7.64 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+  Source
+</a>
 
-      // About paragraphs
-      const aboutEl = document.getElementById("about");
-      (cfg.about_paragraphs || []).forEach((text) => {
-        const p = document.createElement("p");
-        p.textContent = text;
-        aboutEl.appendChild(p);
-      });
+<script>
+// ── Configuration ────────────────────────────────────────
+// Defaults are placeholders; real values come from config.json which the
+// deploy task uploads per env. When config.json is missing, malformed,
+// or the cities array hasn't been injected yet, the page still renders
+// (with the empty-state card).
+const CONFIG = {
+  title: 'Bike Map',
+  welcome_paragraphs: [
+    "Bike Map publishes cycling-focused maps and route suggestions for the cities below.",
+  ],
+  welcome_cta: "Click any highlighted area on the map to explore that city's data.",
+  about_paragraphs: [
+    "Bike Map is a personal project that displays cycling-related data and generates route suggestions for the cities below. Each city site shows where crashes, thefts, and bike parking are concentrated based on recent public data, and the routing engine prefers streets with better bike infrastructure, lower speed limits, and less severe recent crash history.",
+    "Data comes from OpenStreetMap contributors and from each city's open data portals. This project does not independently verify the accuracy or completeness of any of these sources, and the route suggestions are informational — no substitute for your own judgment while riding.",
+  ],
+  cities: [],
+};
 
-      // Cities array is injected at deploy time. If it's still a string
-      // (the unreplaced placeholder), treat it as empty so the page
-      // degrades gracefully when opened from a non-deployed copy.
-      const cities = Array.isArray(cfg.cities) ? cfg.cities : [];
+// Indigo, matching link color in the bike-map's About overlay — signals
+// "interactive" without colliding with the data-layer colors.
+const CITY_COLOR = '#6366f1';
 
-      // Fallback / accessibility list
-      const listEl = document.getElementById("city-list");
-      cities.forEach((city) => {
-        const li = document.createElement("li");
-        const a = document.createElement("a");
-        a.href = city.url;
-        a.textContent = city.name;
-        li.appendChild(a);
-        listEl.appendChild(li);
-      });
+let map = null;
+let hoveredCityId = null;
 
-      // Map
-      if (cities.length === 0) {
-        document.getElementById("map-empty").classList.add("show");
-        return;
-      }
+// ── Bootstrap ────────────────────────────────────────────
+loadConfig().then(init);
 
-      const map = new maplibregl.Map({
-        container: "map",
-        style: {
-          version: 8,
-          sources: {
-            osm: {
-              type: "raster",
-              tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-              tileSize: 256,
-              attribution: "&copy; OpenStreetMap contributors",
-            },
-          },
-          layers: [{ id: "osm", type: "raster", source: "osm" }],
-        },
-        center: cfg.map_center || [-98.5795, 39.8283],
-        zoom: cfg.map_zoom != null ? cfg.map_zoom : 3,
-      });
+async function loadConfig() {
+  try {
+    const r = await fetch('config.json');
+    if (r.ok) Object.assign(CONFIG, await r.json());
+  } catch {
+    // fall through to defaults
+  }
+}
 
-      map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "top-right");
+function init() {
+  const cities = Array.isArray(CONFIG.cities) ? CONFIG.cities : [];
+  applyCopy(cities);
+  wireOverlays();
+  wireNav();
+  initMap(cities);
+  if (cities.length === 0) {
+    document.getElementById('empty-state').classList.add('visible');
+  }
+}
 
-      cities.forEach((city) => {
-        const el = document.createElement("a");
-        el.href = city.url;
-        el.className = "city-pin";
-        el.setAttribute("aria-label", `${city.name} bike map`);
-        el.innerHTML = `<span class="dot"></span><span class="label">${escapeHTML(city.name)}</span>`;
-        new maplibregl.Marker({ element: el, anchor: "center" })
-          .setLngLat(city.center)
-          .addTo(map);
-      });
+// ── Copy injection ───────────────────────────────────────
+function applyCopy(cities) {
+  document.title = CONFIG.title;
+  document.getElementById('nav-brand').textContent = CONFIG.title;
+  document.getElementById('welcome-title').textContent = CONFIG.title;
+  document.getElementById('info-title').textContent = `About ${CONFIG.title}`;
 
-      // Auto-fit bounds to the cities when there's more than one and
-      // the config didn't pin a specific view.
-      if (cities.length > 1 && cfg.map_zoom == null) {
-        const bounds = new maplibregl.LngLatBounds();
-        cities.forEach((c) => bounds.extend(c.center));
-        map.fitBounds(bounds, { padding: 80, maxZoom: 7, duration: 0 });
-      } else if (cities.length === 1 && cfg.map_zoom == null) {
-        map.setCenter(cities[0].center);
-        map.setZoom(10);
-      }
+  document.getElementById('welcome-body').innerHTML =
+    (CONFIG.welcome_paragraphs || []).map(p => `<p>${p}</p>`).join('');
+
+  document.getElementById('info-body').innerHTML =
+    (CONFIG.about_paragraphs || []).map(p => `<p>${p}</p>`).join('');
+
+  // CTA only makes sense if there's something to click.
+  const ctaEl = document.getElementById('welcome-cta');
+  if (cities.length === 0) {
+    ctaEl.textContent = 'No cities are deployed in this environment yet — check back soon.';
+  } else {
+    ctaEl.textContent = CONFIG.welcome_cta;
+  }
+}
+
+// ── Overlay wiring ───────────────────────────────────────
+function wireOverlays() {
+  document.getElementById('welcome-close').addEventListener('click', () => {
+    document.getElementById('welcome-overlay').classList.remove('visible');
+  });
+  document.getElementById('welcome-overlay').addEventListener('click', (e) => {
+    if (e.target === e.currentTarget) e.currentTarget.classList.remove('visible');
+  });
+
+  document.getElementById('info-close').addEventListener('click', () => {
+    document.getElementById('info-overlay').classList.remove('visible');
+  });
+  document.getElementById('info-overlay').addEventListener('click', (e) => {
+    if (e.target === e.currentTarget) e.currentTarget.classList.remove('visible');
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    document.querySelectorAll('.overlay.visible').forEach(o => o.classList.remove('visible'));
+  });
+}
+
+function wireNav() {
+  document.getElementById('info-btn').addEventListener('click', () => {
+    document.getElementById('info-overlay').classList.add('visible');
+  });
+}
+
+// ── Map init ─────────────────────────────────────────────
+function initMap(cities) {
+  map = new maplibregl.Map({
+    container: 'map',
+    style: 'https://tiles.openfreemap.org/styles/liberty',
+    center: defaultMapCenter(cities),
+    zoom: 3,
+    attributionControl: true,
+  });
+
+  map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
+
+  map.on('load', () => {
+    if (cities.length === 0) return;
+    addCityLayer(cities);
+    fitToCities(cities);
+  });
+}
+
+function defaultMapCenter(cities) {
+  if (cities.length === 0) return [-98.5795, 39.8283];  // geographic center of US
+  const lngs = cities.map(c => c.center[0]);
+  const lats = cities.map(c => c.center[1]);
+  return [
+    (Math.min(...lngs) + Math.max(...lngs)) / 2,
+    (Math.min(...lats) + Math.max(...lats)) / 2,
+  ];
+}
+
+// ── City layer ───────────────────────────────────────────
+function bboxToPolygon(bbox) {
+  // bbox shape matches the Python BBox dataclass: {south, west, north, east}
+  const { south: s, west: w, north: n, east: e } = bbox;
+  return {
+    type: 'Polygon',
+    coordinates: [[[w, s], [e, s], [e, n], [w, n], [w, s]]],
+  };
+}
+
+function addCityLayer(cities) {
+  const features = cities.map((city, i) => ({
+    type: 'Feature',
+    id: i,  // numeric id required for feature-state hover
+    properties: {
+      id: city.id,
+      name: city.name,
+      url: city.url,
+    },
+    geometry: bboxToPolygon(city.bbox),
+  }));
+
+  map.addSource('cities', {
+    type: 'geojson',
+    data: { type: 'FeatureCollection', features },
+  });
+
+  map.addLayer({
+    id: 'city-fill',
+    type: 'fill',
+    source: 'cities',
+    paint: {
+      'fill-color': CITY_COLOR,
+      'fill-opacity': [
+        'case',
+        ['boolean', ['feature-state', 'hover'], false], 0.35,
+        0.15,
+      ],
+    },
+  });
+
+  map.addLayer({
+    id: 'city-outline',
+    type: 'line',
+    source: 'cities',
+    paint: {
+      'line-color': CITY_COLOR,
+      'line-width': [
+        'case',
+        ['boolean', ['feature-state', 'hover'], false], 3,
+        2,
+      ],
+      'line-opacity': 0.9,
+    },
+  });
+
+  // City name labels centered inside each bbox. Halo for legibility
+  // against the variable base-map content underneath.
+  map.addLayer({
+    id: 'city-label',
+    type: 'symbol',
+    source: 'cities',
+    layout: {
+      'text-field': ['get', 'name'],
+      'text-font': ['Noto Sans Bold'],
+      'text-size': 16,
+      'text-anchor': 'center',
+      'symbol-placement': 'point',
+    },
+    paint: {
+      'text-color': '#ffffff',
+      'text-halo-color': 'rgba(0, 0, 0, 0.85)',
+      'text-halo-width': 2,
+    },
+  });
+
+  map.on('mousemove', 'city-fill', (e) => {
+    if (!e.features.length) return;
+    const id = e.features[0].id;
+    if (hoveredCityId !== null && hoveredCityId !== id) {
+      map.setFeatureState({ source: 'cities', id: hoveredCityId }, { hover: false });
     }
+    hoveredCityId = id;
+    map.setFeatureState({ source: 'cities', id }, { hover: true });
+    map.getCanvas().style.cursor = 'pointer';
+  });
 
-    function escapeHTML(s) {
-      return String(s).replace(/[&<>"']/g, (c) => ({
-        "&": "&amp;",
-        "<": "&lt;",
-        ">": "&gt;",
-        '"': "&quot;",
-        "'": "&#39;",
-      }[c]));
+  map.on('mouseleave', 'city-fill', () => {
+    if (hoveredCityId !== null) {
+      map.setFeatureState({ source: 'cities', id: hoveredCityId }, { hover: false });
     }
+    hoveredCityId = null;
+    map.getCanvas().style.cursor = '';
+  });
 
-    init().catch((err) => {
-      console.error("Failed to initialize landing page:", err);
-    });
-  </script>
+  map.on('click', 'city-fill', (e) => {
+    if (!e.features.length) return;
+    const url = e.features[0].properties.url;
+    if (url) window.location.href = url;
+  });
+}
+
+function fitToCities(cities) {
+  const bounds = new maplibregl.LngLatBounds();
+  for (const c of cities) {
+    bounds.extend([c.bbox.west, c.bbox.south]);
+    bounds.extend([c.bbox.east, c.bbox.north]);
+  }
+  map.fitBounds(bounds, {
+    padding: { top: 80, bottom: 60, left: 60, right: 60 },
+    maxZoom: 7,
+    duration: 0,
+  });
+}
+</script>
+
 </body>
 </html>

--- a/apps/bike-map/config/dev/chicago.json
+++ b/apps/bike-map/config/dev/chicago.json
@@ -5,6 +5,12 @@
   "routing_api_key": "<routing_api_key>",
   "map_center": [-87.6298, 41.8781],
   "map_zoom": 11,
+  "map_bbox": {
+    "south": 41.62,
+    "west": -87.97,
+    "north": 42.05,
+    "east": -87.50
+  },
   "layers": [
     {
       "id": "crashes",

--- a/apps/bike-map/config/dev/detroit.json
+++ b/apps/bike-map/config/dev/detroit.json
@@ -5,6 +5,12 @@
   "routing_api_key": "<routing_api_key>",
   "map_center": [-83.099, 42.380],
   "map_zoom": 11,
+  "map_bbox": {
+    "south": 42.18,
+    "west": -83.40,
+    "north": 42.56,
+    "east": -82.84
+  },
   "layers": [
     {
       "id": "thefts",

--- a/apps/bike-map/config/dev/sf.json
+++ b/apps/bike-map/config/dev/sf.json
@@ -5,6 +5,12 @@
   "routing_api_key": "<routing_api_key>",
   "map_center": [-122.43, 37.75],
   "map_zoom": 11,
+  "map_bbox": {
+    "south": 37.61,
+    "west": -122.53,
+    "north": 37.84,
+    "east": -122.35
+  },
   "layers": [
     {
       "id": "thefts",

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -37,6 +37,22 @@ locals {
   zone_name = var.environment == "prod" ? var.base_domain : module.dns_zone[0].zone_name
 }
 
+module "bike_map_landing" {
+  source = "./modules/bike-map-landing"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+    aws.dns       = aws.admin_mgmt
+  }
+
+  basename    = var.basename
+  environment = var.environment
+  zone_id     = local.zone_id
+  zone_name   = local.zone_name
+  cities      = var.cities
+}
+
 module "bike_map" {
   source   = "./modules/bike-map"
   for_each = toset(var.cities)

--- a/infra/modules/bike-map-landing/main.tf
+++ b/infra/modules/bike-map-landing/main.tf
@@ -1,0 +1,239 @@
+# loci_platform/infra/modules/bike-map-landing/main.tf
+locals {
+  resource_name = "${var.basename}-${var.environment}-bike-map-landing"
+  # The landing page lives at the apex of the env's zone:
+  #   prod    → bikeinfra.com
+  #   staging → staging.bikeinfra.com
+  #   dev     → dev.bikeinfra.com
+  domain = var.zone_name
+}
+
+# -----------------------------------------------------------------------------
+# S3 — static site bucket
+# -----------------------------------------------------------------------------
+
+resource "random_string" "site_suffix" {
+  length  = 6
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
+}
+
+resource "aws_s3_bucket" "site" {
+  bucket = "${local.resource_name}-${random_string.site_suffix.result}"
+}
+
+resource "aws_s3_bucket_public_access_block" "site" {
+  bucket                  = aws_s3_bucket.site.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+
+# -----------------------------------------------------------------------------
+# CloudFront
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudfront_origin_access_control" "site" {
+  name                              = local.resource_name
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "site" {
+  enabled             = true
+  default_root_object = "index.html"
+  aliases             = [local.domain]
+
+  origin {
+    domain_name              = aws_s3_bucket.site.bucket_regional_domain_name
+    origin_id                = "s3"
+    origin_access_control_id = aws_cloudfront_origin_access_control.site.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "s3"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.site.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+}
+
+resource "aws_s3_bucket_policy" "site" {
+  bucket = aws_s3_bucket.site.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontRead"
+        Effect    = "Allow"
+        Principal = { Service = "cloudfront.amazonaws.com" }
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.site.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.site.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+
+# -----------------------------------------------------------------------------
+# ACM certificate (must be in us-east-1 for CloudFront)
+# -----------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "site" {
+  provider          = aws.us_east_1
+  domain_name       = local.domain
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  provider = aws.dns
+  for_each = {
+    for dvo in aws_acm_certificate.site.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = var.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 300
+  records = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "site" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.site.arn
+  validation_record_fqdns = [for r in aws_route53_record.cert_validation : r.fqdn]
+}
+
+
+# -----------------------------------------------------------------------------
+# Route53 — apex A record pointing to CloudFront
+# -----------------------------------------------------------------------------
+
+resource "aws_route53_record" "site" {
+  provider = aws.dns
+  zone_id  = var.zone_id
+  name     = local.domain
+  type     = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+
+# -----------------------------------------------------------------------------
+# IAM — deploy user for S3 sync + CloudFront invalidation
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_user" "deploy" {
+  name = "${local.resource_name}-deploy"
+}
+
+resource "aws_iam_user_policy" "deploy" {
+  name = "${local.resource_name}-deploy"
+  user = aws_iam_user.deploy.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "S3SyncSite"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:DeleteObject", "s3:ListBucket"]
+        Resource = [aws_s3_bucket.site.arn, "${aws_s3_bucket.site.arn}/*"]
+      },
+      {
+        Sid      = "CloudFrontInvalidate"
+        Effect   = "Allow"
+        Action   = "cloudfront:CreateInvalidation"
+        Resource = aws_cloudfront_distribution.site.arn
+      },
+      {
+        Sid      = "ReadLandingSSM"
+        Effect   = "Allow"
+        Action   = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
+        Resource = "arn:aws:ssm:*:*:parameter/${var.basename}/${var.environment}/bike-map-landing/*"
+      }
+    ]
+  })
+}
+
+
+# -----------------------------------------------------------------------------
+# SSM Parameter Store
+#
+# Per-env values for the landing page. Path layout:
+#   /<basename>/<environment>/bike-map-landing/<name>
+#
+# The cities list is jsonencode(var.cities) so the deploy task can
+# json.loads() it directly. Tofu re-writes this on every apply, so
+# whatever is in var.cities at apply time is what the landing page
+# will surface on the next deploy.
+# -----------------------------------------------------------------------------
+
+locals {
+  ssm_prefix = "/${var.basename}/${var.environment}/bike-map-landing"
+}
+
+resource "aws_ssm_parameter" "app_file_bucket" {
+  name  = "${local.ssm_prefix}/app-file-bucket"
+  type  = "String"
+  value = aws_s3_bucket.site.bucket
+}
+
+resource "aws_ssm_parameter" "cloudfront_dist_id" {
+  name  = "${local.ssm_prefix}/cloudfront-dist-id"
+  type  = "String"
+  value = aws_cloudfront_distribution.site.id
+}
+
+resource "aws_ssm_parameter" "zone_name" {
+  name  = "${local.ssm_prefix}/zone-name"
+  type  = "String"
+  value = var.zone_name
+}
+
+resource "aws_ssm_parameter" "cities" {
+  name  = "${local.ssm_prefix}/cities"
+  type  = "String"
+  value = jsonencode(var.cities)
+}

--- a/infra/modules/bike-map-landing/outputs.tf
+++ b/infra/modules/bike-map-landing/outputs.tf
@@ -1,0 +1,25 @@
+# loci_platform/infra/modules/bike-map-landing/outputs.tf
+output "s3_bucket_name" {
+  description = "S3 bucket name for landing site content."
+  value       = aws_s3_bucket.site.bucket
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID for cache invalidation."
+  value       = aws_cloudfront_distribution.site.id
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name."
+  value       = aws_cloudfront_distribution.site.domain_name
+}
+
+output "deploy_user_name" {
+  description = "IAM deploy user name."
+  value       = aws_iam_user.deploy.name
+}
+
+output "site_url" {
+  description = "Public URL of the landing page."
+  value       = "https://${local.domain}"
+}

--- a/infra/modules/bike-map-landing/variables.tf
+++ b/infra/modules/bike-map-landing/variables.tf
@@ -1,0 +1,29 @@
+# loci_platform/infra/modules/bike-map-landing/variables.tf
+variable "basename" {
+  description = "Base name for resource naming."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev, staging, prod)."
+  type        = string
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Invalid environment. Must be dev, staging, or prod."
+  }
+}
+
+variable "zone_id" {
+  description = "Route53 hosted zone ID for DNS records."
+  type        = string
+}
+
+variable "zone_name" {
+  description = "Route53 hosted zone domain name. The landing page is served at the apex of this zone (e.g. 'dev.bikeinfra.com' or 'bikeinfra.com')."
+  type        = string
+}
+
+variable "cities" {
+  description = "List of city identifiers deployed in this environment. Written to SSM so the landing deploy task can read it."
+  type        = list(string)
+}

--- a/infra/modules/bike-map-landing/versions.tf
+++ b/infra/modules/bike-map-landing/versions.tf
@@ -1,0 +1,12 @@
+# loci_platform/infra/modules/bike-map-landing/versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.us_east_1, aws.dns]
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -4,6 +4,11 @@ output "dns_zone_name_servers" {
   value       = var.environment == "prod" ? null : module.dns_zone[0].name_servers
 }
 
+output "bike_map_landing_url" {
+  description = "Public URL of the bike-map landing page."
+  value       = module.bike_map_landing.site_url
+}
+
 output "bike_map_urls" {
   description = "Public URLs of the bike map, per city."
   value       = { for c, m in module.bike_map : c => m.site_url }

--- a/platform/airflow/dags/dag_files/bike_map/refresh_bike_map_landing.py
+++ b/platform/airflow/dags/dag_files/bike_map/refresh_bike_map_landing.py
@@ -1,0 +1,36 @@
+# loci_platform/platform/airflow/dags/dag_files/bike_map/refresh_bike_map_landing.py
+"""Refresh the bike-map landing page: deploy static site + injected config to S3."""
+
+import logging
+from datetime import datetime
+
+from airflow.sdk import Param, dag
+from loci.environments import VALID_ENVS
+from loci.tasks.deploy_tasks import deploy_bike_map_landing
+
+ENV_TEMPLATE = "{{ params.env }}"
+
+task_logger = logging.getLogger("airflow.task")
+
+
+@dag(
+    dag_id="refresh_bike_map_landing",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["bike-map", "landing"],
+    params={
+        "env": Param(
+            "dev",
+            type="string",
+            enum=list(VALID_ENVS),
+            title="Target environment",
+            description="Which AWS account to deploy the landing page to.",
+        ),
+    },
+)
+def refresh_bike_map_landing():
+    deploy_bike_map_landing(env=ENV_TEMPLATE, task_logger=task_logger)
+
+
+refresh_bike_map_landing()

--- a/platform/airflow/dags/loci/environments.py
+++ b/platform/airflow/dags/loci/environments.py
@@ -26,6 +26,7 @@ of the process, so DAG tasks share a single SSM round-trip.
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from functools import cache
@@ -41,6 +42,24 @@ VALID_CITIES = (
 )  # extend as we onboard more cities
 
 _SSM_PREFIX = "/loci-infra"
+
+
+@dataclass(frozen=True)
+class LandingEnvConfig:
+    """Env-scoped (non-city) config for the bike-map landing page.
+
+    Loaded from SSM at /loci-infra/<env>/bike-map-landing/ by the
+    bike-map-landing tofu module. Same role as EnvConfig but per-env
+    rather than per-(env, city).
+    """
+
+    name: str
+    aws_profile: str | None
+    aws_region: str
+    app_file_bucket: str
+    cloudfront_dist_id: str
+    zone_name: str
+    cities: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -155,4 +174,42 @@ def get_env(env: str, city: str) -> EnvConfig:
         log_endpoint=_require_ssm(route_logger, "log-endpoint", route_logger_path),
         dbt_target=env,
         marts_schema=marts_schema,
+    )
+
+
+@cache
+def get_env_apex(env: str) -> LandingEnvConfig:
+    """Load the env-scoped landing config from SSM.
+
+    Cached for the lifetime of the process. Mirrors get_env(env, city)
+    but reads from the per-env landing prefix populated by the
+    bike-map-landing tofu module.
+    """
+    if env not in VALID_ENVS:
+        raise ValueError(f"Unknown env: {env!r}. Expected one of {VALID_ENVS}.")
+
+    env_suffix = env.upper()
+    aws_profile = os.environ.get(f"AWS_PROFILE_{env_suffix}")
+    aws_region = _require_env("BIKE_MAP_AWS_REGION", env_suffix)
+
+    session_kwargs: dict = {"region_name": aws_region}
+    if aws_profile:
+        session_kwargs["profile_name"] = aws_profile
+    session = boto3.Session(**session_kwargs)
+
+    landing_path = f"{_SSM_PREFIX}/{env}/bike-map-landing"
+    landing = load_parameters_by_path(session, landing_path)
+
+    # `cities` is jsonencode(var.cities) in tofu — decode it back into a
+    # tuple so the frozen dataclass stays hashable.
+    cities = tuple(json.loads(_require_ssm(landing, "cities", landing_path)))
+
+    return LandingEnvConfig(
+        name=env,
+        aws_profile=aws_profile,
+        aws_region=aws_region,
+        app_file_bucket=_require_ssm(landing, "app-file-bucket", landing_path),
+        cloudfront_dist_id=_require_ssm(landing, "cloudfront-dist-id", landing_path),
+        zone_name=_require_ssm(landing, "zone-name", landing_path),
+        cities=cities,
     )

--- a/platform/airflow/dags/loci/tasks/deploy_tasks.py
+++ b/platform/airflow/dags/loci/tasks/deploy_tasks.py
@@ -274,10 +274,15 @@ def _build_cities_array(
     """Build the cities array for the landing page config.
 
     For each city in city_ids, reads its per-city config from the bike-map
-    app dir to pick up city_name and map_center. The URL is constructed
-    from zone_name. Raises if any per-city config is missing or malformed
-    — running the landing deploy with a city in the SSM list but no
-    config on disk is a deployment-ordering bug we want to fail loudly.
+    app dir to pick up city_name, map_center, and map_bbox. The URL is
+    constructed from zone_name. Raises if any per-city config is missing
+    or malformed — running the landing deploy with a city in the SSM
+    list but no config on disk is a deployment-ordering bug we want to
+    fail loudly.
+
+    map_bbox is expected as an object {"south", "west", "north", "east"}
+    mirroring the loci.geometry.BBox dataclass, so the field meanings
+    are unambiguous wherever this shape shows up.
     """
     cities = []
     for city_id in city_ids:
@@ -295,11 +300,15 @@ def _build_cities_array(
                     "id": city_id,
                     "name": city_config["city_name"],
                     "center": city_config["map_center"],
+                    "bbox": city_config["map_bbox"],
                     "url": f"https://{city_id}.{zone_name}",
                 }
             )
         except KeyError as e:
-            raise KeyError(f"Per-city config {config_path} is missing required field {e}") from e
+            raise KeyError(
+                f"Per-city config {config_path} is missing required field {e}. "
+                f"Landing page needs city_name, map_center, and map_bbox."
+            ) from e
     logger.info("Built cities array with %d entries", len(cities))
     return cities
 
@@ -340,9 +349,6 @@ def _sync_bike_map_landing_config(cfg: "LandingEnvConfig", logger: Logger) -> di
         "cities_count": len(cities),
         "source": str(config_path),
     }
-
-
-# ── New Airflow task ───────────────────────────────────────────────────────
 
 
 @task

--- a/platform/airflow/dags/loci/tasks/deploy_tasks.py
+++ b/platform/airflow/dags/loci/tasks/deploy_tasks.py
@@ -27,8 +27,9 @@ from pathlib import Path
 from airflow.sdk import task
 from loci.aws import get_boto_session
 from loci.deploy import upload_file_to_s3
-from loci.environments import EnvConfig, get_env
+from loci.environments import EnvConfig, LandingEnvConfig, get_env, get_env_apex
 
+BIKE_MAP_LANDING_APP_DIR = "/opt/airflow/app-files/bike-map-landing"
 BIKE_MAP_APP_DIR = "/opt/airflow/app-files/bike-map"
 BIKE_MAP_EXPORT_DIR_BASE = "/opt/airflow/exports/bike-map"
 ROUTING_LAMBDA_ZIP = Path("/opt/airflow/build/routing/routing-lambda.zip")
@@ -264,4 +265,113 @@ def deploy_lambda(env: str, city: str, task_logger: Logger) -> dict:
         "lambda_arn": cfg.routing_lambda_arn,
         "zip_built_at": mtime_iso,
         "last_update_status": response.get("LastUpdateStatus"),
+    }
+
+
+def _build_cities_array(
+    env: str, city_ids: list[str], zone_name: str, logger: Logger
+) -> list[dict]:
+    """Build the cities array for the landing page config.
+
+    For each city in city_ids, reads its per-city config from the bike-map
+    app dir to pick up city_name and map_center. The URL is constructed
+    from zone_name. Raises if any per-city config is missing or malformed
+    — running the landing deploy with a city in the SSM list but no
+    config on disk is a deployment-ordering bug we want to fail loudly.
+    """
+    cities = []
+    for city_id in city_ids:
+        config_path = Path(BIKE_MAP_APP_DIR) / "config" / env / f"{city_id}.json"
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"Per-city config not found for landing page: {config_path}. "
+                f"Add the config or remove '{city_id}' from var.cities."
+            )
+        with config_path.open() as f:
+            city_config = json.load(f)
+        try:
+            cities.append(
+                {
+                    "id": city_id,
+                    "name": city_config["city_name"],
+                    "center": city_config["map_center"],
+                    "url": f"https://{city_id}.{zone_name}",
+                }
+            )
+        except KeyError as e:
+            raise KeyError(f"Per-city config {config_path} is missing required field {e}") from e
+    logger.info("Built cities array with %d entries", len(cities))
+    return cities
+
+
+def _sync_bike_map_landing_config(cfg: "LandingEnvConfig", logger: Logger) -> dict:
+    """Upload the env-specific landing config.json to S3 with cities injected.
+
+    Reads config/<env>.json from the landing app dir, fills in the cities
+    array using the SSM-sourced city list + per-city configs, and uploads
+    the result as config.json at the root of the landing S3 bucket.
+    """
+    config_path = Path(BIKE_MAP_LANDING_APP_DIR) / "config" / f"{cfg.name}.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Landing config file not found: {config_path}")
+
+    with config_path.open() as f:
+        config = json.load(f)
+
+    cities = _build_cities_array(cfg.name, cfg.cities, cfg.zone_name, logger)
+    config["cities"] = cities
+
+    s3 = get_boto_session(cfg).client("s3")
+    logger.info(
+        "Uploading landing config → s3://%s/config.json (from %s, %d cities)",
+        cfg.app_file_bucket,
+        config_path,
+        len(cities),
+    )
+    s3.put_object(
+        Bucket=cfg.app_file_bucket,
+        Key="config.json",
+        Body=json.dumps(config, indent=2).encode("utf-8"),
+        ContentType="application/json",
+    )
+    return {
+        "bucket": cfg.app_file_bucket,
+        "environment": cfg.name,
+        "cities_count": len(cities),
+        "source": str(config_path),
+    }
+
+
+# ── New Airflow task ───────────────────────────────────────────────────────
+
+
+@task
+def deploy_bike_map_landing(env: str, task_logger: Logger) -> dict:
+    """Sync the bike-map landing page to S3 and invalidate the CloudFront cache.
+
+    Reads the list of deployed cities from SSM (provisioned by tofu) and
+    builds the landing config from the per-city configs on disk.
+    """
+    cfg = get_env_apex(env)
+
+    # _sync_to_s3 already skips the config/ subdir via SKIP_DIRS, so the
+    # raw config/<env>.json doesn't get uploaded — only the post-processed
+    # version written by _sync_bike_map_landing_config below.
+    file_count = _sync_to_s3([BIKE_MAP_LANDING_APP_DIR], cfg, task_logger)
+    task_logger.info("Uploaded %d landing files to s3://%s", file_count, cfg.app_file_bucket)
+
+    conf_log = _sync_bike_map_landing_config(cfg, task_logger)
+    task_logger.info(
+        "Uploaded landing config for env=%s with %d cities",
+        conf_log["environment"],
+        conf_log["cities_count"],
+    )
+
+    invalidation_id = _invalidate_cloudfront(cfg, task_logger)
+
+    return {
+        "bucket": cfg.app_file_bucket,
+        "files_uploaded": file_count,
+        "cities_count": conf_log["cities_count"],
+        "invalidation_id": invalidation_id,
     }

--- a/platform/docker-compose.yaml
+++ b/platform/docker-compose.yaml
@@ -89,6 +89,7 @@ x-airflow-common:
     - ./dbt:/opt/airflow/dbt:U
     - ./profiles.yml:/home/airflow/.dbt/profiles.yml
     - ../apps/bike-map:/opt/airflow/app-files/bike-map:ro
+    - ../apps/bike-map-landing:/opt/airflow/app-files/bike-map-landing:ro
     - ../services/routing/build-output:/opt/airflow/build/routing:ro
     - ~/.aws/config:/home/airflow/.aws/config:ro
     - ~/.aws/sso:/home/airflow/.aws/sso:ro


### PR DESCRIPTION
Changes:
* Adds a landing page for the site that links to all of the implemented bike-infra maps. Closes #212 
    * Adds AWS resources in `opentofu` to support the landing page
    * Adds a new index.html page with a similar style to the city specific bike-infra pages.
    * Now requires city configs include the bounding box (in the same order as the `BBox` class) so that the front page can show the bbox region.

Deployed landing page to dev env.

<img width="2126" height="802" alt="image" src="https://github.com/user-attachments/assets/20a83072-a4f4-4449-9dd4-22bd72deeece" />

<img width="3356" height="2160" alt="image" src="https://github.com/user-attachments/assets/19135409-83ce-4976-a97f-0e4669d979ea" />
