### PR TITLE
Adds new columns to two Socrata datasets and configures retrys on another observed error type

### DIFF
--- a/platform/airflow/dags/loci/collectors/socrata/client.py
+++ b/platform/airflow/dags/loci/collectors/socrata/client.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator
 from typing import Any
 
 import requests
-from requests.exceptions import ConnectionError, ReadTimeout
+from requests.exceptions import ChunkedEncodingError, ConnectionError, ReadTimeout
 from tenacity import (
     before_sleep_log,
     retry,
@@ -108,7 +108,9 @@ class SocrataClient:
         return self._request(domain, dataset_id, params, include_system_fields)
 
     @retry(
-        retry=retry_if_exception_type((json.JSONDecodeError, ConnectionError, ReadTimeout)),
+        retry=retry_if_exception_type(
+            (json.JSONDecodeError, ConnectionError, ReadTimeout, ChunkedEncodingError)
+        ),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, max=10),
         before_sleep=before_sleep_log(logger, logging.WARNING),

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -1523,6 +1523,7 @@ COOK_COUNTY_PARCEL_ADDRESSES_SPEC = SocrataDatasetSpec(
     target_table="cook_county_parcel_addresses",
     target_schema="raw_data",
     entity_key=["row_id"],
+    max_rows=3_000_000,
     full_update_mode="file_download",
 )
 

--- a/platform/migrations/postgres/V53__add_new_columns.sql
+++ b/platform/migrations/postgres/V53__add_new_columns.sql
@@ -1,0 +1,10 @@
+alter table raw_data.cook_county_parcel_addresses
+    add column if not exists "owner_address_name"      text,
+    add column if not exists "owner_address_full"      text,
+    add column if not exists "owner_address_city_name" text,
+    add column if not exists "owner_address_state"     text,
+    add column if not exists "owner_address_zipcode_1" text;
+
+
+alter table raw_data.chicago_traffic_crashes_crashes
+    add column if not exists "idot_control_no" text;


### PR DESCRIPTION
Changes:
* Adds newly added columns to storage table for the `cook_county_parcel_addresses` and `chicago_traffic_crashes_crashes` datasets. Closes #253 
* Configures retries on the `ChunkedEncodingError` error for Socrata datasets. Closes #254 