### PR TITLE
Expands SF BBox and adjusts memory usage after deployment.

### DIFF
--- a/apps/bike-map/config/dev/sf.json
+++ b/apps/bike-map/config/dev/sf.json
@@ -3,13 +3,13 @@
   "log_endpoint": "<log_endpoint>",
   "routing_api_url": "<routing_api_url>",
   "routing_api_key": "<routing_api_key>",
-  "map_center": [-122.43, 37.75],
+  "map_center": [-122.16, 37.59],
   "map_zoom": 11,
   "map_bbox": {
-    "south": 37.61,
-    "west": -122.53,
-    "north": 37.84,
-    "east": -122.35
+    "south": 37.18,
+    "west": -122.59,
+    "north": 38.00,
+    "east": -121.73
   },
   "layers": [
     {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -46,8 +46,8 @@ variable "routing_lambda_memory_by_city" {
   description = "Per-city memory (MB) for the routing Lambda. Must include every city in var.cities."
   type        = map(number)
   default = {
-    chicago = 512
-    detroit = 512
-    sf      = 1024
+    chicago = 400
+    detroit = 400
+    sf      = 600
   }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -46,8 +46,8 @@ variable "routing_lambda_memory_by_city" {
   description = "Per-city memory (MB) for the routing Lambda. Must include every city in var.cities."
   type        = map(number)
   default = {
-    chicago = 400
-    detroit = 400
-    sf      = 600
+    chicago = 1024
+    detroit = 1024
+    sf      = 1536
   }
 }

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -80,8 +80,8 @@ SAN_FRANCISCO_BIKEINDEX_BIKE_THEFTS_SPEC = BikeIndexDatasetSpec(
     name="sf_bikeindex_bike_thefts",
     target_table="sf_bikeindex_bike_thefts",
     entity_key=["id"],
-    location="San Francisco, CA",
-    distance=15,
+    location="37.59,-122.16",
+    distance=35,
     stolenness="proximity",
 )
 
@@ -411,8 +411,7 @@ MADISON_BBOX = BBox(42.96, -89.60, 43.21, -89.21)
 NEW_ORLEANS_BBOX = BBox(29.83, -90.22, 30.19, -89.60)
 NEW_YORK_CITY_BBOX = BBox(40.52, -74.05, 40.93, -73.67)
 PORTLAND_BBOX = BBox(45.41, -122.86, 45.66, -122.46)
-SAN_FRANCISCO_BBOX = BBox(37.61, -122.53, 37.84, -122.35)
-SF_BAY_AREA_BBOX = BBox(37.18, -122.59, 37.88, -121.73)
+SAN_FRANCISCO_BBOX = BBox(37.18, -122.59, 38.00, -121.73)
 SEATTLE_BBOX = BBox(47.47, -122.48, 47.78, -122.04)
 TORONTO_BBOX = BBox(43.48, -79.79, 43.95, -78.84)
 WASHINGTON_DC_BBOX = BBox(38.85, -77.09, 38.97, -76.93)


### PR DESCRIPTION
Changes:
* Significantly increases the size of the SF bounding box to cover the entire bay area. Closes #209 
    * It takes a little time (5 to 9 seconds) to get a route along the entire corner-to-corner length of the bounding box (which is about 115 miles), but I'd say that's not unreasonable.
    * I'm rerunning the collection of BikeIndex bike theft data to cover the newly added area, and that collection run will take a couple hours, at which point I'll do a refresh.

<img width="1416" height="1276" alt="Screenshot from 2026-05-19 14-54-21" src="https://github.com/user-attachments/assets/e093f07a-6e11-4417-a2ab-698dc14b5f63" />
<img width="1396" height="794" alt="Screenshot from 2026-05-19 15-05-07" src="https://github.com/user-attachments/assets/63838b1c-6dd0-4573-9605-a5347f316a7f" />


Here's what the SF map looks like now, with the full BikeIndex bike theft coverage.
<img width="3356" height="2160" alt="image" src="https://github.com/user-attachments/assets/d0c4403a-a1c9-4a82-a34f-9606916bea97" />

