### PR TITLE
Refactors reused configs out of refresh_bike_map DAGs and improves smoke test and logging.

### DIFF
--- a/apps/bike-map-landing/config/prod.json
+++ b/apps/bike-map-landing/config/prod.json
@@ -1,0 +1,9 @@
+{
+  "title": "Bike Infrastructure Maps",
+  "tagline": "Cycling data, route suggestions, and infrastructure maps for the cities below.",
+  "about_paragraphs": [
+    "Bike Map is a personal project that publishes cycling-focused maps and route suggestions for the cities below. Each city map shows where crashes, thefts, and bike parking are concentrated based on recent public data, and the routing engine prefers streets with better bike infrastructure, lower speed limits, and less severe recent crash history.",
+    "Data comes from OpenStreetMap contributors and from each city's open data portals. This project does not independently verify the accuracy or completeness of any of these sources, and the route suggestions are informational — no substitute for your own judgment while riding."
+  ],
+  "cities": "<cities>"
+}

--- a/apps/bike-map-landing/config/staging.json
+++ b/apps/bike-map-landing/config/staging.json
@@ -1,0 +1,9 @@
+{
+  "title": "Bike Infrastructure Maps",
+  "tagline": "Cycling data, route suggestions, and infrastructure maps for the cities below.",
+  "about_paragraphs": [
+    "Bike Map is a personal project that publishes cycling-focused maps and route suggestions for the cities below. Each city map shows where crashes, thefts, and bike parking are concentrated based on recent public data, and the routing engine prefers streets with better bike infrastructure, lower speed limits, and less severe recent crash history.",
+    "Data comes from OpenStreetMap contributors and from each city's open data portals. This project does not independently verify the accuracy or completeness of any of these sources, and the route suggestions are informational — no substitute for your own judgment while riding."
+  ],
+  "cities": "<cities>"
+}

--- a/platform/airflow/dags/dag_files/refresh_bike_map_dc.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_dc.py
@@ -4,7 +4,8 @@
 from datetime import datetime
 
 from airflow.sdk import dag
-from loci.exports.bike_map_layers import LayerDisplayConfig, PopupField
+from loci.apps.bike_map import data_layers
+from loci.exports.bike_map_layers import LayerDisplayConfig
 from loci.exports.geojson_export import GeoJSONExportConfig
 from loci.sources.dataset_specs import WASHINGTON_DC_BBOX
 from loci.tasks.bike_map_tasks import (
@@ -14,111 +15,44 @@ from loci.tasks.bike_map_tasks import (
 )
 from loci.tasks.testing.route_tests import RouteTestCase
 
-DC_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
-    GeoJSONExportConfig(
-        name="thefts",
-        table="dc_bikeindex_bike_thefts",
-        latitude_column="latitude",
-        longitude_column="longitude",
-        properties=[
-            "source",
-            "source_id",
-            "theft_date",
-            "theft_year",
-            "theft_hour",
-            "bike_title",
-            "bike_description",
-            "theft_description",
-            "locking_description",
-            "lock_defeat_description",
-            "theft_status",
-            "latitude",
-            "longitude",
-            "location",
-        ],
-    ),
-    GeoJSONExportConfig(
-        name="parking",
-        table="dc_osm_bike_parking",
-        geometry_column="geom",
-        properties=[
-            "osm_id",
-            "type",
-            "capacity",
-            "covered",
-            "indoor",
-            "fee",
-            "lit",
-            "operator",
-            "access",
-        ],
-    ),
+CITY = "dc"
+
+CITY_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
+    data_layers.bikeindex_bike_theft_geojson_config_factory(CITY),
+    data_layers.osm_bike_parking_geojson_config_factory(CITY),
 ]
 
-DC_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
-    LayerDisplayConfig(
-        export_name="thefts",
-        label="Thefts",
-        color="#f59e0b",
-        popup_title="Thefts",
-        date_field="theft_date",
-        popup_fields=[
-            PopupField(key="source", label="Source"),
-            PopupField(key="theft_date", label="Theft Date"),
-            PopupField(key="theft_year", label="Theft Year"),
-            PopupField(key="theft_hour", label="Theft Hour", fmt="hour"),
-            PopupField(key="bike_title", label="Bike Title"),
-            PopupField(key="bike_description", label="Bike Description"),
-            PopupField(key="theft_description", label="Theft Description"),
-            PopupField(key="locking_description", label="Locking Description"),
-            PopupField(key="lock_defeat_description", label="Lock Defeat Description"),
-            PopupField(key="theft_status", label="Theft Status"),
-        ],
-    ),
-    LayerDisplayConfig(
-        export_name="parking",
-        label="Parking",
-        color="#22c55e",
-        popup_title="Parking",
-        popup_fields=[
-            PopupField(key="type", label="Type"),
-            PopupField(key="capacity", label="Capacity"),
-            PopupField(key="covered", label="Covered", fmt="yes_no_bool"),
-            PopupField(key="indoor", label="Indoor", fmt="yes_no_bool"),
-            PopupField(key="lit", label="Lit", fmt="yes_no_bool"),
-            PopupField(key="fee", label="Fee", fmt="yes_no_bool"),
-            PopupField(key="operator", label="Operator"),
-            PopupField(key="access", label="Access"),
-        ],
-    ),
+CITY_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
+    data_layers.BIKEINDEX_BIKE_THEFTS_LAYER_CONFIG,
+    data_layers.OSM_BIKE_PARKING_LAYER_CONFIG,
 ]
 
-DC_ROUTE_TESTS: list[RouteTestCase] = []
+CITY_ROUTE_TESTS: list[RouteTestCase] = []
 
-DC_SPEC = CityBuildSpec(
-    city="dc",
+CITY_SPEC = CityBuildSpec(
+    city=CITY,
     bbox=WASHINGTON_DC_BBOX,
     pre_export_dbt_selects=[
-        ("--select", "+dc_bikeindex_bike_thefts"),
-        ("--select", "+dc_osm_bike_parking"),
+        ("--select", f"+{CITY}_bikeindex_bike_thefts"),
+        ("--select", f"+{CITY}_osm_bike_parking"),
     ],
-    geojson_exports=DC_GEOJSON_EXPORTS,
-    layer_displays=DC_LAYER_DISPLAYS,
-    weights_dbt_select="+dc_bike_stress_weighted_segments",
-    route_tests=DC_ROUTE_TESTS,
+    geojson_exports=CITY_GEOJSON_EXPORTS,
+    layer_displays=CITY_LAYER_DISPLAYS,
+    weights_dbt_select=f"+{CITY}_bike_stress_weighted_segments",
+    route_tests=CITY_ROUTE_TESTS,
 )
 
 
 @dag(
-    dag_id="refresh_bike_map_dc",
+    dag_id=f"refresh_bike_map_{CITY}",
     start_date=datetime(2024, 1, 1),
     schedule=None,
     catchup=False,
-    tags=["bike-map", "dc"],
-    params=standard_dag_params("dc"),
+    tags=["bike-map", CITY],
+    params=standard_dag_params(CITY),
 )
 def refresh_bike_map_dc():
-    build_refresh_task_graph(DC_SPEC)
+    build_refresh_task_graph(CITY_SPEC)
 
 
 refresh_bike_map_dc()

--- a/platform/airflow/dags/dag_files/refresh_bike_map_detroit.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_detroit.py
@@ -1,10 +1,11 @@
-# loci_platform/platform/airflow/dags/dag_files/refresh_bike_map_chicago.py
-"""Refresh the Chicago bike map: dbt build → export → deploy."""
+# loci_platform/platform/airflow/dags/dag_files/refresh_bike_map_detroit.py
+"""Refresh the Detroit bike map: dbt build → export → deploy."""
 
 from datetime import datetime
 
 from airflow.sdk import dag
-from loci.exports.bike_map_layers import LayerDisplayConfig, PopupField
+from loci.apps.bike_map import data_layers
+from loci.exports.bike_map_layers import LayerDisplayConfig
 from loci.exports.geojson_export import GeoJSONExportConfig
 from loci.sources.dataset_specs import DETROIT_BBOX
 from loci.tasks.bike_map_tasks import (
@@ -14,111 +15,44 @@ from loci.tasks.bike_map_tasks import (
 )
 from loci.tasks.testing.route_tests import RouteTestCase
 
-DETROIT_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
-    GeoJSONExportConfig(
-        name="thefts",
-        table="detroit_bikeindex_bike_thefts",
-        latitude_column="latitude",
-        longitude_column="longitude",
-        properties=[
-            "source",
-            "source_id",
-            "theft_date",
-            "theft_year",
-            "theft_hour",
-            "bike_title",
-            "bike_description",
-            "theft_description",
-            "locking_description",
-            "lock_defeat_description",
-            "theft_status",
-            "latitude",
-            "longitude",
-            "location",
-        ],
-    ),
-    GeoJSONExportConfig(
-        name="parking",
-        table="detroit_osm_bike_parking",
-        geometry_column="geom",
-        properties=[
-            "osm_id",
-            "type",
-            "capacity",
-            "covered",
-            "indoor",
-            "fee",
-            "lit",
-            "operator",
-            "access",
-        ],
-    ),
+CITY = "detroit"
+
+CITY_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
+    data_layers.bikeindex_bike_theft_geojson_config_factory(CITY),
+    data_layers.osm_bike_parking_geojson_config_factory(CITY),
 ]
 
-DETROIT_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
-    LayerDisplayConfig(
-        export_name="thefts",
-        label="Thefts",
-        color="#f59e0b",
-        popup_title="Thefts",
-        date_field="theft_date",
-        popup_fields=[
-            PopupField(key="source", label="Source"),
-            PopupField(key="theft_date", label="Theft Date"),
-            PopupField(key="theft_year", label="Theft Year"),
-            PopupField(key="theft_hour", label="Theft Hour", fmt="hour"),
-            PopupField(key="bike_title", label="Bike Title"),
-            PopupField(key="bike_description", label="Bike Description"),
-            PopupField(key="theft_description", label="Theft Description"),
-            PopupField(key="locking_description", label="Locking Description"),
-            PopupField(key="lock_defeat_description", label="Lock Defeat Description"),
-            PopupField(key="theft_status", label="Theft Status"),
-        ],
-    ),
-    LayerDisplayConfig(
-        export_name="parking",
-        label="Parking",
-        color="#22c55e",
-        popup_title="Parking",
-        popup_fields=[
-            PopupField(key="type", label="Type"),
-            PopupField(key="capacity", label="Capacity"),
-            PopupField(key="covered", label="Covered", fmt="yes_no_bool"),
-            PopupField(key="indoor", label="Indoor", fmt="yes_no_bool"),
-            PopupField(key="lit", label="Lit", fmt="yes_no_bool"),
-            PopupField(key="fee", label="Fee", fmt="yes_no_bool"),
-            PopupField(key="operator", label="Operator"),
-            PopupField(key="access", label="Access"),
-        ],
-    ),
+CITY_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
+    data_layers.BIKEINDEX_BIKE_THEFTS_LAYER_CONFIG,
+    data_layers.OSM_BIKE_PARKING_LAYER_CONFIG,
 ]
 
-DETROIT_ROUTE_TESTS: list[RouteTestCase] = []
+CITY_ROUTE_TESTS: list[RouteTestCase] = []
 
-DETROIT_SPEC = CityBuildSpec(
-    city="detroit",
+CITY_SPEC = CityBuildSpec(
+    city=CITY,
     bbox=DETROIT_BBOX,
     pre_export_dbt_selects=[
-        ("--select", "+detroit_bikeindex_bike_thefts"),
-        ("--select", "+detroit_osm_bike_parking"),
+        ("--select", f"+{CITY}_bikeindex_bike_thefts"),
+        ("--select", f"+{CITY}_osm_bike_parking"),
     ],
-    geojson_exports=DETROIT_GEOJSON_EXPORTS,
-    layer_displays=DETROIT_LAYER_DISPLAYS,
-    weights_dbt_select="+detroit_bike_stress_weighted_segments",
-    route_tests=DETROIT_ROUTE_TESTS,
+    geojson_exports=CITY_GEOJSON_EXPORTS,
+    layer_displays=CITY_LAYER_DISPLAYS,
+    weights_dbt_select=f"+{CITY}_bike_stress_weighted_segments",
+    route_tests=CITY_ROUTE_TESTS,
 )
 
 
 @dag(
-    dag_id="refresh_bike_map_detroit",
+    dag_id=f"refresh_bike_map_{CITY}",
     start_date=datetime(2024, 1, 1),
     schedule=None,
     catchup=False,
-    tags=["bike-map", "detroit"],
-    params=standard_dag_params("detroit"),
+    tags=["bike-map", CITY],
+    params=standard_dag_params(CITY),
 )
 def refresh_bike_map_detroit():
-    build_refresh_task_graph(DETROIT_SPEC)
+    build_refresh_task_graph(CITY_SPEC)
 
 
 refresh_bike_map_detroit()

--- a/platform/airflow/dags/dag_files/refresh_bike_map_madison.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_madison.py
@@ -4,7 +4,8 @@
 from datetime import datetime
 
 from airflow.sdk import dag
-from loci.exports.bike_map_layers import LayerDisplayConfig, PopupField
+from loci.apps.bike_map import data_layers
+from loci.exports.bike_map_layers import LayerDisplayConfig
 from loci.exports.geojson_export import GeoJSONExportConfig
 from loci.sources.dataset_specs import MADISON_BBOX
 from loci.tasks.bike_map_tasks import (
@@ -14,111 +15,44 @@ from loci.tasks.bike_map_tasks import (
 )
 from loci.tasks.testing.route_tests import RouteTestCase
 
-MADISON_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
-    GeoJSONExportConfig(
-        name="thefts",
-        table="madison_bikeindex_bike_thefts",
-        latitude_column="latitude",
-        longitude_column="longitude",
-        properties=[
-            "source",
-            "source_id",
-            "theft_date",
-            "theft_year",
-            "theft_hour",
-            "bike_title",
-            "bike_description",
-            "theft_description",
-            "locking_description",
-            "lock_defeat_description",
-            "theft_status",
-            "latitude",
-            "longitude",
-            "location",
-        ],
-    ),
-    GeoJSONExportConfig(
-        name="parking",
-        table="madison_osm_bike_parking",
-        geometry_column="geom",
-        properties=[
-            "osm_id",
-            "type",
-            "capacity",
-            "covered",
-            "indoor",
-            "fee",
-            "lit",
-            "operator",
-            "access",
-        ],
-    ),
+CITY = "madison"
+
+CITY_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
+    data_layers.bikeindex_bike_theft_geojson_config_factory(CITY),
+    data_layers.osm_bike_parking_geojson_config_factory(CITY),
 ]
 
-MADISON_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
-    LayerDisplayConfig(
-        export_name="thefts",
-        label="Thefts",
-        color="#f59e0b",
-        popup_title="Thefts",
-        date_field="theft_date",
-        popup_fields=[
-            PopupField(key="source", label="Source"),
-            PopupField(key="theft_date", label="Theft Date"),
-            PopupField(key="theft_year", label="Theft Year"),
-            PopupField(key="theft_hour", label="Theft Hour", fmt="hour"),
-            PopupField(key="bike_title", label="Bike Title"),
-            PopupField(key="bike_description", label="Bike Description"),
-            PopupField(key="theft_description", label="Theft Description"),
-            PopupField(key="locking_description", label="Locking Description"),
-            PopupField(key="lock_defeat_description", label="Lock Defeat Description"),
-            PopupField(key="theft_status", label="Theft Status"),
-        ],
-    ),
-    LayerDisplayConfig(
-        export_name="parking",
-        label="Parking",
-        color="#22c55e",
-        popup_title="Parking",
-        popup_fields=[
-            PopupField(key="type", label="Type"),
-            PopupField(key="capacity", label="Capacity"),
-            PopupField(key="covered", label="Covered", fmt="yes_no_bool"),
-            PopupField(key="indoor", label="Indoor", fmt="yes_no_bool"),
-            PopupField(key="lit", label="Lit", fmt="yes_no_bool"),
-            PopupField(key="fee", label="Fee", fmt="yes_no_bool"),
-            PopupField(key="operator", label="Operator"),
-            PopupField(key="access", label="Access"),
-        ],
-    ),
+CITY_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
+    data_layers.BIKEINDEX_BIKE_THEFTS_LAYER_CONFIG,
+    data_layers.OSM_BIKE_PARKING_LAYER_CONFIG,
 ]
 
-MADISON_ROUTE_TESTS: list[RouteTestCase] = []
+CITY_ROUTE_TESTS: list[RouteTestCase] = []
 
-MADISON_SPEC = CityBuildSpec(
-    city="madison",
+CITY_SPEC = CityBuildSpec(
+    city=CITY,
     bbox=MADISON_BBOX,
     pre_export_dbt_selects=[
-        ("--select", "+madison_bikeindex_bike_thefts"),
-        ("--select", "+madison_osm_bike_parking"),
+        ("--select", f"+{CITY}_bikeindex_bike_thefts"),
+        ("--select", f"+{CITY}_osm_bike_parking"),
     ],
-    geojson_exports=MADISON_GEOJSON_EXPORTS,
-    layer_displays=MADISON_LAYER_DISPLAYS,
-    weights_dbt_select="+madison_bike_stress_weighted_segments",
-    route_tests=MADISON_ROUTE_TESTS,
+    geojson_exports=CITY_GEOJSON_EXPORTS,
+    layer_displays=CITY_LAYER_DISPLAYS,
+    weights_dbt_select=f"+{CITY}_bike_stress_weighted_segments",
+    route_tests=CITY_ROUTE_TESTS,
 )
 
 
 @dag(
-    dag_id="refresh_bike_map_madison",
+    dag_id=f"refresh_bike_map_{CITY}",
     start_date=datetime(2024, 1, 1),
     schedule=None,
     catchup=False,
-    tags=["bike-map", "madison"],
-    params=standard_dag_params("madison"),
+    tags=["bike-map", CITY],
+    params=standard_dag_params(CITY),
 )
 def refresh_bike_map_madison():
-    build_refresh_task_graph(MADISON_SPEC)
+    build_refresh_task_graph(CITY_SPEC)
 
 
 refresh_bike_map_madison()

--- a/platform/airflow/dags/dag_files/refresh_bike_map_nola.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_nola.py
@@ -4,7 +4,8 @@
 from datetime import datetime
 
 from airflow.sdk import dag
-from loci.exports.bike_map_layers import LayerDisplayConfig, PopupField
+from loci.apps.bike_map import data_layers
+from loci.exports.bike_map_layers import LayerDisplayConfig
 from loci.exports.geojson_export import GeoJSONExportConfig
 from loci.sources.dataset_specs import NEW_ORLEANS_BBOX
 from loci.tasks.bike_map_tasks import (
@@ -14,111 +15,44 @@ from loci.tasks.bike_map_tasks import (
 )
 from loci.tasks.testing.route_tests import RouteTestCase
 
-NOLA_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
-    GeoJSONExportConfig(
-        name="thefts",
-        table="nola_bikeindex_bike_thefts",
-        latitude_column="latitude",
-        longitude_column="longitude",
-        properties=[
-            "source",
-            "source_id",
-            "theft_date",
-            "theft_year",
-            "theft_hour",
-            "bike_title",
-            "bike_description",
-            "theft_description",
-            "locking_description",
-            "lock_defeat_description",
-            "theft_status",
-            "latitude",
-            "longitude",
-            "location",
-        ],
-    ),
-    GeoJSONExportConfig(
-        name="parking",
-        table="nola_osm_bike_parking",
-        geometry_column="geom",
-        properties=[
-            "osm_id",
-            "type",
-            "capacity",
-            "covered",
-            "indoor",
-            "fee",
-            "lit",
-            "operator",
-            "access",
-        ],
-    ),
+CITY = "nola"
+
+CITY_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
+    data_layers.bikeindex_bike_theft_geojson_config_factory(CITY),
+    data_layers.osm_bike_parking_geojson_config_factory(CITY),
 ]
 
-NOLA_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
-    LayerDisplayConfig(
-        export_name="thefts",
-        label="Thefts",
-        color="#f59e0b",
-        popup_title="Thefts",
-        date_field="theft_date",
-        popup_fields=[
-            PopupField(key="source", label="Source"),
-            PopupField(key="theft_date", label="Theft Date"),
-            PopupField(key="theft_year", label="Theft Year"),
-            PopupField(key="theft_hour", label="Theft Hour", fmt="hour"),
-            PopupField(key="bike_title", label="Bike Title"),
-            PopupField(key="bike_description", label="Bike Description"),
-            PopupField(key="theft_description", label="Theft Description"),
-            PopupField(key="locking_description", label="Locking Description"),
-            PopupField(key="lock_defeat_description", label="Lock Defeat Description"),
-            PopupField(key="theft_status", label="Theft Status"),
-        ],
-    ),
-    LayerDisplayConfig(
-        export_name="parking",
-        label="Parking",
-        color="#22c55e",
-        popup_title="Parking",
-        popup_fields=[
-            PopupField(key="type", label="Type"),
-            PopupField(key="capacity", label="Capacity"),
-            PopupField(key="covered", label="Covered", fmt="yes_no_bool"),
-            PopupField(key="indoor", label="Indoor", fmt="yes_no_bool"),
-            PopupField(key="lit", label="Lit", fmt="yes_no_bool"),
-            PopupField(key="fee", label="Fee", fmt="yes_no_bool"),
-            PopupField(key="operator", label="Operator"),
-            PopupField(key="access", label="Access"),
-        ],
-    ),
+CITY_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
+    data_layers.BIKEINDEX_BIKE_THEFTS_LAYER_CONFIG,
+    data_layers.OSM_BIKE_PARKING_LAYER_CONFIG,
 ]
 
-NOLA_ROUTE_TESTS: list[RouteTestCase] = []
+CITY_ROUTE_TESTS: list[RouteTestCase] = []
 
-NOLA_SPEC = CityBuildSpec(
+CITY_SPEC = CityBuildSpec(
     city="nola",
     bbox=NEW_ORLEANS_BBOX,
     pre_export_dbt_selects=[
-        ("--select", "+nola_bikeindex_bike_thefts"),
-        ("--select", "+nola_osm_bike_parking"),
+        ("--select", f"+{CITY}_bikeindex_bike_thefts"),
+        ("--select", f"+{CITY}_osm_bike_parking"),
     ],
-    geojson_exports=NOLA_GEOJSON_EXPORTS,
-    layer_displays=NOLA_LAYER_DISPLAYS,
-    weights_dbt_select="+nola_bike_stress_weighted_segments",
-    route_tests=NOLA_ROUTE_TESTS,
+    geojson_exports=CITY_GEOJSON_EXPORTS,
+    layer_displays=CITY_LAYER_DISPLAYS,
+    weights_dbt_select=f"+{CITY}_bike_stress_weighted_segments",
+    route_tests=CITY_ROUTE_TESTS,
 )
 
 
 @dag(
-    dag_id="refresh_bike_map_nola",
+    dag_id=f"refresh_bike_map_{CITY}",
     start_date=datetime(2024, 1, 1),
     schedule=None,
     catchup=False,
-    tags=["bike-map", "new_orleans"],
-    params=standard_dag_params("nola"),
+    tags=["bike-map", "new_orleans", CITY],
+    params=standard_dag_params(CITY),
 )
 def refresh_bike_map_nola():
-    build_refresh_task_graph(NOLA_SPEC)
+    build_refresh_task_graph(CITY_SPEC)
 
 
 refresh_bike_map_nola()

--- a/platform/airflow/dags/dag_files/refresh_bike_map_sf.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_sf.py
@@ -4,7 +4,8 @@
 from datetime import datetime
 
 from airflow.sdk import dag
-from loci.exports.bike_map_layers import LayerDisplayConfig, PopupField
+from loci.apps.bike_map import data_layers
+from loci.exports.bike_map_layers import LayerDisplayConfig
 from loci.exports.geojson_export import GeoJSONExportConfig
 from loci.sources.dataset_specs import SAN_FRANCISCO_BBOX
 from loci.tasks.bike_map_tasks import (
@@ -14,111 +15,44 @@ from loci.tasks.bike_map_tasks import (
 )
 from loci.tasks.testing.route_tests import RouteTestCase
 
-SF_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
-    GeoJSONExportConfig(
-        name="thefts",
-        table="sf_bikeindex_bike_thefts",
-        latitude_column="latitude",
-        longitude_column="longitude",
-        properties=[
-            "source",
-            "source_id",
-            "theft_date",
-            "theft_year",
-            "theft_hour",
-            "bike_title",
-            "bike_description",
-            "theft_description",
-            "locking_description",
-            "lock_defeat_description",
-            "theft_status",
-            "latitude",
-            "longitude",
-            "location",
-        ],
-    ),
-    GeoJSONExportConfig(
-        name="parking",
-        table="sf_osm_bike_parking",
-        geometry_column="geom",
-        properties=[
-            "osm_id",
-            "type",
-            "capacity",
-            "covered",
-            "indoor",
-            "fee",
-            "lit",
-            "operator",
-            "access",
-        ],
-    ),
+CITY = "sf"
+
+CITY_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
+    data_layers.bikeindex_bike_theft_geojson_config_factory(CITY),
+    data_layers.osm_bike_parking_geojson_config_factory(CITY),
 ]
 
-SF_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
-    LayerDisplayConfig(
-        export_name="thefts",
-        label="Thefts",
-        color="#f59e0b",
-        popup_title="Thefts",
-        date_field="theft_date",
-        popup_fields=[
-            PopupField(key="source", label="Source"),
-            PopupField(key="theft_date", label="Theft Date"),
-            PopupField(key="theft_year", label="Theft Year"),
-            PopupField(key="theft_hour", label="Theft Hour", fmt="hour"),
-            PopupField(key="bike_title", label="Bike Title"),
-            PopupField(key="bike_description", label="Bike Description"),
-            PopupField(key="theft_description", label="Theft Description"),
-            PopupField(key="locking_description", label="Locking Description"),
-            PopupField(key="lock_defeat_description", label="Lock Defeat Description"),
-            PopupField(key="theft_status", label="Theft Status"),
-        ],
-    ),
-    LayerDisplayConfig(
-        export_name="parking",
-        label="Parking",
-        color="#22c55e",
-        popup_title="Parking",
-        popup_fields=[
-            PopupField(key="type", label="Type"),
-            PopupField(key="capacity", label="Capacity"),
-            PopupField(key="covered", label="Covered", fmt="yes_no_bool"),
-            PopupField(key="indoor", label="Indoor", fmt="yes_no_bool"),
-            PopupField(key="lit", label="Lit", fmt="yes_no_bool"),
-            PopupField(key="fee", label="Fee", fmt="yes_no_bool"),
-            PopupField(key="operator", label="Operator"),
-            PopupField(key="access", label="Access"),
-        ],
-    ),
+CITY_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
+    data_layers.BIKEINDEX_BIKE_THEFTS_LAYER_CONFIG,
+    data_layers.OSM_BIKE_PARKING_LAYER_CONFIG,
 ]
 
-SF_ROUTE_TESTS: list[RouteTestCase] = []
+CITY_ROUTE_TESTS: list[RouteTestCase] = []
 
-SF_SPEC = CityBuildSpec(
-    city="sf",
+CITY_SPEC = CityBuildSpec(
+    city=CITY,
     bbox=SAN_FRANCISCO_BBOX,
     pre_export_dbt_selects=[
-        ("--select", "+sf_bikeindex_bike_thefts"),
-        ("--select", "+sf_osm_bike_parking"),
+        ("--select", f"+{CITY}_bikeindex_bike_thefts"),
+        ("--select", f"+{CITY}_osm_bike_parking"),
     ],
-    geojson_exports=SF_GEOJSON_EXPORTS,
-    layer_displays=SF_LAYER_DISPLAYS,
-    weights_dbt_select="+sf_bike_stress_weighted_segments",
-    route_tests=SF_ROUTE_TESTS,
+    geojson_exports=CITY_GEOJSON_EXPORTS,
+    layer_displays=CITY_LAYER_DISPLAYS,
+    weights_dbt_select=f"+{CITY}_bike_stress_weighted_segments",
+    route_tests=CITY_ROUTE_TESTS,
 )
 
 
 @dag(
-    dag_id="refresh_bike_map_sf",
+    dag_id=f"refresh_bike_map_{CITY}",
     start_date=datetime(2024, 1, 1),
     schedule=None,
     catchup=False,
-    tags=["bike-map", "san_francisco"],
-    params=standard_dag_params("sf"),
+    tags=["bike-map", "san_francisco", CITY],
+    params=standard_dag_params(CITY),
 )
 def refresh_bike_map_sf():
-    build_refresh_task_graph(SF_SPEC)
+    build_refresh_task_graph(CITY_SPEC)
 
 
 refresh_bike_map_sf()

--- a/platform/airflow/dags/loci/apps/bike_map/data_layers.py
+++ b/platform/airflow/dags/loci/apps/bike_map/data_layers.py
@@ -1,0 +1,83 @@
+from loci.exports.bike_map_layers import LayerDisplayConfig, PopupField
+from loci.exports.geojson_export import GeoJSONExportConfig
+
+BIKEINDEX_BIKE_THEFTS_LAYER_CONFIG = LayerDisplayConfig(
+    export_name="thefts",
+    label="Thefts",
+    color="#f59e0b",
+    popup_title="Thefts",
+    date_field="theft_date",
+    popup_fields=[
+        PopupField(key="source", label="Source"),
+        PopupField(key="theft_date", label="Theft Date"),
+        PopupField(key="theft_year", label="Theft Year"),
+        PopupField(key="theft_hour", label="Theft Hour", fmt="hour"),
+        PopupField(key="bike_title", label="Bike Title"),
+        PopupField(key="bike_description", label="Bike Description"),
+        PopupField(key="theft_description", label="Theft Description"),
+        PopupField(key="locking_description", label="Locking Description"),
+        PopupField(key="lock_defeat_description", label="Lock Defeat Description"),
+        PopupField(key="theft_status", label="Theft Status"),
+    ],
+)
+
+OSM_BIKE_PARKING_LAYER_CONFIG = LayerDisplayConfig(
+    export_name="parking",
+    label="Parking",
+    color="#22c55e",
+    popup_title="Parking",
+    popup_fields=[
+        PopupField(key="type", label="Type"),
+        PopupField(key="capacity", label="Capacity"),
+        PopupField(key="covered", label="Covered", fmt="yes_no_bool"),
+        PopupField(key="indoor", label="Indoor", fmt="yes_no_bool"),
+        PopupField(key="lit", label="Lit", fmt="yes_no_bool"),
+        PopupField(key="fee", label="Fee", fmt="yes_no_bool"),
+        PopupField(key="operator", label="Operator"),
+        PopupField(key="access", label="Access"),
+    ],
+)
+
+
+def bikeindex_bike_theft_geojson_config_factory(city: str) -> GeoJSONExportConfig:
+    return GeoJSONExportConfig(
+        name="thefts",
+        table=f"{city}_bikeindex_bike_thefts",
+        latitude_column="latitude",
+        longitude_column="longitude",
+        properties=[
+            "source",
+            "source_id",
+            "theft_date",
+            "theft_year",
+            "theft_hour",
+            "bike_title",
+            "bike_description",
+            "theft_description",
+            "locking_description",
+            "lock_defeat_description",
+            "theft_status",
+            "latitude",
+            "longitude",
+            "location",
+        ],
+    )
+
+
+def osm_bike_parking_geojson_config_factory(city: str) -> GeoJSONExportConfig:
+    return GeoJSONExportConfig(
+        name="parking",
+        table=f"{city}_osm_bike_parking",
+        geometry_column="geom",
+        properties=[
+            "osm_id",
+            "type",
+            "capacity",
+            "covered",
+            "indoor",
+            "fee",
+            "lit",
+            "operator",
+            "access",
+        ],
+    )

--- a/platform/airflow/dags/loci/exports/graph_export.py
+++ b/platform/airflow/dags/loci/exports/graph_export.py
@@ -155,9 +155,7 @@ class RoutingGraphExporter:
         if highway is None or not highway.startswith("["):
             return highway
 
-        logger.warning(
-            "highway value arrived as stringified list, normalizing: %r", highway
-        )
+        logger.warning("highway value arrived as stringified list, normalizing: %r", highway)
         # Strip "[", "]", quotes, then take the first comma-separated value.
         cleaned = highway.strip("[]'\" ").split("'")[0].split(",")[0].strip()
         return cleaned or None
@@ -267,7 +265,22 @@ class RoutingGraphExporter:
         if self.min_component_size <= 1:
             return G
 
-        components = list(nx.weakly_connected_components(G))
+        components = sorted(nx.weakly_connected_components(G), key=len, reverse=True)
+        # (node_count, edge_count) per component, biggest first.
+        component_stats = [(len(c), G.subgraph(c).number_of_edges()) for c in components]
+
+        logger.info("Found %d weakly connected components", len(components))
+        for i, (n_nodes, n_edges) in enumerate(component_stats[:10]):
+            logger.info("  Component %d: %d nodes, %d edges", i, n_nodes, n_edges)
+        if len(component_stats) > 10:
+            smaller = component_stats[10:]
+            logger.info(
+                "  ... and %d smaller components (max %d nodes, %d nodes total)",
+                len(smaller),
+                max(n for n, _ in smaller),
+                sum(n for n, _ in smaller),
+            )
+
         before_nodes = G.number_of_nodes()
         before_edges = G.number_of_edges()
 
@@ -275,7 +288,6 @@ class RoutingGraphExporter:
         nodes_to_remove = set().union(*small) if small else set()
         G.remove_nodes_from(nodes_to_remove)
 
-        # Prune geometries for segments no longer referenced by any edge
         referenced = {data["segment_id"] for _, _, data in G.edges(data=True)}
         seg_geom = G.graph.get("segment_geometry", {})
         for sid in list(seg_geom):
@@ -292,6 +304,19 @@ class RoutingGraphExporter:
             G.number_of_nodes(),
             G.number_of_edges(),
         )
+
+        kept = [c for c in components if len(c) >= self.min_component_size]
+        if len(kept) > 1:
+            kept_stats = [(len(c), G.subgraph(c).number_of_edges()) for c in kept]
+            logger.warning(
+                "Graph has %d large components after filtering (sizes: %s). "
+                "Routes between components will fail. This is usually an OSM data "
+                "problem — check for missing bridges/tunnels, broken way connectivity, "
+                "or a bbox that splits the network.",
+                len(kept),
+                kept_stats,
+            )
+
         return G
 
     # ------------------------------------------------------------------

--- a/platform/airflow/dags/loci/tasks/testing/deployment_smoke_test.py
+++ b/platform/airflow/dags/loci/tasks/testing/deployment_smoke_test.py
@@ -67,75 +67,62 @@ def smoke_test_deployed_routing(
     logger: logging.Logger,
     max_distance_miles: float = 5.0,
     cold_start_timeout_s: int = 30,
+    warm_timeout_s: int = 10,
+    max_route_attempts: int = 5,
     seed: int | None = None,
 ) -> dict:
-    """Verify the deployed site can route end-to-end.
-
-    Fetches config.json from the site (same as a browser would), then
-    POSTs to the routing API using exactly those values with random
-    origin/destination points within the city bbox. Catches URL/path
-    mismatches, bad API keys, Lambda failures, and stale CloudFront
-    caches.
-
-    Args:
-        site_url: Base URL of the deployed site (no trailing slash).
-        bbox: (south, west, north, east) in lat/lon degrees.
-        logger: Task logger for progress and result reporting.
-        max_distance_miles: Cap on origin-to-destination distance.
-        cold_start_timeout_s: Request timeout. The Lambda cold start
-            takes ~15s, so this needs headroom above that.
-        seed: Optional seed for reproducible point selection. None
-            means a fresh random pair each run.
-
-    Returns:
-        The parsed routing API response, on success.
-
-    Raises:
-        RuntimeError: If the API returns non-200 or an obviously
-            invalid response (no coordinates, zero length).
-    """
+    """..."""
     rng = random.Random(seed)
-    origin, destination = _random_route_within(bbox, max_distance_miles, rng)
-    logger.info("Smoke test route: origin=%s destination=%s", origin, destination)
 
     config = requests.get(f"{site_url}/config.json", timeout=10).json()
     api_url = config["routing_api_url"]
     api_key = config["routing_api_key"]
     logger.info("Posting to %s", api_url)
 
-    resp = requests.post(
-        api_url,
-        headers={"Content-Type": "application/json", "X-Api-Key": api_key},
-        json={"origin": list(origin), "destination": list(destination)},
-        timeout=cold_start_timeout_s,
-    )
+    for attempt in range(1, max_route_attempts + 1):
+        origin, destination = _random_route_within(bbox, max_distance_miles, rng)
+        logger.info("Attempt %d: origin=%s destination=%s", attempt, origin, destination)
 
-    if resp.status_code != 200:
-        raise RuntimeError(
-            f"Smoke test failed: {resp.status_code} from {api_url} — {resp.text[:500]}"
+        timeout = cold_start_timeout_s if attempt == 1 else warm_timeout_s
+        resp = requests.post(
+            api_url,
+            headers={"Content-Type": "application/json", "X-Api-Key": api_key},
+            json={"origin": list(origin), "destination": list(destination)},
+            timeout=timeout,
         )
 
-    data = resp.json()
-    segments = data.get("segments")
-    if not segments:
-        raise RuntimeError(f"Routing returned no segments: {data}")
-    if data.get("total_length_m", 0) <= 0:
-        raise RuntimeError(f"Routing returned zero length: {data}")
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Smoke test failed: {resp.status_code} from {api_url} — {resp.text[:500]}"
+            )
 
-    # Sanity: every segment should have at least one coordinate pair and a
-    # stress_cost. Catches malformed responses where the shape is right but
-    # the contents are empty.
-    for i, seg in enumerate(segments):
-        if not seg.get("coordinates"):
-            raise RuntimeError(f"Segment {i} has no coordinates: {seg}")
-        if seg.get("stress_cost") is None:
-            raise RuntimeError(f"Segment {i} missing stress_cost: {seg}")
+        data = resp.json()
+        segments = data.get("segments")
 
-    total_points = sum(len(seg["coordinates"]) for seg in segments)
-    logger.info(
-        "Smoke test OK: %.0fm route, %d segments, %d total points",
-        data["total_length_m"],
-        len(segments),
-        total_points,
+        # Empty route on a 200 means both points snapped to the same node,
+        # which happens when one or both land in water/parkland/etc. inside
+        # the bbox. That's a sampling problem, not a deploy problem.
+        if not segments or data.get("total_length_m", 0) <= 0:
+            logger.warning("Attempt %d: empty route (likely off-graph snap), retrying", attempt)
+            continue
+
+        for i, seg in enumerate(segments):
+            if not seg.get("coordinates"):
+                raise RuntimeError(f"Segment {i} has no coordinates: {seg}")
+            if seg.get("stress_cost") is None:
+                raise RuntimeError(f"Segment {i} missing stress_cost: {seg}")
+
+        total_points = sum(len(seg["coordinates"]) for seg in segments)
+        logger.info(
+            "Smoke test OK on attempt %d: %.0fm route, %d segments, %d total points",
+            attempt,
+            data["total_length_m"],
+            len(segments),
+            total_points,
+        )
+        return data
+
+    raise RuntimeError(
+        f"Smoke test could not find a routable origin/destination pair in bbox "
+        f"after {max_route_attempts} attempts."
     )
-    return data


### PR DESCRIPTION
Changes:
* Refactors data layer configs out of refresh_bike_map DAGs for reuse. Closes #223 
* Makes smoke test more robust by implementing retries (to draw more random origin-destination points). Closes #226 
* Improves logging in graph export to assist in diagnosing no-route-between issues. Closes #225 

Deployed all cities to dev after refactoring (I didn't pull as much out of Chicago as there are non-defaults).