### PR TITLE
Iss216 219 222 add nola madison and dc maps

### DIFF
--- a/apps/bike-map/config/dev/dc.json
+++ b/apps/bike-map/config/dev/dc.json
@@ -1,0 +1,69 @@
+{
+  "city_name": "Washington, DC",
+  "log_endpoint": "<log_endpoint>",
+  "routing_api_url": "<routing_api_url>",
+  "routing_api_key": "<routing_api_key>",
+  "map_center": [-77.01, 38.91],
+  "map_zoom": 11,
+  "map_bbox": {
+    "south": 38.85,
+    "west": -77.09,
+    "north": 38.97,
+    "east": -76.93
+  },
+  "layers": [
+    {
+      "id": "thefts",
+      "label": "Thefts",
+      "color": "#f59e0b",
+      "file": "data/thefts.geojson",
+      "popup_title": "Thefts",
+      "popup_fields": [
+        {"key": "source", "label": "Source"},
+        {"key": "theft_date", "label": "Theft Date"},
+        {"key": "theft_year", "label": "Theft Year"},
+        {"key": "theft_hour", "label": "Theft Hour", "fmt": "hour"},
+        {"key": "bike_title", "label": "Bike Title"},
+        {"key": "bike_description", "label": "Bike Description"},
+        {"key": "theft_description", "label": "Theft Description"},
+        {"key": "locking_description", "label": "Locking Description"},
+        {"key": "lock_defeat_description", "label": "Lock Defeat Description"},
+        {"key": "theft_status", "label": "Theft Status"}
+      ],
+      "default_visible": true,
+      "cluster_max_zoom": 13,
+      "cluster_radius": 45,
+      "point_radius": 5,
+      "date_field": "theft_date"
+    },
+    {
+      "id": "parking",
+      "label": "Parking",
+      "color": "#22c55e",
+      "file": "data/parking.geojson",
+      "popup_title": "Parking",
+      "popup_fields": [
+        {"key": "type", "label": "Type"},
+        {"key": "capacity", "label": "Capacity"},
+        {"key": "covered", "label": "Covered"},
+        {"key": "indoor", "label": "Indoor"},
+        {"key": "fee", "label": "Fee"},
+        {"key": "lit", "label": "Lit"},
+        {"key": "operator", "label": "Operator"},
+        {"key": "access", "label": "Access"}
+      ],
+      "default_visible": true,
+      "cluster_max_zoom": 13,
+      "cluster_radius": 45,
+      "point_radius": 5
+    }
+  ],
+  "about_paragraphs": [
+    "Washington DC Bike Map helps you explore cycling conditions around the city.",
+    "Routes prefer streets with better bike infrastructure, lower speed limits, and less severe recent crash history, even if that means a slightly longer ride. We recommend always wearing a helmet while riding.",
+    "Routes are generated using OpenStreetMap data that may be incomplete or outdated. Route suggestions are informational and are no substitute for your own judgment while riding."
+  ],
+  "terms_what_is": "Washington DC Bike Map is a personal project that displays cycling-related data for the Washington DC area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
+  "terms_data_sources": "Map data comes from OpenStreetMap contributors and is subject to the <a href=\"https://opendatacommons.org/licenses/odbl/\" target=\"_blank\" rel=\"noopener\">ODbL license</a>. This project does not independently verify the accuracy or completeness of any of these sources.",
+  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of Washington DC Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
+}

--- a/apps/bike-map/config/dev/madison.json
+++ b/apps/bike-map/config/dev/madison.json
@@ -7,7 +7,7 @@
   "map_zoom": 11,
   "map_bbox": {
     "south": 42.96,
-    "west": -83.60,
+    "west": -89.60,
     "north": 43.21,
     "east": -89.21
   },

--- a/apps/bike-map/config/dev/madison.json
+++ b/apps/bike-map/config/dev/madison.json
@@ -1,0 +1,69 @@
+{
+  "city_name": "Madison, WI",
+  "log_endpoint": "<log_endpoint>",
+  "routing_api_url": "<routing_api_url>",
+  "routing_api_key": "<routing_api_key>",
+  "map_center": [-89.405, 43.085],
+  "map_zoom": 11,
+  "map_bbox": {
+    "south": 42.96,
+    "west": -83.60,
+    "north": 43.21,
+    "east": -89.21
+  },
+  "layers": [
+    {
+      "id": "thefts",
+      "label": "Thefts",
+      "color": "#f59e0b",
+      "file": "data/thefts.geojson",
+      "popup_title": "Thefts",
+      "popup_fields": [
+        {"key": "source", "label": "Source"},
+        {"key": "theft_date", "label": "Theft Date"},
+        {"key": "theft_year", "label": "Theft Year"},
+        {"key": "theft_hour", "label": "Theft Hour", "fmt": "hour"},
+        {"key": "bike_title", "label": "Bike Title"},
+        {"key": "bike_description", "label": "Bike Description"},
+        {"key": "theft_description", "label": "Theft Description"},
+        {"key": "locking_description", "label": "Locking Description"},
+        {"key": "lock_defeat_description", "label": "Lock Defeat Description"},
+        {"key": "theft_status", "label": "Theft Status"}
+      ],
+      "default_visible": true,
+      "cluster_max_zoom": 13,
+      "cluster_radius": 45,
+      "point_radius": 5,
+      "date_field": "theft_date"
+    },
+    {
+      "id": "parking",
+      "label": "Parking",
+      "color": "#22c55e",
+      "file": "data/parking.geojson",
+      "popup_title": "Parking",
+      "popup_fields": [
+        {"key": "type", "label": "Type"},
+        {"key": "capacity", "label": "Capacity"},
+        {"key": "covered", "label": "Covered"},
+        {"key": "indoor", "label": "Indoor"},
+        {"key": "fee", "label": "Fee"},
+        {"key": "lit", "label": "Lit"},
+        {"key": "operator", "label": "Operator"},
+        {"key": "access", "label": "Access"}
+      ],
+      "default_visible": true,
+      "cluster_max_zoom": 13,
+      "cluster_radius": 45,
+      "point_radius": 5
+    }
+  ],
+  "about_paragraphs": [
+    "Madison Bike Map helps you explore cycling conditions around the city.",
+    "Routes prefer streets with better bike infrastructure, lower speed limits, and less severe recent crash history, even if that means a slightly longer ride. We recommend always wearing a helmet while riding.",
+    "Routes are generated using OpenStreetMap data that may be incomplete or outdated. Route suggestions are informational and are no substitute for your own judgment while riding."
+  ],
+  "terms_what_is": "Madison Bike Map is a personal project that displays cycling-related data for the Madison area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
+  "terms_data_sources": "Map data comes from OpenStreetMap contributors and is subject to the <a href=\"https://opendatacommons.org/licenses/odbl/\" target=\"_blank\" rel=\"noopener\">ODbL license</a>. This project does not independently verify the accuracy or completeness of any of these sources.",
+  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of Madison Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
+}

--- a/apps/bike-map/config/dev/nola.json
+++ b/apps/bike-map/config/dev/nola.json
@@ -3,11 +3,11 @@
   "log_endpoint": "<log_endpoint>",
   "routing_api_url": "<routing_api_url>",
   "routing_api_key": "<routing_api_key>",
-  "map_center": [-89.91, 30.01],
+  "map_center": [-90.08, 29.96],
   "map_zoom": 11,
   "map_bbox": {
-    "south": 29.83,
-    "west": -90.22,
+    "south": 29.79,
+    "west": -90.34,
     "north": 30.19,
     "east": -89.60
   },

--- a/apps/bike-map/config/dev/nola.json
+++ b/apps/bike-map/config/dev/nola.json
@@ -1,0 +1,69 @@
+{
+  "city_name": "New Orleans",
+  "log_endpoint": "<log_endpoint>",
+  "routing_api_url": "<routing_api_url>",
+  "routing_api_key": "<routing_api_key>",
+  "map_center": [-89.91, 30.01],
+  "map_zoom": 11,
+  "map_bbox": {
+    "south": 29.83,
+    "west": -90.22,
+    "north": 30.19,
+    "east": -89.60
+  },
+  "layers": [
+    {
+      "id": "thefts",
+      "label": "Thefts",
+      "color": "#f59e0b",
+      "file": "data/thefts.geojson",
+      "popup_title": "Thefts",
+      "popup_fields": [
+        {"key": "source", "label": "Source"},
+        {"key": "theft_date", "label": "Theft Date"},
+        {"key": "theft_year", "label": "Theft Year"},
+        {"key": "theft_hour", "label": "Theft Hour", "fmt": "hour"},
+        {"key": "bike_title", "label": "Bike Title"},
+        {"key": "bike_description", "label": "Bike Description"},
+        {"key": "theft_description", "label": "Theft Description"},
+        {"key": "locking_description", "label": "Locking Description"},
+        {"key": "lock_defeat_description", "label": "Lock Defeat Description"},
+        {"key": "theft_status", "label": "Theft Status"}
+      ],
+      "default_visible": true,
+      "cluster_max_zoom": 13,
+      "cluster_radius": 45,
+      "point_radius": 5,
+      "date_field": "theft_date"
+    },
+    {
+      "id": "parking",
+      "label": "Parking",
+      "color": "#22c55e",
+      "file": "data/parking.geojson",
+      "popup_title": "Parking",
+      "popup_fields": [
+        {"key": "type", "label": "Type"},
+        {"key": "capacity", "label": "Capacity"},
+        {"key": "covered", "label": "Covered"},
+        {"key": "indoor", "label": "Indoor"},
+        {"key": "fee", "label": "Fee"},
+        {"key": "lit", "label": "Lit"},
+        {"key": "operator", "label": "Operator"},
+        {"key": "access", "label": "Access"}
+      ],
+      "default_visible": true,
+      "cluster_max_zoom": 13,
+      "cluster_radius": 45,
+      "point_radius": 5
+    }
+  ],
+  "about_paragraphs": [
+    "Washington DC Bike Map helps you explore cycling conditions around the city.",
+    "Routes prefer streets with better bike infrastructure, lower speed limits, and less severe recent crash history, even if that means a slightly longer ride. We recommend always wearing a helmet while riding.",
+    "Routes are generated using OpenStreetMap data that may be incomplete or outdated. Route suggestions are informational and are no substitute for your own judgment while riding."
+  ],
+  "terms_what_is": "Washington DC Bike Map is a personal project that displays cycling-related data for the Washington DC area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
+  "terms_data_sources": "Map data comes from OpenStreetMap contributors and is subject to the <a href=\"https://opendatacommons.org/licenses/odbl/\" target=\"_blank\" rel=\"noopener\">ODbL license</a>. This project does not independently verify the accuracy or completeness of any of these sources.",
+  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of Washington DC Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -47,7 +47,10 @@ variable "routing_lambda_memory_by_city" {
   type        = map(number)
   default = {
     chicago = 1024
+    dc      = 512
     detroit = 1024
+    madison = 512
+    nola    = 512
     sf      = 1536
   }
 }

--- a/platform/airflow/dags/dag_files/bike_index/update_nola_bikeindex_bike_thefts.py
+++ b/platform/airflow/dags/dag_files/bike_index/update_nola_bikeindex_bike_thefts.py
@@ -2,8 +2,10 @@ import datetime as dt
 from logging import getLogger
 
 from airflow.sdk import dag
-from loci.collectors.osm.taskflow import update_osm_table
-from loci.sources.update_configs import NEW_ORLEANS_OSM_BIKE_PARKING_UC as UPDATE_CONFIG
+from loci.collectors.bike_index.taskflow import update_bike_index_table
+from loci.sources.update_configs import (
+    NEW_ORLEANS_BIKEINDEX_BIKE_THEFTS_UC as UPDATE_CONFIG,
+)
 
 task_logger = getLogger("airflow.task")
 
@@ -15,14 +17,14 @@ CONN_ID = "gis_dwh_db"
     schedule=UPDATE_CONFIG.update_cron,
     start_date=dt.datetime(2022, 11, 1),
     catchup=False,
-    tags=["osm", "new_orleans", "biking"],
+    tags=["bikeindex", "new_orleans", "nola", "theft", "biking"],
 )
-def update_new_orleans_osm_bike_parking():
-    update_osm_table(
+def update_nola_bikeindex_bike_thefts():
+    update_bike_index_table(
         conn_id=CONN_ID,
         update_config=UPDATE_CONFIG,
         task_logger=task_logger,
     )
 
 
-update_new_orleans_osm_bike_parking()
+update_nola_bikeindex_bike_thefts()

--- a/platform/airflow/dags/dag_files/bike_index/update_nyc_bikeindex_bike_thefts.py
+++ b/platform/airflow/dags/dag_files/bike_index/update_nyc_bikeindex_bike_thefts.py
@@ -1,0 +1,30 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.bike_index.taskflow import update_bike_index_table
+from loci.sources.update_configs import (
+    NYC_BIKEINDEX_BIKE_THEFTS_UC as UPDATE_CONFIG,
+)
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["bikeindex", "nyc", "theft", "biking"],
+)
+def update_nyc_bikeindex_bike_thefts():
+    update_bike_index_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_nyc_bikeindex_bike_thefts()

--- a/platform/airflow/dags/dag_files/osm/update_new_orleans_osm_bike_parking.py
+++ b/platform/airflow/dags/dag_files/osm/update_new_orleans_osm_bike_parking.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.osm.taskflow import update_osm_table
+from loci.sources.update_configs import NEW_ORLEANS_OSM_BIKE_PARKING_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["osm", "new_orleans", "biking"],
+)
+def update_new_orleans_osm_bike_parking():
+    update_osm_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_new_orleans_osm_bike_parking()

--- a/platform/airflow/dags/dag_files/osm/update_nola_osm_bike_network_edges.py
+++ b/platform/airflow/dags/dag_files/osm/update_nola_osm_bike_network_edges.py
@@ -2,10 +2,8 @@ import datetime as dt
 from logging import getLogger
 
 from airflow.sdk import dag
-from loci.collectors.bike_index.taskflow import update_bike_index_table
-from loci.sources.update_configs import (
-    NEW_ORLEANS_BIKEINDEX_BIKE_THEFTS_UC as UPDATE_CONFIG,
-)
+from loci.collectors.osm.taskflow import update_osm_table
+from loci.sources.update_configs import NEW_ORLEANS_OSM_BIKE_NETWORK_EDGES_UC as UPDATE_CONFIG
 
 task_logger = getLogger("airflow.task")
 
@@ -17,14 +15,14 @@ CONN_ID = "gis_dwh_db"
     schedule=UPDATE_CONFIG.update_cron,
     start_date=dt.datetime(2022, 11, 1),
     catchup=False,
-    tags=["bikeindex", "new_orleans", "theft", "biking"],
+    tags=["osm", "new_orleans", "nola", "biking", "network"],
 )
-def update_new_orleans_bikeindex_bike_thefts():
-    update_bike_index_table(
+def update_nola_osm_bike_network_edges():
+    update_osm_table(
         conn_id=CONN_ID,
         update_config=UPDATE_CONFIG,
         task_logger=task_logger,
     )
 
 
-update_new_orleans_bikeindex_bike_thefts()
+update_nola_osm_bike_network_edges()

--- a/platform/airflow/dags/dag_files/osm/update_nola_osm_bike_network_nodes.py
+++ b/platform/airflow/dags/dag_files/osm/update_nola_osm_bike_network_nodes.py
@@ -15,9 +15,9 @@ CONN_ID = "gis_dwh_db"
     schedule=UPDATE_CONFIG.update_cron,
     start_date=dt.datetime(2022, 11, 1),
     catchup=False,
-    tags=["osm", "new_orleans", "biking", "network"],
+    tags=["osm", "new_orleans", "nola", "biking", "network"],
 )
-def update_new_orleans_osm_bike_network_nodes():
+def update_nola_osm_bike_network_nodes():
     update_osm_table(
         conn_id=CONN_ID,
         update_config=UPDATE_CONFIG,
@@ -25,4 +25,4 @@ def update_new_orleans_osm_bike_network_nodes():
     )
 
 
-update_new_orleans_osm_bike_network_nodes()
+update_nola_osm_bike_network_nodes()

--- a/platform/airflow/dags/dag_files/osm/update_nola_osm_bike_parking.py
+++ b/platform/airflow/dags/dag_files/osm/update_nola_osm_bike_parking.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 from airflow.sdk import dag
 from loci.collectors.osm.taskflow import update_osm_table
-from loci.sources.update_configs import NEW_ORLEANS_OSM_BIKE_NETWORK_EDGES_UC as UPDATE_CONFIG
+from loci.sources.update_configs import NEW_ORLEANS_OSM_BIKE_PARKING_UC as UPDATE_CONFIG
 
 task_logger = getLogger("airflow.task")
 
@@ -15,9 +15,9 @@ CONN_ID = "gis_dwh_db"
     schedule=UPDATE_CONFIG.update_cron,
     start_date=dt.datetime(2022, 11, 1),
     catchup=False,
-    tags=["osm", "new_orleans", "biking", "network"],
+    tags=["osm", "new_orleans", "nola", "biking"],
 )
-def update_new_orleans_osm_bike_network_edges():
+def update_nola_osm_bike_parking():
     update_osm_table(
         conn_id=CONN_ID,
         update_config=UPDATE_CONFIG,
@@ -25,4 +25,4 @@ def update_new_orleans_osm_bike_network_edges():
     )
 
 
-update_new_orleans_osm_bike_network_edges()
+update_nola_osm_bike_parking()

--- a/platform/airflow/dags/dag_files/osm/update_nyc_osm_bike_network_edges.py
+++ b/platform/airflow/dags/dag_files/osm/update_nyc_osm_bike_network_edges.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.osm.taskflow import update_osm_table
+from loci.sources.update_configs import NYC_OSM_BIKE_NETWORK_EDGES_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["osm", "nyc", "biking", "network"],
+)
+def update_nyc_osm_bike_network_edges():
+    update_osm_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_nyc_osm_bike_network_edges()

--- a/platform/airflow/dags/dag_files/osm/update_nyc_osm_bike_network_nodes.py
+++ b/platform/airflow/dags/dag_files/osm/update_nyc_osm_bike_network_nodes.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.osm.taskflow import update_osm_table
+from loci.sources.update_configs import NYC_OSM_BIKE_NETWORK_NODES_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["osm", "nyc", "biking", "network"],
+)
+def update_nyc_osm_bike_network_nodes():
+    update_osm_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_nyc_osm_bike_network_nodes()

--- a/platform/airflow/dags/dag_files/osm/update_nyc_osm_bike_parking.py
+++ b/platform/airflow/dags/dag_files/osm/update_nyc_osm_bike_parking.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.osm.taskflow import update_osm_table
+from loci.sources.update_configs import NYC_OSM_BIKE_PARKING_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["osm", "nyc", "biking"],
+)
+def update_nyc_osm_bike_parking():
+    update_osm_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_nyc_osm_bike_parking()

--- a/platform/airflow/dags/dag_files/refresh_bike_map_dc.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_dc.py
@@ -1,0 +1,124 @@
+# loci_platform/platform/airflow/dags/dag_files/refresh_bike_map_dc.py
+"""Refresh the Washington DC bike map: dbt build → export → deploy."""
+
+from datetime import datetime
+
+from airflow.sdk import dag
+from loci.exports.bike_map_layers import LayerDisplayConfig, PopupField
+from loci.exports.geojson_export import GeoJSONExportConfig
+from loci.sources.dataset_specs import WASHINGTON_DC_BBOX
+from loci.tasks.bike_map_tasks import (
+    CityBuildSpec,
+    build_refresh_task_graph,
+    standard_dag_params,
+)
+from loci.tasks.testing.route_tests import RouteTestCase
+
+DC_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
+    GeoJSONExportConfig(
+        name="thefts",
+        table="dc_bikeindex_bike_thefts",
+        latitude_column="latitude",
+        longitude_column="longitude",
+        properties=[
+            "source",
+            "source_id",
+            "theft_date",
+            "theft_year",
+            "theft_hour",
+            "bike_title",
+            "bike_description",
+            "theft_description",
+            "locking_description",
+            "lock_defeat_description",
+            "theft_status",
+            "latitude",
+            "longitude",
+            "location",
+        ],
+    ),
+    GeoJSONExportConfig(
+        name="parking",
+        table="dc_osm_bike_parking",
+        geometry_column="geom",
+        properties=[
+            "osm_id",
+            "type",
+            "capacity",
+            "covered",
+            "indoor",
+            "fee",
+            "lit",
+            "operator",
+            "access",
+        ],
+    ),
+]
+
+DC_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
+    LayerDisplayConfig(
+        export_name="thefts",
+        label="Thefts",
+        color="#f59e0b",
+        popup_title="Thefts",
+        date_field="theft_date",
+        popup_fields=[
+            PopupField(key="source", label="Source"),
+            PopupField(key="theft_date", label="Theft Date"),
+            PopupField(key="theft_year", label="Theft Year"),
+            PopupField(key="theft_hour", label="Theft Hour", fmt="hour"),
+            PopupField(key="bike_title", label="Bike Title"),
+            PopupField(key="bike_description", label="Bike Description"),
+            PopupField(key="theft_description", label="Theft Description"),
+            PopupField(key="locking_description", label="Locking Description"),
+            PopupField(key="lock_defeat_description", label="Lock Defeat Description"),
+            PopupField(key="theft_status", label="Theft Status"),
+        ],
+    ),
+    LayerDisplayConfig(
+        export_name="parking",
+        label="Parking",
+        color="#22c55e",
+        popup_title="Parking",
+        popup_fields=[
+            PopupField(key="type", label="Type"),
+            PopupField(key="capacity", label="Capacity"),
+            PopupField(key="covered", label="Covered", fmt="yes_no_bool"),
+            PopupField(key="indoor", label="Indoor", fmt="yes_no_bool"),
+            PopupField(key="lit", label="Lit", fmt="yes_no_bool"),
+            PopupField(key="fee", label="Fee", fmt="yes_no_bool"),
+            PopupField(key="operator", label="Operator"),
+            PopupField(key="access", label="Access"),
+        ],
+    ),
+]
+
+DC_ROUTE_TESTS: list[RouteTestCase] = []
+
+DC_SPEC = CityBuildSpec(
+    city="dc",
+    bbox=WASHINGTON_DC_BBOX,
+    pre_export_dbt_selects=[
+        ("--select", "+dc_bikeindex_bike_thefts"),
+        ("--select", "+dc_osm_bike_parking"),
+    ],
+    geojson_exports=DC_GEOJSON_EXPORTS,
+    layer_displays=DC_LAYER_DISPLAYS,
+    weights_dbt_select="+dc_bike_stress_weighted_segments",
+    route_tests=DC_ROUTE_TESTS,
+)
+
+
+@dag(
+    dag_id="refresh_bike_map_dc",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["bike-map", "dc"],
+    params=standard_dag_params("dc"),
+)
+def refresh_bike_map_dc():
+    build_refresh_task_graph(DC_SPEC)
+
+
+refresh_bike_map_dc()

--- a/platform/airflow/dags/dag_files/refresh_bike_map_madison.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_madison.py
@@ -1,0 +1,124 @@
+# loci_platform/platform/airflow/dags/dag_files/refresh_bike_map_madison.py
+"""Refresh the Madison bike map: dbt build → export → deploy."""
+
+from datetime import datetime
+
+from airflow.sdk import dag
+from loci.exports.bike_map_layers import LayerDisplayConfig, PopupField
+from loci.exports.geojson_export import GeoJSONExportConfig
+from loci.sources.dataset_specs import MADISON_BBOX
+from loci.tasks.bike_map_tasks import (
+    CityBuildSpec,
+    build_refresh_task_graph,
+    standard_dag_params,
+)
+from loci.tasks.testing.route_tests import RouteTestCase
+
+MADISON_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
+    GeoJSONExportConfig(
+        name="thefts",
+        table="madison_bikeindex_bike_thefts",
+        latitude_column="latitude",
+        longitude_column="longitude",
+        properties=[
+            "source",
+            "source_id",
+            "theft_date",
+            "theft_year",
+            "theft_hour",
+            "bike_title",
+            "bike_description",
+            "theft_description",
+            "locking_description",
+            "lock_defeat_description",
+            "theft_status",
+            "latitude",
+            "longitude",
+            "location",
+        ],
+    ),
+    GeoJSONExportConfig(
+        name="parking",
+        table="madison_osm_bike_parking",
+        geometry_column="geom",
+        properties=[
+            "osm_id",
+            "type",
+            "capacity",
+            "covered",
+            "indoor",
+            "fee",
+            "lit",
+            "operator",
+            "access",
+        ],
+    ),
+]
+
+MADISON_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
+    LayerDisplayConfig(
+        export_name="thefts",
+        label="Thefts",
+        color="#f59e0b",
+        popup_title="Thefts",
+        date_field="theft_date",
+        popup_fields=[
+            PopupField(key="source", label="Source"),
+            PopupField(key="theft_date", label="Theft Date"),
+            PopupField(key="theft_year", label="Theft Year"),
+            PopupField(key="theft_hour", label="Theft Hour", fmt="hour"),
+            PopupField(key="bike_title", label="Bike Title"),
+            PopupField(key="bike_description", label="Bike Description"),
+            PopupField(key="theft_description", label="Theft Description"),
+            PopupField(key="locking_description", label="Locking Description"),
+            PopupField(key="lock_defeat_description", label="Lock Defeat Description"),
+            PopupField(key="theft_status", label="Theft Status"),
+        ],
+    ),
+    LayerDisplayConfig(
+        export_name="parking",
+        label="Parking",
+        color="#22c55e",
+        popup_title="Parking",
+        popup_fields=[
+            PopupField(key="type", label="Type"),
+            PopupField(key="capacity", label="Capacity"),
+            PopupField(key="covered", label="Covered", fmt="yes_no_bool"),
+            PopupField(key="indoor", label="Indoor", fmt="yes_no_bool"),
+            PopupField(key="lit", label="Lit", fmt="yes_no_bool"),
+            PopupField(key="fee", label="Fee", fmt="yes_no_bool"),
+            PopupField(key="operator", label="Operator"),
+            PopupField(key="access", label="Access"),
+        ],
+    ),
+]
+
+MADISON_ROUTE_TESTS: list[RouteTestCase] = []
+
+MADISON_SPEC = CityBuildSpec(
+    city="madison",
+    bbox=MADISON_BBOX,
+    pre_export_dbt_selects=[
+        ("--select", "+madison_bikeindex_bike_thefts"),
+        ("--select", "+madison_osm_bike_parking"),
+    ],
+    geojson_exports=MADISON_GEOJSON_EXPORTS,
+    layer_displays=MADISON_LAYER_DISPLAYS,
+    weights_dbt_select="+madison_bike_stress_weighted_segments",
+    route_tests=MADISON_ROUTE_TESTS,
+)
+
+
+@dag(
+    dag_id="refresh_bike_map_madison",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["bike-map", "madison"],
+    params=standard_dag_params("madison"),
+)
+def refresh_bike_map_madison():
+    build_refresh_task_graph(MADISON_SPEC)
+
+
+refresh_bike_map_madison()

--- a/platform/airflow/dags/dag_files/refresh_bike_map_nola.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_nola.py
@@ -1,0 +1,124 @@
+# loci_platform/platform/airflow/dags/dag_files/refresh_bike_map_nola.py
+"""Refresh the New Orleans bike map: dbt build → export → deploy."""
+
+from datetime import datetime
+
+from airflow.sdk import dag
+from loci.exports.bike_map_layers import LayerDisplayConfig, PopupField
+from loci.exports.geojson_export import GeoJSONExportConfig
+from loci.sources.dataset_specs import NEW_ORLEANS_BBOX
+from loci.tasks.bike_map_tasks import (
+    CityBuildSpec,
+    build_refresh_task_graph,
+    standard_dag_params,
+)
+from loci.tasks.testing.route_tests import RouteTestCase
+
+NOLA_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
+    GeoJSONExportConfig(
+        name="thefts",
+        table="nola_bikeindex_bike_thefts",
+        latitude_column="latitude",
+        longitude_column="longitude",
+        properties=[
+            "source",
+            "source_id",
+            "theft_date",
+            "theft_year",
+            "theft_hour",
+            "bike_title",
+            "bike_description",
+            "theft_description",
+            "locking_description",
+            "lock_defeat_description",
+            "theft_status",
+            "latitude",
+            "longitude",
+            "location",
+        ],
+    ),
+    GeoJSONExportConfig(
+        name="parking",
+        table="nola_osm_bike_parking",
+        geometry_column="geom",
+        properties=[
+            "osm_id",
+            "type",
+            "capacity",
+            "covered",
+            "indoor",
+            "fee",
+            "lit",
+            "operator",
+            "access",
+        ],
+    ),
+]
+
+NOLA_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
+    LayerDisplayConfig(
+        export_name="thefts",
+        label="Thefts",
+        color="#f59e0b",
+        popup_title="Thefts",
+        date_field="theft_date",
+        popup_fields=[
+            PopupField(key="source", label="Source"),
+            PopupField(key="theft_date", label="Theft Date"),
+            PopupField(key="theft_year", label="Theft Year"),
+            PopupField(key="theft_hour", label="Theft Hour", fmt="hour"),
+            PopupField(key="bike_title", label="Bike Title"),
+            PopupField(key="bike_description", label="Bike Description"),
+            PopupField(key="theft_description", label="Theft Description"),
+            PopupField(key="locking_description", label="Locking Description"),
+            PopupField(key="lock_defeat_description", label="Lock Defeat Description"),
+            PopupField(key="theft_status", label="Theft Status"),
+        ],
+    ),
+    LayerDisplayConfig(
+        export_name="parking",
+        label="Parking",
+        color="#22c55e",
+        popup_title="Parking",
+        popup_fields=[
+            PopupField(key="type", label="Type"),
+            PopupField(key="capacity", label="Capacity"),
+            PopupField(key="covered", label="Covered", fmt="yes_no_bool"),
+            PopupField(key="indoor", label="Indoor", fmt="yes_no_bool"),
+            PopupField(key="lit", label="Lit", fmt="yes_no_bool"),
+            PopupField(key="fee", label="Fee", fmt="yes_no_bool"),
+            PopupField(key="operator", label="Operator"),
+            PopupField(key="access", label="Access"),
+        ],
+    ),
+]
+
+NOLA_ROUTE_TESTS: list[RouteTestCase] = []
+
+NOLA_SPEC = CityBuildSpec(
+    city="nola",
+    bbox=NEW_ORLEANS_BBOX,
+    pre_export_dbt_selects=[
+        ("--select", "+nola_bikeindex_bike_thefts"),
+        ("--select", "+nola_osm_bike_parking"),
+    ],
+    geojson_exports=NOLA_GEOJSON_EXPORTS,
+    layer_displays=NOLA_LAYER_DISPLAYS,
+    weights_dbt_select="+nola_bike_stress_weighted_segments",
+    route_tests=NOLA_ROUTE_TESTS,
+)
+
+
+@dag(
+    dag_id="refresh_bike_map_nola",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["bike-map", "new_orleans"],
+    params=standard_dag_params("nola"),
+)
+def refresh_bike_map_nola():
+    build_refresh_task_graph(NOLA_SPEC)
+
+
+refresh_bike_map_nola()

--- a/platform/airflow/dags/loci/environments.py
+++ b/platform/airflow/dags/loci/environments.py
@@ -37,7 +37,10 @@ from loci.exports.graph_export import GRAPH_S3_KEY
 VALID_ENVS = ("dev", "staging", "prod")
 VALID_CITIES = (
     "chicago",
+    "dc",
     "detroit",
+    "madison",
+    "nola",
     "sf",
 )  # extend as we onboard more cities
 

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -59,11 +59,20 @@ MADISON_BIKEINDEX_BIKE_THEFTS_SPEC = BikeIndexDatasetSpec(
 )
 
 NEW_ORLEANS_BIKEINDEX_BIKE_THEFTS_SPEC = BikeIndexDatasetSpec(
-    name="new_orleans_bikeindex_bike_thefts",
-    target_table="new_orleans_bikeindex_bike_thefts",
+    name="nola_bikeindex_bike_thefts",
+    target_table="nola_bikeindex_bike_thefts",
     entity_key=["id"],
     location="30.01,-89.91",
     distance=10,
+    stolenness="proximity",
+)
+
+NYC_BIKEINDEX_BIKE_THEFTS_SPEC = BikeIndexDatasetSpec(
+    name="nyc_bikeindex_bike_thefts",
+    target_table="nyc_bikeindex_bike_thefts",
+    entity_key=["id"],
+    location="40.67,-74.00",
+    distance=18,
     stolenness="proximity",
 )
 
@@ -409,7 +418,7 @@ DETROIT_BBOX = BBox(42.18, -83.40, 42.56, -82.84)
 LOS_ANGELES_BBOX = BBox(33.69, -118.72, 34.38, -118.02)
 MADISON_BBOX = BBox(42.96, -89.60, 43.21, -89.21)
 NEW_ORLEANS_BBOX = BBox(29.83, -90.22, 30.19, -89.60)
-NEW_YORK_CITY_BBOX = BBox(40.52, -74.05, 40.93, -73.67)
+NEW_YORK_CITY_BBOX = BBox(40.48, -74.26, 40.93, -73.70)
 PORTLAND_BBOX = BBox(45.41, -122.86, 45.66, -122.46)
 SAN_FRANCISCO_BBOX = BBox(37.18, -122.59, 38.00, -121.73)
 SEATTLE_BBOX = BBox(47.47, -122.48, 47.78, -122.04)
@@ -723,10 +732,17 @@ MADISON_OSM_BIKE_NETWORK_NODES_SPEC = generate_osm_bike_network_nodes_spec(
 )
 
 NEW_ORLEANS_OSM_BIKE_NETWORK_EDGES_SPEC = generate_osm_bike_network_edges_spec(
-    city="new_orleans", bbox=NEW_ORLEANS_BBOX
+    city="nola", bbox=NEW_ORLEANS_BBOX
 )
 NEW_ORLEANS_OSM_BIKE_NETWORK_NODES_SPEC = generate_osm_bike_network_nodes_spec(
-    city="new_orleans", bbox=NEW_ORLEANS_BBOX
+    city="nola", bbox=NEW_ORLEANS_BBOX
+)
+
+NYC_OSM_BIKE_NETWORK_EDGES_SPEC = generate_osm_bike_network_edges_spec(
+    city="nyc", bbox=NEW_YORK_CITY_BBOX
+)
+NYC_OSM_BIKE_NETWORK_NODES_SPEC = generate_osm_bike_network_nodes_spec(
+    city="nyc", bbox=NEW_YORK_CITY_BBOX
 )
 
 PORTLAND_OSM_BIKE_NETWORK_EDGES_SPEC = generate_osm_bike_network_edges_spec(
@@ -765,6 +781,12 @@ DETROIT_OSM_BIKE_PARKING_SPEC = generate_osm_bike_parking_spec(city="detroit", b
 DENVER_OSM_BIKE_PARKING_SPEC = generate_osm_bike_parking_spec(city="denver", bbox=DENVER_BBOX)
 
 MADISON_OSM_BIKE_PARKING_SPEC = generate_osm_bike_parking_spec(city="madison", bbox=MADISON_BBOX)
+
+NEW_ORLEANS_OSM_BIKE_PARKING_SPEC = generate_osm_bike_parking_spec(
+    city="nola", bbox=NEW_ORLEANS_BBOX
+)
+
+NYC_OSM_BIKE_PARKING_SPEC = generate_osm_bike_parking_spec(city="nyc", bbox=NEW_YORK_CITY_BBOX)
 
 PORTLAND_OSM_BIKE_PARKING_SPEC = generate_osm_bike_parking_spec(city="portland", bbox=PORTLAND_BBOX)
 

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -62,8 +62,8 @@ NEW_ORLEANS_BIKEINDEX_BIKE_THEFTS_SPEC = BikeIndexDatasetSpec(
     name="nola_bikeindex_bike_thefts",
     target_table="nola_bikeindex_bike_thefts",
     entity_key=["id"],
-    location="30.01,-89.91",
-    distance=10,
+    location="30.02,-89.98",
+    distance=25,
     stolenness="proximity",
 )
 
@@ -108,7 +108,7 @@ WASHINGTON_DC_BIKEINDEX_BIKE_THEFTS_SPEC = BikeIndexDatasetSpec(
     target_table="dc_bikeindex_bike_thefts",
     entity_key=["id"],
     location="38.89,-77.01",
-    distance=5,
+    distance=10,
     stolenness="proximity",
 )
 
@@ -417,13 +417,13 @@ DENVER_BBOX = BBox(39.55, -105.19, 39.94, -104.56)
 DETROIT_BBOX = BBox(42.18, -83.40, 42.56, -82.84)
 LOS_ANGELES_BBOX = BBox(33.69, -118.72, 34.38, -118.02)
 MADISON_BBOX = BBox(42.96, -89.60, 43.21, -89.21)
-NEW_ORLEANS_BBOX = BBox(29.83, -90.22, 30.19, -89.60)
+NEW_ORLEANS_BBOX = BBox(29.79, -90.34, 30.19, -89.60)
 NEW_YORK_CITY_BBOX = BBox(40.48, -74.26, 40.93, -73.70)
 PORTLAND_BBOX = BBox(45.41, -122.86, 45.66, -122.46)
 SAN_FRANCISCO_BBOX = BBox(37.18, -122.59, 38.00, -121.73)
 SEATTLE_BBOX = BBox(47.47, -122.48, 47.78, -122.04)
 TORONTO_BBOX = BBox(43.48, -79.79, 43.95, -78.84)
-WASHINGTON_DC_BBOX = BBox(38.85, -77.09, 38.97, -76.93)
+WASHINGTON_DC_BBOX = BBox(38.75, -77.22, 39.04, -76.83)
 
 
 # ----------------------------------------------------------------------

--- a/platform/airflow/dags/loci/sources/update_configs.py
+++ b/platform/airflow/dags/loci/sources/update_configs.py
@@ -95,6 +95,13 @@ NEW_ORLEANS_BIKEINDEX_BIKE_THEFTS_UC = DatasetUpdateConfig(
     full_update_mode="api",
 )
 
+NYC_BIKEINDEX_BIKE_THEFTS_UC = DatasetUpdateConfig(
+    spec=specs.NYC_BIKEINDEX_BIKE_THEFTS_SPEC,
+    update_cron="0 2 * * 2",
+    full_update_week_of_month=1,
+    full_update_mode="api",
+)
+
 PORTLAND_BIKEINDEX_BIKE_THEFTS_UC = DatasetUpdateConfig(
     spec=specs.PORTLAND_BIKEINDEX_BIKE_THEFTS_SPEC,
     update_cron="0 4 * * 0",
@@ -806,6 +813,20 @@ MADISON_OSM_TRANSIT_UC = DatasetUpdateConfig(
     full_update_mode="api",
 )
 
+NEW_ORLEANS_OSM_BIKE_PARKING_UC = DatasetUpdateConfig(
+    spec=specs.NEW_ORLEANS_OSM_BIKE_PARKING_SPEC,
+    update_cron="41 2 * * 2",
+    full_update_week_of_month=1,
+    full_update_mode="api",
+)
+
+NYC_OSM_BIKE_PARKING_UC = DatasetUpdateConfig(
+    spec=specs.NYC_OSM_BIKE_PARKING_SPEC,
+    update_cron="37 2 * * 2",
+    full_update_week_of_month=1,
+    full_update_mode="api",
+)
+
 PORTLAND_OSM_BIKE_PARKING_UC = DatasetUpdateConfig(
     spec=specs.PORTLAND_OSM_BIKE_PARKING_SPEC,
     update_cron="25 2 * * 2",
@@ -920,7 +941,20 @@ NEW_ORLEANS_OSM_BIKE_NETWORK_NODES_UC = DatasetUpdateConfig(
     spec=specs.NEW_ORLEANS_OSM_BIKE_NETWORK_NODES_SPEC,
     update_cron="16 1 * * 3",
     full_update_week_of_month=1,
-    full_update_day_of_week=4,
+    full_update_mode="api",
+)
+
+NYC_OSM_BIKE_NETWORK_EDGES_UC = DatasetUpdateConfig(
+    spec=specs.NYC_OSM_BIKE_NETWORK_EDGES_SPEC,
+    update_cron="32 1 * * 3",
+    full_update_week_of_month=1,
+    full_update_mode="api",
+)
+
+NYC_OSM_BIKE_NETWORK_NODES_UC = DatasetUpdateConfig(
+    spec=specs.NYC_OSM_BIKE_NETWORK_NODES_SPEC,
+    update_cron="35 1 * * 3",
+    full_update_week_of_month=1,
     full_update_mode="api",
 )
 

--- a/platform/dbt/models/_bikeindex_sources.yml
+++ b/platform/dbt/models/_bikeindex_sources.yml
@@ -12,6 +12,8 @@ sources:
       - name: detroit_bikeindex_bike_thefts
       - name: madison_bikeindex_bike_thefts
       - name: new_orleans_bikeindex_bike_thefts
+      - name: nola_bikeindex_bike_thefts
+      - name: nyc_bikeindex_bike_thefts
       - name: portland_bikeindex_bike_thefts
       - name: sf_bikeindex_bike_thefts
       - name: toronto_bikeindex_bike_thefts

--- a/platform/dbt/models/_bikeindex_sources.yml
+++ b/platform/dbt/models/_bikeindex_sources.yml
@@ -11,7 +11,6 @@ sources:
       - name: denver_bikeindex_bike_thefts
       - name: detroit_bikeindex_bike_thefts
       - name: madison_bikeindex_bike_thefts
-      - name: new_orleans_bikeindex_bike_thefts
       - name: nola_bikeindex_bike_thefts
       - name: nyc_bikeindex_bike_thefts
       - name: portland_bikeindex_bike_thefts

--- a/platform/dbt/models/_osm_sources.yml
+++ b/platform/dbt/models/_osm_sources.yml
@@ -23,9 +23,6 @@ sources:
       - name: madison_osm_bike_network_edges
       - name: madison_osm_bike_network_nodes
       - name: madison_osm_bike_parking
-      - name: new_orleans_osm_bike_network_edges
-      - name: new_orleans_osm_bike_network_nodes
-      - name: new_orleans_osm_bike_parking
       - name: nola_osm_bike_network_edges
       - name: nola_osm_bike_network_nodes
       - name: nola_osm_bike_parking

--- a/platform/dbt/models/_osm_sources.yml
+++ b/platform/dbt/models/_osm_sources.yml
@@ -26,6 +26,12 @@ sources:
       - name: new_orleans_osm_bike_network_edges
       - name: new_orleans_osm_bike_network_nodes
       - name: new_orleans_osm_bike_parking
+      - name: nola_osm_bike_network_edges
+      - name: nola_osm_bike_network_nodes
+      - name: nola_osm_bike_parking
+      - name: nyc_osm_bike_network_edges
+      - name: nyc_osm_bike_network_nodes
+      - name: nyc_osm_bike_parking
       - name: portland_osm_bike_network_edges
       - name: portland_osm_bike_network_nodes
       - name: portland_osm_bike_parking

--- a/platform/dbt/models/marts/cycling/dc/_marts_dc_cycling.yml
+++ b/platform/dbt/models/marts/cycling/dc/_marts_dc_cycling.yml
@@ -1,0 +1,217 @@
+version: 2
+models:
+  - name: dc_segment_costs
+    description: Per-segment intrinsic stress costs from OSM physical attributes (highway
+      class, infrastructure, surface, lighting, tunnel).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - segment_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: physical_cost >= 0
+          config:
+            name: dc_segment_costs_physical_cost_non_negative
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_dc_bike_segments')
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: way_id
+        data_tests:
+          - not_null
+      - name: start_node_id
+        data_tests:
+          - not_null
+      - name: end_node_id
+        data_tests:
+          - not_null
+      - name: length_m
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                strictly: true
+      - name: geom
+        data_tests:
+          - not_null
+      - name: speed_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: road_type_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: infrastructure_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: tunnel_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: surface_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: lighting_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: physical_cost
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+      - name: infra_category
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - separated
+                  - on_road
+                  - shared
+                  - path
+              config:
+                where: infra_category is not null
+  - name: dc_intersection_costs
+    description: Logical bike-network intersections with stress penalties. A row exists
+      for each node where >= 2 distinct OSM ways meet AND >= 1 of those ways carries
+      cars. Joined into dc_bike_stress_weighted_segments on end_node_id.
+    columns:
+      - name: osmid
+        description: OSM node id (unique).
+        data_tests:
+          - not_null
+          - unique
+          - dbt_utils.relationships_where:
+              arguments:
+                to: source('osm', 'dc_osm_bike_network_nodes')
+                field: osm_id
+                from_condition: traffic_control is not null
+                to_condition: osm_type = 'node' and valid_to is null
+              config:
+                severity: warn
+      - name: traffic_control
+        description: Raw OSM 'highway' tag value on the node, or NULL for uncontrolled
+          intersections.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - traffic_signals
+                  - stop
+                  - crossing
+                  - mini_roundabout
+                  - give_way
+                  - turning_circle
+                  - turning_loop
+                quote: true
+      - name: max_road_class
+        description: Worst road class among car-carrying ways at this node.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - primary
+                  - secondary
+                  - tertiary
+                  - minor
+      - name: max_road_rank
+        description: Numeric form of max_road_class (1-4).
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 4
+      - name: intersection_cost
+        description: Stress cost added to a route for traversing through this intersection.
+        data_tests:
+          - not_null
+  - name: dc_bike_stress_weighted_segments
+    description: Stress-weighted directed segments for bike routing. One row per directed
+      edge (u, v, key). stress_cost is the primary routing weight, combining length,
+      speed, infrastructure, surface, lighting, crash history, and traffic control
+      penalties.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - start_node_id
+              - end_node_id
+              - way_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: stress_cost >= 0
+          config:
+            name: dc_stress_cost_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: crash_cost >= 0
+          config:
+            name: dc_crash_cost_non_negative
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_dc_bike_segments')
+    columns:
+      - name: start_node_id
+        data_tests:
+          - not_null
+      - name: end_node_id
+        data_tests:
+          - not_null
+      - name: way_id
+        data_tests:
+          - not_null
+      - name: length_m
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                strictly: true
+      - name: stress_cost
+        data_tests:
+          - not_null
+      - name: speed_factor
+        data_tests:
+          - not_null
+      - name: infrastructure_factor
+        data_tests:
+          - not_null
+      - name: surface_factor
+        data_tests:
+          - not_null
+      - name: lighting_factor
+        data_tests:
+          - not_null
+      - name: crash_cost
+        data_tests:
+          - not_null
+      - name: intersection_cost
+        data_tests:
+          - not_null
+      - name: geom
+        data_tests:
+          - not_null

--- a/platform/dbt/models/marts/cycling/dc/dc_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/dc/dc_bike_stress_weighted_segments.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized='table',
+    pre_hook=["SET work_mem = '256MB'"],
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (segment_id)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "RESET work_mem"
+    ]
+) }}
+
+{{ generate_city_bike_stress_weighted_segments_model('dc', include_crashes=false) }}

--- a/platform/dbt/models/marts/cycling/dc/dc_bikeindex_bike_thefts.sql
+++ b/platform/dbt/models/marts/cycling/dc/dc_bikeindex_bike_thefts.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_bikeindex_bike_thefts_model('dc', time_zone = 'America/New_York') }}

--- a/platform/dbt/models/marts/cycling/dc/dc_intersection_costs.sql
+++ b/platform/dbt/models/marts/cycling/dc/dc_intersection_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_intersection_costs_model('dc') }}

--- a/platform/dbt/models/marts/cycling/dc/dc_osm_bike_parking.sql
+++ b/platform/dbt/models/marts/cycling/dc/dc_osm_bike_parking.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_osm_bike_parking_model('dc') }}

--- a/platform/dbt/models/marts/cycling/dc/dc_segment_costs.sql
+++ b/platform/dbt/models/marts/cycling/dc/dc_segment_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_costs_model('dc') }}

--- a/platform/dbt/models/marts/cycling/madison/_marts_madison_cycling.yml
+++ b/platform/dbt/models/marts/cycling/madison/_marts_madison_cycling.yml
@@ -1,0 +1,217 @@
+version: 2
+models:
+  - name: madison_segment_costs
+    description: Per-segment intrinsic stress costs from OSM physical attributes (highway
+      class, infrastructure, surface, lighting, tunnel).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - segment_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: physical_cost >= 0
+          config:
+            name: madison_segment_costs_physical_cost_non_negative
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_madison_bike_segments')
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: way_id
+        data_tests:
+          - not_null
+      - name: start_node_id
+        data_tests:
+          - not_null
+      - name: end_node_id
+        data_tests:
+          - not_null
+      - name: length_m
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                strictly: true
+      - name: geom
+        data_tests:
+          - not_null
+      - name: speed_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: road_type_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: infrastructure_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: tunnel_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: surface_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: lighting_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: physical_cost
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+      - name: infra_category
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - separated
+                  - on_road
+                  - shared
+                  - path
+              config:
+                where: infra_category is not null
+  - name: madison_intersection_costs
+    description: Logical bike-network intersections with stress penalties. A row exists
+      for each node where >= 2 distinct OSM ways meet AND >= 1 of those ways carries
+      cars. Joined into madison_bike_stress_weighted_segments on end_node_id.
+    columns:
+      - name: osmid
+        description: OSM node id (unique).
+        data_tests:
+          - not_null
+          - unique
+          - dbt_utils.relationships_where:
+              arguments:
+                to: source('osm', 'madison_osm_bike_network_nodes')
+                field: osm_id
+                from_condition: traffic_control is not null
+                to_condition: osm_type = 'node' and valid_to is null
+              config:
+                severity: warn
+      - name: traffic_control
+        description: Raw OSM 'highway' tag value on the node, or NULL for uncontrolled
+          intersections.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - traffic_signals
+                  - stop
+                  - crossing
+                  - mini_roundabout
+                  - give_way
+                  - turning_circle
+                  - turning_loop
+                quote: true
+      - name: max_road_class
+        description: Worst road class among car-carrying ways at this node.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - primary
+                  - secondary
+                  - tertiary
+                  - minor
+      - name: max_road_rank
+        description: Numeric form of max_road_class (1-4).
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 4
+      - name: intersection_cost
+        description: Stress cost added to a route for traversing through this intersection.
+        data_tests:
+          - not_null
+  - name: madison_bike_stress_weighted_segments
+    description: Stress-weighted directed segments for bike routing. One row per directed
+      edge (u, v, key). stress_cost is the primary routing weight, combining length,
+      speed, infrastructure, surface, lighting, crash history, and traffic control
+      penalties.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - start_node_id
+              - end_node_id
+              - way_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: stress_cost >= 0
+          config:
+            name: madison_stress_cost_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: crash_cost >= 0
+          config:
+            name: madison_crash_cost_non_negative
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_madison_bike_segments')
+    columns:
+      - name: start_node_id
+        data_tests:
+          - not_null
+      - name: end_node_id
+        data_tests:
+          - not_null
+      - name: way_id
+        data_tests:
+          - not_null
+      - name: length_m
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                strictly: true
+      - name: stress_cost
+        data_tests:
+          - not_null
+      - name: speed_factor
+        data_tests:
+          - not_null
+      - name: infrastructure_factor
+        data_tests:
+          - not_null
+      - name: surface_factor
+        data_tests:
+          - not_null
+      - name: lighting_factor
+        data_tests:
+          - not_null
+      - name: crash_cost
+        data_tests:
+          - not_null
+      - name: intersection_cost
+        data_tests:
+          - not_null
+      - name: geom
+        data_tests:
+          - not_null

--- a/platform/dbt/models/marts/cycling/madison/madison_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/madison/madison_bike_stress_weighted_segments.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized='table',
+    pre_hook=["SET work_mem = '256MB'"],
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (segment_id)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "RESET work_mem"
+    ]
+) }}
+
+{{ generate_city_bike_stress_weighted_segments_model('madison', include_crashes=false) }}

--- a/platform/dbt/models/marts/cycling/madison/madison_bikeindex_bike_thefts.sql
+++ b/platform/dbt/models/marts/cycling/madison/madison_bikeindex_bike_thefts.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_bikeindex_bike_thefts_model('madison', time_zone = 'America/Chicago') }}

--- a/platform/dbt/models/marts/cycling/madison/madison_intersection_costs.sql
+++ b/platform/dbt/models/marts/cycling/madison/madison_intersection_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_intersection_costs_model('madison') }}

--- a/platform/dbt/models/marts/cycling/madison/madison_osm_bike_parking.sql
+++ b/platform/dbt/models/marts/cycling/madison/madison_osm_bike_parking.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_osm_bike_parking_model('madison') }}

--- a/platform/dbt/models/marts/cycling/madison/madison_segment_costs.sql
+++ b/platform/dbt/models/marts/cycling/madison/madison_segment_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_costs_model('madison') }}

--- a/platform/dbt/models/marts/cycling/nola/_marts_nola_cycling.yml
+++ b/platform/dbt/models/marts/cycling/nola/_marts_nola_cycling.yml
@@ -1,0 +1,217 @@
+version: 2
+models:
+  - name: nola_segment_costs
+    description: Per-segment intrinsic stress costs from OSM physical attributes (highway
+      class, infrastructure, surface, lighting, tunnel).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - segment_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: physical_cost >= 0
+          config:
+            name: nola_segment_costs_physical_cost_non_negative
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_nola_bike_segments')
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: way_id
+        data_tests:
+          - not_null
+      - name: start_node_id
+        data_tests:
+          - not_null
+      - name: end_node_id
+        data_tests:
+          - not_null
+      - name: length_m
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                strictly: true
+      - name: geom
+        data_tests:
+          - not_null
+      - name: speed_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: road_type_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: infrastructure_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: tunnel_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: surface_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: lighting_factor
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: physical_cost
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+      - name: infra_category
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - separated
+                  - on_road
+                  - shared
+                  - path
+              config:
+                where: infra_category is not null
+  - name: nola_intersection_costs
+    description: Logical bike-network intersections with stress penalties. A row exists
+      for each node where >= 2 distinct OSM ways meet AND >= 1 of those ways carries
+      cars. Joined into nola_bike_stress_weighted_segments on end_node_id.
+    columns:
+      - name: osmid
+        description: OSM node id (unique).
+        data_tests:
+          - not_null
+          - unique
+          - dbt_utils.relationships_where:
+              arguments:
+                to: source('osm', 'nola_osm_bike_network_nodes')
+                field: osm_id
+                from_condition: traffic_control is not null
+                to_condition: osm_type = 'node' and valid_to is null
+              config:
+                severity: warn
+      - name: traffic_control
+        description: Raw OSM 'highway' tag value on the node, or NULL for uncontrolled
+          intersections.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - traffic_signals
+                  - stop
+                  - crossing
+                  - mini_roundabout
+                  - give_way
+                  - turning_circle
+                  - turning_loop
+                quote: true
+      - name: max_road_class
+        description: Worst road class among car-carrying ways at this node.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - primary
+                  - secondary
+                  - tertiary
+                  - minor
+      - name: max_road_rank
+        description: Numeric form of max_road_class (1-4).
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 4
+      - name: intersection_cost
+        description: Stress cost added to a route for traversing through this intersection.
+        data_tests:
+          - not_null
+  - name: nola_bike_stress_weighted_segments
+    description: Stress-weighted directed segments for bike routing. One row per directed
+      edge (u, v, key). stress_cost is the primary routing weight, combining length,
+      speed, infrastructure, surface, lighting, crash history, and traffic control
+      penalties.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - start_node_id
+              - end_node_id
+              - way_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: stress_cost >= 0
+          config:
+            name: nola_stress_cost_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: crash_cost >= 0
+          config:
+            name: nola_crash_cost_non_negative
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_nola_bike_segments')
+    columns:
+      - name: start_node_id
+        data_tests:
+          - not_null
+      - name: end_node_id
+        data_tests:
+          - not_null
+      - name: way_id
+        data_tests:
+          - not_null
+      - name: length_m
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                strictly: true
+      - name: stress_cost
+        data_tests:
+          - not_null
+      - name: speed_factor
+        data_tests:
+          - not_null
+      - name: infrastructure_factor
+        data_tests:
+          - not_null
+      - name: surface_factor
+        data_tests:
+          - not_null
+      - name: lighting_factor
+        data_tests:
+          - not_null
+      - name: crash_cost
+        data_tests:
+          - not_null
+      - name: intersection_cost
+        data_tests:
+          - not_null
+      - name: geom
+        data_tests:
+          - not_null

--- a/platform/dbt/models/marts/cycling/nola/nola_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/nola/nola_bike_stress_weighted_segments.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized='table',
+    pre_hook=["SET work_mem = '256MB'"],
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (segment_id)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "RESET work_mem"
+    ]
+) }}
+
+{{ generate_city_bike_stress_weighted_segments_model('nola', include_crashes=false) }}

--- a/platform/dbt/models/marts/cycling/nola/nola_bikeindex_bike_thefts.sql
+++ b/platform/dbt/models/marts/cycling/nola/nola_bikeindex_bike_thefts.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_bikeindex_bike_thefts_model('nola', time_zone = 'America/Chicago') }}

--- a/platform/dbt/models/marts/cycling/nola/nola_intersection_costs.sql
+++ b/platform/dbt/models/marts/cycling/nola/nola_intersection_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_intersection_costs_model('nola') }}

--- a/platform/dbt/models/marts/cycling/nola/nola_osm_bike_parking.sql
+++ b/platform/dbt/models/marts/cycling/nola/nola_osm_bike_parking.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_osm_bike_parking_model('nola') }}

--- a/platform/dbt/models/marts/cycling/nola/nola_segment_costs.sql
+++ b/platform/dbt/models/marts/cycling/nola/nola_segment_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_costs_model('nola') }}

--- a/platform/dbt/models/staging/cycling/dc/_stg_dc_cycling.yml
+++ b/platform/dbt/models/staging/cycling/dc/_stg_dc_cycling.yml
@@ -1,0 +1,68 @@
+version: 2
+models:
+  - name: stg_dc_bike_ways
+    columns:
+      - name: osm_id
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: node_ids
+        data_tests:
+          - not_null
+      - name: node_count
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 2
+      - name: highway
+        data_tests:
+          - dbt_utils.not_empty_string
+  - name: stg_dc_way_nodes
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - way_id
+              - position
+    columns:
+      - name: way_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_dc_bike_ways')
+                field: osm_id
+      - name: position
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: node_id
+        data_tests:
+          - not_null
+  - name: stg_dc_intersection_nodes
+    data_tests:
+      - intersection_node_count_in_range:
+          arguments:
+            way_nodes_model: ref('stg_dc_way_nodes')
+    columns:
+      - name: node_id
+        data_tests:
+          - not_null
+          - unique
+  - name: stg_dc_way_segments
+    data_tests:
+      - segment_endpoints_match_node_ids:
+          arguments:
+            ways_model: ref('stg_dc_bike_ways')
+      - segments_cover_full_ways:
+          arguments:
+            way_nodes_model: ref('stg_dc_way_nodes')
+            intersection_nodes_model: ref('stg_dc_intersection_nodes')
+      - segment_geom_endpoints_match_node_positions:
+          arguments:
+            ways_model: ref('stg_dc_bike_ways')

--- a/platform/dbt/models/staging/cycling/dc/stg_dc_bike_segments.sql
+++ b/platform/dbt/models/staging/cycling/dc/stg_dc_bike_segments.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (way_id, start_position, end_position)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_bike_segments_model('dc') }}

--- a/platform/dbt/models/staging/cycling/dc/stg_dc_bike_ways.sql
+++ b/platform/dbt/models/staging/cycling/dc/stg_dc_bike_ways.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_bike_ways_model('dc', include_all_sidewalks=false) }}

--- a/platform/dbt/models/staging/cycling/dc/stg_dc_bikeindex_bike_thefts.sql
+++ b/platform/dbt/models/staging/cycling/dc/stg_dc_bikeindex_bike_thefts.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_bikeindex_bike_thefts_model('dc') }}

--- a/platform/dbt/models/staging/cycling/dc/stg_dc_intersection_nodes.sql
+++ b/platform/dbt/models/staging/cycling/dc/stg_dc_intersection_nodes.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_intersection_nodes_model('dc') }}

--- a/platform/dbt/models/staging/cycling/dc/stg_dc_osm_bike_infra.sql
+++ b/platform/dbt/models/staging/cycling/dc/stg_dc_osm_bike_infra.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_osm_bike_infra_model('dc', include_all_sidewalks=false) }}

--- a/platform/dbt/models/staging/cycling/dc/stg_dc_osm_bike_parking.sql
+++ b/platform/dbt/models/staging/cycling/dc/stg_dc_osm_bike_parking.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_osm_bike_parking_model('dc') }}

--- a/platform/dbt/models/staging/cycling/dc/stg_dc_way_nodes.sql
+++ b/platform/dbt/models/staging/cycling/dc/stg_dc_way_nodes.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_way_nodes_model('dc') }}

--- a/platform/dbt/models/staging/cycling/dc/stg_dc_way_segments.sql
+++ b/platform/dbt/models/staging/cycling/dc/stg_dc_way_segments.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_way_segments_model('dc') }}

--- a/platform/dbt/models/staging/cycling/madison/_stg_madison_cycling.yml
+++ b/platform/dbt/models/staging/cycling/madison/_stg_madison_cycling.yml
@@ -1,0 +1,68 @@
+version: 2
+models:
+  - name: stg_madison_bike_ways
+    columns:
+      - name: osm_id
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: node_ids
+        data_tests:
+          - not_null
+      - name: node_count
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 2
+      - name: highway
+        data_tests:
+          - dbt_utils.not_empty_string
+  - name: stg_madison_way_nodes
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - way_id
+              - position
+    columns:
+      - name: way_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_madison_bike_ways')
+                field: osm_id
+      - name: position
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: node_id
+        data_tests:
+          - not_null
+  - name: stg_madison_intersection_nodes
+    data_tests:
+      - intersection_node_count_in_range:
+          arguments:
+            way_nodes_model: ref('stg_madison_way_nodes')
+    columns:
+      - name: node_id
+        data_tests:
+          - not_null
+          - unique
+  - name: stg_madison_way_segments
+    data_tests:
+      - segment_endpoints_match_node_ids:
+          arguments:
+            ways_model: ref('stg_madison_bike_ways')
+      - segments_cover_full_ways:
+          arguments:
+            way_nodes_model: ref('stg_madison_way_nodes')
+            intersection_nodes_model: ref('stg_madison_intersection_nodes')
+      - segment_geom_endpoints_match_node_positions:
+          arguments:
+            ways_model: ref('stg_madison_bike_ways')

--- a/platform/dbt/models/staging/cycling/madison/stg_madison_bike_segments.sql
+++ b/platform/dbt/models/staging/cycling/madison/stg_madison_bike_segments.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (way_id, start_position, end_position)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_bike_segments_model('madison') }}

--- a/platform/dbt/models/staging/cycling/madison/stg_madison_bike_ways.sql
+++ b/platform/dbt/models/staging/cycling/madison/stg_madison_bike_ways.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_bike_ways_model('madison', include_all_sidewalks=false) }}

--- a/platform/dbt/models/staging/cycling/madison/stg_madison_bikeindex_bike_thefts.sql
+++ b/platform/dbt/models/staging/cycling/madison/stg_madison_bikeindex_bike_thefts.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_bikeindex_bike_thefts_model('madison') }}

--- a/platform/dbt/models/staging/cycling/madison/stg_madison_intersection_nodes.sql
+++ b/platform/dbt/models/staging/cycling/madison/stg_madison_intersection_nodes.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_intersection_nodes_model('madison') }}

--- a/platform/dbt/models/staging/cycling/madison/stg_madison_osm_bike_infra.sql
+++ b/platform/dbt/models/staging/cycling/madison/stg_madison_osm_bike_infra.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_osm_bike_infra_model('madison', include_all_sidewalks=false) }}

--- a/platform/dbt/models/staging/cycling/madison/stg_madison_osm_bike_parking.sql
+++ b/platform/dbt/models/staging/cycling/madison/stg_madison_osm_bike_parking.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_osm_bike_parking_model('madison') }}

--- a/platform/dbt/models/staging/cycling/madison/stg_madison_way_nodes.sql
+++ b/platform/dbt/models/staging/cycling/madison/stg_madison_way_nodes.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_way_nodes_model('madison') }}

--- a/platform/dbt/models/staging/cycling/madison/stg_madison_way_segments.sql
+++ b/platform/dbt/models/staging/cycling/madison/stg_madison_way_segments.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_way_segments_model('madison') }}

--- a/platform/dbt/models/staging/cycling/nola/_stg_nola_cycling.yml
+++ b/platform/dbt/models/staging/cycling/nola/_stg_nola_cycling.yml
@@ -1,0 +1,68 @@
+version: 2
+models:
+  - name: stg_nola_bike_ways
+    columns:
+      - name: osm_id
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: node_ids
+        data_tests:
+          - not_null
+      - name: node_count
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 2
+      - name: highway
+        data_tests:
+          - dbt_utils.not_empty_string
+  - name: stg_nola_way_nodes
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - way_id
+              - position
+    columns:
+      - name: way_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_nola_bike_ways')
+                field: osm_id
+      - name: position
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: node_id
+        data_tests:
+          - not_null
+  - name: stg_nola_intersection_nodes
+    data_tests:
+      - intersection_node_count_in_range:
+          arguments:
+            way_nodes_model: ref('stg_nola_way_nodes')
+    columns:
+      - name: node_id
+        data_tests:
+          - not_null
+          - unique
+  - name: stg_nola_way_segments
+    data_tests:
+      - segment_endpoints_match_node_ids:
+          arguments:
+            ways_model: ref('stg_nola_bike_ways')
+      - segments_cover_full_ways:
+          arguments:
+            way_nodes_model: ref('stg_nola_way_nodes')
+            intersection_nodes_model: ref('stg_nola_intersection_nodes')
+      - segment_geom_endpoints_match_node_positions:
+          arguments:
+            ways_model: ref('stg_nola_bike_ways')

--- a/platform/dbt/models/staging/cycling/nola/stg_nola_bike_segments.sql
+++ b/platform/dbt/models/staging/cycling/nola/stg_nola_bike_segments.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (way_id, start_position, end_position)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_bike_segments_model('nola') }}

--- a/platform/dbt/models/staging/cycling/nola/stg_nola_bike_ways.sql
+++ b/platform/dbt/models/staging/cycling/nola/stg_nola_bike_ways.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_bike_ways_model('nola', include_all_sidewalks=false) }}

--- a/platform/dbt/models/staging/cycling/nola/stg_nola_bikeindex_bike_thefts.sql
+++ b/platform/dbt/models/staging/cycling/nola/stg_nola_bikeindex_bike_thefts.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_bikeindex_bike_thefts_model('nola') }}

--- a/platform/dbt/models/staging/cycling/nola/stg_nola_intersection_nodes.sql
+++ b/platform/dbt/models/staging/cycling/nola/stg_nola_intersection_nodes.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_intersection_nodes_model('nola') }}

--- a/platform/dbt/models/staging/cycling/nola/stg_nola_osm_bike_infra.sql
+++ b/platform/dbt/models/staging/cycling/nola/stg_nola_osm_bike_infra.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_osm_bike_infra_model('nola', include_all_sidewalks=false) }}

--- a/platform/dbt/models/staging/cycling/nola/stg_nola_osm_bike_parking.sql
+++ b/platform/dbt/models/staging/cycling/nola/stg_nola_osm_bike_parking.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_osm_bike_parking_model('nola') }}

--- a/platform/dbt/models/staging/cycling/nola/stg_nola_way_nodes.sql
+++ b/platform/dbt/models/staging/cycling/nola/stg_nola_way_nodes.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_way_nodes_model('nola') }}

--- a/platform/dbt/models/staging/cycling/nola/stg_nola_way_segments.sql
+++ b/platform/dbt/models/staging/cycling/nola/stg_nola_way_segments.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_way_segments_model('nola') }}

--- a/platform/migrations/postgres/V51__add_osm_tables.sql
+++ b/platform/migrations/postgres/V51__add_osm_tables.sql
@@ -1,0 +1,180 @@
+alter table raw_data.new_orleans_osm_bike_network_edges rename to nola_osm_bike_network_edges;
+alter table raw_data.new_orleans_osm_bike_network_nodes rename to nola_osm_bike_network_nodes;
+
+create table if not exists raw_data.nola_osm_bike_parking (
+    "osm_type" text not null,
+    "osm_id" bigint not null,
+    "osm_version" integer,
+    "osm_timestamp" timestamptz,
+    "geom" geometry(Geometry, 4326),
+    "tags" jsonb,
+    "node_ids" bigint[],
+    "name" text,
+    "bicycle_parking" text,
+    "capacity" text,
+    "covered" text,
+    "access" text,
+    "ingested_at" timestamptz not null,
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.nola_osm_bike_parking
+    add constraint uq_nola_osm_bike_parking_entity_hash
+    unique ("osm_type", "osm_id", "record_hash");
+create index if not exists ix_nola_osm_bike_parking_current
+    on raw_data.nola_osm_bike_parking ("osm_type", "osm_id")
+    where valid_to is null;
+create index if not exists ix_nola_osm_bike_parking_geom
+    on raw_data.nola_osm_bike_parking using gist (geom)
+    where valid_to is null;
+
+
+create table if not exists raw_data.nyc_osm_bike_network_edges (
+    "osm_type" text not null,
+    "osm_id" bigint not null,
+    "osm_version" integer,
+    "osm_timestamp" timestamptz,
+    "geom" geometry(Geometry, 4326),
+    "tags" jsonb,
+    "node_ids" bigint[],
+    "highway" text,
+    "name" text,
+    "bicycle" text,
+    "cycleway" text,
+    "cycleway_left" text,
+    "cycleway_right" text,
+    "surface" text,
+    "maxspeed" text,
+    "oneway" text,
+    "ingested_at" timestamptz not null,
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.nyc_osm_bike_network_edges
+    add constraint uq_nyc_osm_bike_network_edges_entity_hash
+    unique ("osm_type", "osm_id", "record_hash");
+create index if not exists ix_nyc_osm_bike_network_edges_current
+    on raw_data.nyc_osm_bike_network_edges ("osm_type", "osm_id")
+    where valid_to is null;
+create index if not exists ix_nyc_osm_bike_network_edges_geom
+    on raw_data.nyc_osm_bike_network_edges using gist (geom)
+    where valid_to is null;
+
+
+create table if not exists raw_data.nyc_osm_bike_network_nodes (
+    "osm_type" text not null,
+    "osm_id" bigint not null,
+    "osm_version" integer,
+    "osm_timestamp" timestamptz,
+    "geom" geometry(Geometry, 4326),
+    "tags" jsonb,
+    "node_ids" bigint[],
+    "highway" text,
+    "crossing" text,
+    "traffic_calming" text,
+    "barrier" text,
+    "bicycle" text,
+    "name" text,
+    "button_operated" text,
+    "tactile_paving" text,
+    "ingested_at" timestamptz not null,
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.nyc_osm_bike_network_nodes
+    add constraint uq_nyc_osm_bike_network_nodes_entity_hash
+    unique ("osm_type", "osm_id", "record_hash");
+create index if not exists ix_nyc_osm_bike_network_nodes_current
+    on raw_data.nyc_osm_bike_network_nodes ("osm_type", "osm_id")
+    where valid_to is null;
+create index if not exists ix_nyc_osm_bike_network_nodes_geom
+    on raw_data.nyc_osm_bike_network_nodes using gist (geom)
+    where valid_to is null;
+
+
+create table if not exists raw_data.nyc_osm_bike_parking (
+    "osm_type" text not null,
+    "osm_id" bigint not null,
+    "osm_version" integer,
+    "osm_timestamp" timestamptz,
+    "geom" geometry(Geometry, 4326),
+    "tags" jsonb,
+    "node_ids" bigint[],
+    "name" text,
+    "bicycle_parking" text,
+    "capacity" text,
+    "covered" text,
+    "access" text,
+    "ingested_at" timestamptz not null,
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.nyc_osm_bike_parking
+    add constraint uq_nyc_osm_bike_parking_entity_hash
+    unique ("osm_type", "osm_id", "record_hash");
+create index if not exists ix_nyc_osm_bike_parking_current
+    on raw_data.nyc_osm_bike_parking ("osm_type", "osm_id")
+    where valid_to is null;
+create index if not exists ix_nyc_osm_bike_parking_geom
+    on raw_data.nyc_osm_bike_parking using gist (geom)
+    where valid_to is null;
+
+
+create table raw_data.nyc_bikeindex_bike_thefts (
+    "id" integer not null,
+    "title" text,
+    "serial" text,
+    "manufacturer_name" text,
+    "frame_model" text,
+    "frame_colors" jsonb,
+    "year" integer,
+    "stolen" boolean,
+    "date_stolen" bigint,
+    "description" text,
+    "thumb" text,
+    "url" text,
+    "stolen_coordinates_lat" double precision,
+    "stolen_coordinates_lon" double precision,
+    "stolen_location" text,
+    "latitude" double precision,
+    "longitude" double precision,
+    "theft_description" text,
+    "locking_description" text,
+    "lock_defeat_description" text,
+    "police_report_number" text,
+    "police_report_department" text,
+    "propulsion_type_slug" text,
+    "cycle_type_slug" text,
+    "status" text,
+    "registration_created_at" bigint,
+    "registration_updated_at" bigint,
+    "manufacturer_id" integer,
+    "paint_description" text,
+    "frame_size" text,
+    "frame_material_slug" text,
+    "handlebar_type_slug" text,
+    "front_gear_type_slug" text,
+    "rear_gear_type_slug" text,
+    "rear_wheel_size_iso_bsd" integer,
+    "front_wheel_size_iso_bsd" integer,
+    "rear_tire_narrow" boolean,
+    "front_tire_narrow" boolean,
+    "extra_registration_number" text,
+    "additional_registration" text,
+    "components" jsonb,
+    "public_images" jsonb,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.nyc_bikeindex_bike_thefts
+    add constraint uq_nyc_bikeindex_bike_thefts_entity_hash
+    unique ("id", "record_hash");
+create index ix_nyc_bikeindex_bike_thefts_current
+    on raw_data.nyc_bikeindex_bike_thefts ("id")
+    where "valid_to" is null;

--- a/platform/migrations/postgres/V52__rename_table.sql
+++ b/platform/migrations/postgres/V52__rename_table.sql
@@ -1,0 +1,1 @@
+alter table raw_data.new_orleans_bikeindex_bike_thefts rename to nola_bikeindex_bike_thefts;


### PR DESCRIPTION
Changes:
* Adds basic OSM and BikeIndex bike-infra map for New Orleans (and changed the name to "nola" for a more compact url). Closes #216 
* Adds basic OSM and BikeIndex bike-infra map for Madison, WI. Closes #219 
* Adds basic OSM and BikeIndex bike-infra map for DC. Closes #222 
* Adds data collection DAGs for NYC edges, nodes, and bike thefts.

<img width="3356" height="2160" alt="image" src="https://github.com/user-attachments/assets/571d3ba1-fd9c-49fb-9541-e8846a4838ee" />

<img width="3356" height="2160" alt="image" src="https://github.com/user-attachments/assets/b7fdd468-60f7-4ad2-bcaa-c96e97eb245a" />

<img width="3356" height="2160" alt="image" src="https://github.com/user-attachments/assets/1c5104f8-72e3-4818-9d54-dd82461f5b65" />
