### PR TITLE
Iss267 add 3dep elevation collector

### DIFF
--- a/apps/bike-map/index.html
+++ b/apps/bike-map/index.html
@@ -795,7 +795,7 @@
           Why this route?
         </button>
         <div class="route-why-text" id="route-why-text">
-          This route prefers streets with better bike infrastructure, lower speed limits, lighting, and less severe recent crash history, even if that means a slightly longer ride. It may differ from the shortest path based on these preferences. Conditions change — always use your own judgment. Hover or tap any segment to see what factors drove its cost.
+          This route prefers calmer, lower-stress riding: better bike infrastructure, quieter and slower streets, good lighting, gentler hills, and fewer stressful intersections and turns, while also weighing recent crash history. It avoids steep climbs and descents where a gentler way around exists, even if that means a slightly longer ride. Conditions change, and the underlying data can be incomplete or out of date, so always use your own judgment. Hover or tap any segment to see what drove its cost.
         </div>
       </div>
     </div>
@@ -1726,6 +1726,7 @@ function buildRouteSegmentPopupHTML(props) {
     ['Physical',     fmtMeters(cc.physical_cost)],
     ['Intersection', fmtMeters(cc.intersection_cost)],
     ['Crash',        fmtMeters(cc.crash_cost)],
+    ['Elevation',    fmtMeters(cc.elevation_cost)],
     ['Left turn',    fmtMeters(cc.left_turn_penalty)],
   ].filter(([, v]) => v != null && parseFloat(v) > 0);
 

--- a/platform/airflow/dags/dag_files/dbt_build_dag.py
+++ b/platform/airflow/dags/dag_files/dbt_build_dag.py
@@ -12,7 +12,7 @@ def install_dependencies() -> str:
 
 @task
 def alt_build() -> str:
-    return run_dbt("build", "--select", "+detroit_bike_stress_weighted_segments")
+    return run_dbt("build", "--select", "+portland_bike_stress_weighted_segments")
 
 
 @dag(

--- a/platform/airflow/dags/dag_files/refresh_bike_map_portland.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_portland.py
@@ -13,7 +13,7 @@ from loci.tasks.bike_map_tasks import (
     build_refresh_task_graph,
     standard_dag_params,
 )
-from loci.tasks.testing.route_tests import RouteTestCase
+from loci.tasks.testing.route_tests import Gate, RouteTestCase
 
 CITY = "portland"
 
@@ -27,7 +27,17 @@ CITY_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
     data_layers.OSM_BIKE_PARKING_LAYER_CONFIG,
 ]
 
-CITY_ROUTE_TESTS: list[RouteTestCase] = []
+CITY_ROUTE_TESTS: list[RouteTestCase] = [
+    RouteTestCase(
+        name="Avoids hilly variations when largely flat alt routes are available",
+        origin=(45.5184, -122.6983),
+        destination=(45.5089, -122.6950),
+        must_not_cross=[
+            Gate((45.5129, -122.6965), (45.5130, -122.6955)),
+            Gate((45.5114, -122.6965), (45.5120, -122.6961)),
+        ],
+    ),
+]
 
 ROUTABLE_ORIGIN_DEST_PAIR = ((45.5165, -122.6832), (45.5233, -122.6816))
 

--- a/platform/airflow/dags/dag_files/refresh_bike_map_sf.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_sf.py
@@ -13,7 +13,7 @@ from loci.tasks.bike_map_tasks import (
     build_refresh_task_graph,
     standard_dag_params,
 )
-from loci.tasks.testing.route_tests import RouteTestCase
+from loci.tasks.testing.route_tests import Gate, RouteTestCase
 
 CITY = "sf"
 
@@ -27,7 +27,14 @@ CITY_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
     data_layers.OSM_BIKE_PARKING_LAYER_CONFIG,
 ]
 
-CITY_ROUTE_TESTS: list[RouteTestCase] = []
+CITY_ROUTE_TESTS: list[RouteTestCase] = [
+    RouteTestCase(
+        name="Church and Duboce to avoids steep climb by Mission Delores Park",
+        origin=(37.7693, -122.4290),  # Church St and Dubonce Ave
+        destination=(37.7481, -122.4013),  # Marin St and Kansas St
+        must_not_cross=[Gate((37.7596, -122.4295), (37.7597, -122.4272))],
+    ),
+]
 
 ROUTABLE_ORIGIN_DEST_PAIR = ((37.8033, -122.4733), (37.7765, -122.4339))
 

--- a/platform/airflow/dags/dag_files/threedep/update_boston_3dep_elevation.py
+++ b/platform/airflow/dags/dag_files/threedep/update_boston_3dep_elevation.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.threedep.taskflow import update_threedep_table
+from loci.sources.update_configs import BOSTON_3DEP_ELEVATION_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["boston", "3dep", "elevation"],
+)
+def update_boston_3dep_elevation():
+    update_threedep_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_boston_3dep_elevation()

--- a/platform/airflow/dags/dag_files/threedep/update_chicago_3dep_elevation.py
+++ b/platform/airflow/dags/dag_files/threedep/update_chicago_3dep_elevation.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.threedep.taskflow import update_threedep_table
+from loci.sources.update_configs import CHICAGO_3DEP_ELEVATION_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["chicago", "3dep", "elevation"],
+)
+def update_chicago_3dep_elevation():
+    update_threedep_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_chicago_3dep_elevation()

--- a/platform/airflow/dags/dag_files/threedep/update_dc_3dep_elevation.py
+++ b/platform/airflow/dags/dag_files/threedep/update_dc_3dep_elevation.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.threedep.taskflow import update_threedep_table
+from loci.sources.update_configs import DC_3DEP_ELEVATION_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["dc", "3dep", "elevation"],
+)
+def update_dc_3dep_elevation():
+    update_threedep_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_dc_3dep_elevation()

--- a/platform/airflow/dags/dag_files/threedep/update_denver_3dep_elevation.py
+++ b/platform/airflow/dags/dag_files/threedep/update_denver_3dep_elevation.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.threedep.taskflow import update_threedep_table
+from loci.sources.update_configs import DENVER_3DEP_ELEVATION_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["denver", "3dep", "elevation"],
+)
+def update_denver_3dep_elevation():
+    update_threedep_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_denver_3dep_elevation()

--- a/platform/airflow/dags/dag_files/threedep/update_detroit_3dep_elevation.py
+++ b/platform/airflow/dags/dag_files/threedep/update_detroit_3dep_elevation.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.threedep.taskflow import update_threedep_table
+from loci.sources.update_configs import DETROIT_3DEP_ELEVATION_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["detroit", "3dep", "elevation"],
+)
+def update_detroit_3dep_elevation():
+    update_threedep_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_detroit_3dep_elevation()

--- a/platform/airflow/dags/dag_files/threedep/update_madison_3dep_elevation.py
+++ b/platform/airflow/dags/dag_files/threedep/update_madison_3dep_elevation.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.threedep.taskflow import update_threedep_table
+from loci.sources.update_configs import MADISON_3DEP_ELEVATION_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["madison", "3dep", "elevation"],
+)
+def update_madison_3dep_elevation():
+    update_threedep_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_madison_3dep_elevation()

--- a/platform/airflow/dags/dag_files/threedep/update_nola_3dep_elevation.py
+++ b/platform/airflow/dags/dag_files/threedep/update_nola_3dep_elevation.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.threedep.taskflow import update_threedep_table
+from loci.sources.update_configs import NOLA_3DEP_ELEVATION_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["nola", "new_orleans", "3dep", "elevation"],
+)
+def update_nola_3dep_elevation():
+    update_threedep_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_nola_3dep_elevation()

--- a/platform/airflow/dags/dag_files/threedep/update_portland_3dep_elevation.py
+++ b/platform/airflow/dags/dag_files/threedep/update_portland_3dep_elevation.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.threedep.taskflow import update_threedep_table
+from loci.sources.update_configs import PORTLAND_3DEP_ELEVATION_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["portland", "3dep", "elevation"],
+)
+def update_portland_3dep_elevation():
+    update_threedep_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_portland_3dep_elevation()

--- a/platform/airflow/dags/dag_files/threedep/update_sf_3dep_elevation.py
+++ b/platform/airflow/dags/dag_files/threedep/update_sf_3dep_elevation.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.threedep.taskflow import update_threedep_table
+from loci.sources.update_configs import SF_3DEP_ELEVATION_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["sf", "3dep", "elevation"],
+)
+def update_sf_3dep_elevation():
+    update_threedep_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_sf_3dep_elevation()

--- a/platform/airflow/dags/loci/collectors/threedep/README.md
+++ b/platform/airflow/dags/loci/collectors/threedep/README.md
@@ -1,0 +1,158 @@
+# 3DEP elevation collector
+
+Collection tooling for the [USGS 3D Elevation Program (3DEP)](https://www.usgs.gov/3d-elevation-program) — the national elevation layer of The National Map. This collector pulls bare-earth digital elevation models (DEMs) into a PostGIS **raster** table (typically one per region) that downstream queries sample with `ST_Value`.
+
+This source covers **the contiguous US** (plus partial Alaska, Hawaii, and territories). Reach for this collector when you need US elevation data as a queryable raster.
+
+Unlike the tabular collectors (CMS, Socrata, CKAN, OSM), the payload here is raster, not rows. The mechanics that make raster fit the standard `StagedIngest` path are described under [A raster source](#a-raster-source) below.
+
+## The publication model
+
+3DEP's seamless products are pre-staged as **1° × 1° GeoTIFF tiles** at predictable URLs under the public TNM S3 bucket, with no API or auth required:
+
+```
+https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/TIFF/
+    current/n42w088/USGS_13_n42w088.tif
+```
+
+Tiles are named by their **northwest corner** (`nNNwWWW`), so `n42w088` covers latitude 41–42° N and longitude 88–87° W. They are distributed in **NAD83 (EPSG:4269)** with elevations in **NAVD88 meters** — and 4269 is the `BBox` default SRID, so tile selection and clipping need no reprojection. The `current/` folder is updated in place as new data lands; prior blocks are retained under `historical/` with a date suffix (we only read `current/`).
+
+Two seamless products are supported, both on the same `nNNwWWW` grid:
+
+| product | resolution | notes |
+|---|---|---|
+| `"13"` | 1/3 arc-second (~10 m) | **default** |
+| `"1"`  | 1 arc-second (~30 m)   | ~9× smaller tiles; coarser |
+
+The 1 m product uses a different, project-based tiling and is out of scope.
+
+## Classes
+
+Standard four-class collector interface, built on the shared raster tooling in `loci/raster/`:
+
+* `ThreeDEPClient` (`client.py`) — thin HTTP client over the TNM bucket: HEAD existence checks and streamed tile download. Also holds the pure tile addressing (`tile_name`, `tiles_for_bbox`, `tile_url`).
+* `ThreeDEPMetadata` (`metadata.py`) — source exploration: list products, enumerate the tiles a region needs, and pre-flight which are actually staged (`coverage`, `missing`, `describe`).
+* `ThreeDEPSpec` (`spec.py`) — declares the region (a `BBox`), product, and target table. Subclass of `DatasetSpec`.
+* `ThreeDEPCollector` (`collector.py`) — orchestrates collection: `collect(spec, force)` and `generate_ddl(spec)`.
+
+Specs are defined in `loci/sources/dataset_specs.py`, alongside the per-region `BBox` constants (see [Defining specs](#defining-specs)). Raster serialization, tiling, and the ingest loop live in `loci/raster/{wkb,ingest}.py` and are reusable by any raster source.
+
+## Quick start
+
+```python
+from loci.collectors.threedep.client import ThreeDEPClient
+from loci.collectors.threedep.metadata import ThreeDEPMetadata
+from loci.collectors.threedep.collector import ThreeDEPCollector
+from loci.collectors.threedep.spec import ThreeDEPSpec
+from loci.sources.dataset_specs import PORTLAND_BBOX
+
+spec = ThreeDEPSpec(
+    name="portland_3dep_elevation",
+    target_table="portland_3dep_elevation",
+    bbox=PORTLAND_BBOX,            # product defaults to "13" (~10 m)
+)
+
+# Explore: which tiles does this bbox need, and are they all staged?
+meta = ThreeDEPMetadata(ThreeDEPClient())
+meta.products()                   # {'13': '1/3 arc-second (~10 m)', '1': '...'}
+meta.describe(spec.bbox)          # prints needed / available / missing tiles
+
+# Create the table (run the DDL via a migration), then collect
+collector = ThreeDEPCollector(engine=engine)
+collector.print_ddl(spec)
+summary = collector.collect(spec)              # incremental
+summary = collector.collect(spec, force=True)  # full refresh
+```
+
+## A raster source
+
+The one thing that makes this collector different: the data is a raster, but it still flows through the ordinary `StagedIngest` SCD2 path with **no engine changes**. The mechanism (in `loci/raster/`):
+
+* Each downloaded 1° GeoTIFF is read in windows and split into fixed-size **sub-tiles** (default 512 px). Windowed reads keep peak memory at one sub-tile, so a several-hundred-MB source tile never lands in memory whole.
+* Each sub-tile is serialized to a **PostGIS raster hex-WKB** string — the same representation `raster2pgsql` emits — and handed to `StagedIngest` as the value of a `raster` column. PostGIS parses it on COPY exactly as it parses geometry WKT.
+* SCD2 keys on `tile_id` (`"<1°-tile>/<row>_<col>"`, stable across runs) with the raster excluded from the record hash; a cheap `checksum` (md5 of the sub-tile's bytes) carries the change signal.
+
+**Prerequisite:** the target database needs the raster extension — `CREATE EXTENSION postgis_raster;` (plain `postgis` does not include it).
+
+## Update semantics
+
+The unit of work is one **1° source tile**. The seamless products are essentially static — a tile changes only when USGS re-stages it — so:
+
+* `collect(spec, force=False)` downloads only 1° tiles that have **no rows yet** in the target, then ingests them. This is the cheap path: it avoids re-downloading tiles already held. Presence is judged by whether any sub-tile of the 1° tile is current in the target.
+* `collect(spec, force=True)` re-downloads **every** tile in the bbox and re-ingests. SCD2 dedupes unchanged sub-tiles away and versions any USGS actually changed, so a forced run is how you pick up re-staged tiles.
+
+All ingestion is `StagedIngest` in SCD2 mode, so recollection is always safe: unchanged sub-tiles dedupe away and a forced re-run merges zero rows.
+
+`collect` returns a summary dict: `spec_name`, `mode`, `product`, `tiles_total`, `tiles_collected`, `tiles_skipped_present`, `tiles_missing_at_source`, `sub_tiles_read`, `rows_merged`, and any per-tile `errors` (a failed tile is recorded and the run continues).
+
+## BBox selection and clipping
+
+The `BBox` does double duty. First, the collector enumerates the 1° tiles whose cells intersect it and downloads those. Second, when tiling each downloaded block it **clips** to the bbox, so only sub-tiles covering the region are stored — not the whole 1° block, which would carry up to ~4× the area.
+
+Note the two operate at different granularities: tile *selection* is at 1° resolution (a roughly-right bbox selects the same tiles), while the *clip* is exact.
+
+## DDL generation
+
+`generate_ddl(spec)` produces a raster tile table: `tile_id`, a `rast raster` column, `checksum`, the tile-extent columns (`min_x`/`min_y`/`max_x`/`max_y`), `ingested_at`, the SCD2 metadata columns, a `(tile_id, record_hash)` unique constraint, a partial current-rows index, and — the raster-specific part — a **GiST index on `ST_ConvexHull(rast)`** restricted to current rows, which is what makes point sampling fast. It deliberately does **not** call `AddRasterConstraints`: the strict srid/scale/alignment constraints add friction to SCD2 inserts and aren't needed for `ST_Value`. The collector does not create tables itself — paste the DDL into a migration and apply it.
+
+## Querying elevation
+
+```sql
+select ST_Value(rast, ST_SetSRID(ST_Point(:lon, :lat), 4269),
+                resample => 'bilinear') as elevation_m
+from   raw_data.portland_3dep_elevation r
+where  r."valid_to" is null
+  and  ST_Intersects(rast, ST_SetSRID(ST_Point(:lon, :lat), 4269));
+```
+
+`ST_Intersects(raster, point)` is served by the convex-hull GiST index, so each point resolves to its one sub-tile. `resample => 'bilinear'` interpolates across neighboring cells, smoother than nearest-cell sampling on a 10 m grid. To sample many points at once, join your points table to the raster on `ST_Intersects`. For ad-hoc inspection and rendering see `loci/dev/raster_inspect.py`.
+
+## Tuning
+
+Two knobs, both arguments so they can be swept without touching the modules:
+
+* `tile_size` (collector, default 512) — sub-tile edge in pixels. Larger means fewer, bigger rows (512 keeps a 1° `"13"` tile to ~480 rows vs ~1,800 at 256); smaller means tighter index entries and smaller per-sample reads. 256–512 is the sweet spot for point queries.
+* `batch_size` (default 16) — sub-tiles per COPY batch, low because each raster field is large. Trades staging-buffer memory against round-trips.
+
+## Limitations
+
+* **Partial tiles aren't self-healed on incremental runs.** Presence is judged per 1° tile, so a run that crashed partway through a tile looks "present" and is skipped on the next incremental run. Re-run with `force=True` to heal it. We accept this because the source rarely changes and a forced run is cheap to schedule periodically.
+* **Bare earth vs digital surface.** 3DEP's seamless products are bare-earth; if you ever switch to a surface model, expect canopy/structure bias in sampled values.
+* **No 1 m product.** The project-based 1 m tiling isn't supported by the URL enumeration here; 10 m is ample for most needs.
+
+## Defining specs
+
+Specs live in `loci/sources/dataset_specs.py`, alongside the per-region `BBox` constants (`PORTLAND_BBOX`, `CHICAGO_BBOX`, …). Define one `ThreeDEPSpec` per region you want to cover, landing each in its own table:
+
+```python
+PORTLAND_3DEP_SPEC = ThreeDEPSpec(
+    name="portland_3dep_elevation",
+    target_table="portland_3dep_elevation",
+    bbox=PORTLAND_BBOX,
+)
+```
+
+Because the bbox does double duty (tile selection + clip), reuse the same region `BBox` constant you use for that region's other specs so the stored extent lines up.
+
+## Tests
+
+Three layers, under `tests/collectors/threedep/`:
+
+* **Offline** — tile addressing, spec validation, the bbox clip filter, and collector orchestration with a stub engine + fake client. No network, no database.
+* **DB-backed** — fakes the HTTP boundary (`FakeThreeDEPClient` serves synthetic in-extent tiles) and runs ingestion against a real Postgres, so the raster COPY/`ST_Value` path and SCD2 semantics are exercised. Gated on `LOCI_TEST_PG*`.
+* **Live** — the only network test: verifies the real `prd-tnm` URL contract and that a real tile parses with the assumed CRS/units. Opt-in via `LOCI_TEST_3DEP_LIVE=1`.
+
+```console
+# offline only
+uv run pytest platform/tests/collectors/threedep -q
+# include the DB-backed tests
+uv run --env-file .env_test pytest platform/tests/collectors/threedep -v
+# include the live source check
+LOCI_TEST_3DEP_LIVE=1 uv run --env-file .env_test pytest platform/tests/collectors/threedep -v
+```
+
+The raster tooling itself has its own suite under `tests/raster/` (serializer round-trip, tiling coverage, and a PostGIS smoke test).
+
+## Scheduling
+
+The spec is wrapped in a `DatasetUpdateConfig` in `sources/update_configs.py`, and the 3DEP taskflow (`taskflow.py`) calls `collect(spec, force=…)` based on the schedule. Like OSM and unlike CKAN, it's a two-branch flow — `choose_update_mode` decides full vs. incremental for the run, both feeding `check_ingestion_log` — because 3DEP has a real incremental path (skip tiles already held). Since the source is near-static, a long cadence with an occasional `force=True` run to catch re-stages is the natural schedule.

--- a/platform/airflow/dags/loci/collectors/threedep/client.py
+++ b/platform/airflow/dags/loci/collectors/threedep/client.py
@@ -1,0 +1,182 @@
+# /loci_platform/platform/airflow/dags/loci/collectors/threedep/client.py
+"""
+HTTP client and tile addressing for USGS 3DEP seamless DEMs.
+
+3DEP's seamless products are pre-staged as 1 degree x 1 degree GeoTIFF
+tiles at predictable URLs under the public TNM S3 bucket, e.g.
+
+    https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/TIFF/
+        current/n42w088/USGS_13_n42w088.tif
+
+Tiles are named by their NORTHWEST corner (nNNwWWW), are in NAD83
+(EPSG:4269), and elevations are NAVD88 meters. Because they sit at
+predictable URLs we don't need the TNM Access API: given a BBox we
+enumerate the 1 degree tiles it touches and build URLs directly. This
+mirrors the OverpassAPIQuery.for_bbox pattern — geometry in, concrete
+addresses out.
+
+Products supported here are the two seamless, predictably-tiled layers:
+    "13" -> 1/3 arc-second (~10 m)   [default; right for street grade]
+    "1"  -> 1 arc-second   (~30 m)
+The 1 m product uses a different, project-based tiling and is out of
+scope for this enumeration.
+
+Usage:
+    client = ThreeDEPClient()
+    tiles = tiles_for_bbox(spec.bbox)              # ['n42w088', 'n43w088']
+    for name in tiles:
+        if client.tile_exists(name, product="13"):
+            client.download_tile(name, "13", dest_path)
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+
+import requests
+from loci.geo import BBox
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation"
+
+# product code -> (path segment, filename prefix). Both seamless layers
+# share the nNNwWWW tiling; only the code in the path and filename differ.
+SUPPORTED_PRODUCTS: dict[str, str] = {
+    "13": "1/3 arc-second (~10 m)",
+    "1": "1 arc-second (~30 m)",
+}
+
+
+# ----------------------------------------------------------------------
+# Tile addressing (pure; no network)
+# ----------------------------------------------------------------------
+
+
+def tile_name(north_edge: int, west_edge: int) -> str:
+    """
+    Name the 1 degree tile by its NW corner.
+
+    Parameters
+    ----------
+    north_edge : int
+        Latitude of the tile's north edge (the cell covers
+        [north_edge - 1, north_edge]). Positive (northern hemisphere).
+    west_edge : int
+        Longitude of the tile's west edge (the cell covers
+        [west_edge, west_edge + 1]). Non-positive (western hemisphere).
+
+    Returns
+    -------
+    str
+        e.g. "n42w088".
+    """
+    if north_edge <= 0:
+        raise ValueError(f"north_edge must be positive (northern hemisphere); got {north_edge}")
+    if west_edge > 0:
+        raise ValueError(
+            f"west_edge must be <= 0 (western hemisphere; 3DEP CONUS naming); got {west_edge}"
+        )
+    return f"n{north_edge:02d}w{-west_edge:03d}"
+
+
+def tiles_for_bbox(bbox: BBox) -> list[str]:
+    """
+    Enumerate the 1 degree tiles whose cells intersect `bbox`.
+
+    A latitude cell [k, k+1] has north edge k+1; a longitude cell
+    [m, m+1] has west edge m. We walk every cell the box touches. The
+    result is sorted and de-duplicated.
+    """
+    names = []
+    for k in range(math.floor(bbox.south), math.ceil(bbox.north)):
+        north_edge = k + 1
+        for m in range(math.floor(bbox.west), math.ceil(bbox.east)):
+            names.append(tile_name(north_edge, west_edge=m))
+    return sorted(set(names))
+
+
+def tile_url(name: str, product: str = "13", base_url: str = DEFAULT_BASE_URL) -> str:
+    """Build the `current` GeoTIFF URL for a tile + product."""
+    _check_product(product)
+    return f"{base_url}/{product}/TIFF/current/{name}/USGS_{product}_{name}.tif"
+
+
+def _check_product(product: str) -> None:
+    if product not in SUPPORTED_PRODUCTS:
+        raise ValueError(
+            f"unsupported product {product!r}; supported: {sorted(SUPPORTED_PRODUCTS)}"
+        )
+
+
+# ----------------------------------------------------------------------
+# HTTP
+# ----------------------------------------------------------------------
+
+
+class ThreeDEPClient:
+    """
+    Thin client over the public TNM staged-products bucket.
+
+    No auth. Mirrors CMSClient's session + urllib3 Retry for streamed
+    downloads. The bucket is public, so a missing tile (ocean, gap)
+    answers a non-200 to HEAD rather than raising.
+
+    Parameters
+    ----------
+    base_url : str
+        Root of the staged Elevation products.
+    timeout : int
+        Per-request timeout in seconds. DEM tiles are large; default 120.
+    """
+
+    def __init__(self, base_url: str = DEFAULT_BASE_URL, timeout: int = 120) -> None:
+        self.base_url = base_url
+        self.timeout = timeout
+        self.logger = logging.getLogger("threedep_client")
+
+        self.session = requests.Session()
+        retry = Retry(
+            total=5,
+            backoff_factor=1.0,
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=("GET", "HEAD"),
+        )
+        self.session.mount("https://", HTTPAdapter(max_retries=retry))
+
+    def tile_url(self, name: str, product: str = "13") -> str:
+        return tile_url(name, product=product, base_url=self.base_url)
+
+    def tile_exists(self, name: str, product: str = "13") -> bool:
+        """HEAD the tile; True iff it is present (200)."""
+        url = self.tile_url(name, product=product)
+        resp = self.session.head(url, timeout=self.timeout, allow_redirects=True)
+        if resp.status_code == 200:
+            return True
+        if resp.status_code in (403, 404):
+            return False
+        resp.raise_for_status()
+        return False
+
+    def download_tile(self, name: str, product: str, dest_path: str | Path) -> Path:
+        """
+        Stream a tile's GeoTIFF to dest_path and return the path.
+
+        Raises for HTTP errors other than the caller-checked existence.
+        """
+        url = self.tile_url(name, product=product)
+        dest_path = Path(dest_path)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.logger.info("Downloading %s", url)
+        with self.session.get(url, stream=True, timeout=self.timeout) as resp:
+            resp.raise_for_status()
+            with open(dest_path, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=1 << 20):
+                    f.write(chunk)
+        self.logger.info("Downloaded %s (%.1f MB)", name, dest_path.stat().st_size / (1024 * 1024))
+        return dest_path

--- a/platform/airflow/dags/loci/collectors/threedep/collector.py
+++ b/platform/airflow/dags/loci/collectors/threedep/collector.py
@@ -2,7 +2,7 @@
 """
 USGS 3DEP elevation collection orchestrator.
 
-Wires ThreeDEPSpec + ThreeDEPClient + the raster ingestion tooling into
+Wires ThreeDEPDatasetSpec + ThreeDEPClient + the raster ingestion tooling into
 the standard collector surface: collect(spec, force) and
 generate_ddl(spec), all ingestion via StagedIngest (SCD2, keyed on
 tile_id).
@@ -43,7 +43,7 @@ from pathlib import Path
 from typing import Any
 
 from loci.collectors.threedep.client import ThreeDEPClient, tiles_for_bbox
-from loci.collectors.threedep.spec import THREEDEP_SRID, ThreeDEPSpec
+from loci.collectors.threedep.spec import THREEDEP_SRID, ThreeDEPDatasetSpec
 from loci.raster.ingest import ingest_raster_file, raster_table_ddl
 from loci.tracking.ingestion_tracker import IngestionTracker
 
@@ -92,7 +92,7 @@ class ThreeDEPCollector:
     # Public API
     # ------------------------------------------------------------------
 
-    def collect(self, spec: ThreeDEPSpec, force: bool = False) -> dict[str, Any]:
+    def collect(self, spec: ThreeDEPDatasetSpec, force: bool = False) -> dict[str, Any]:
         """
         Collect 3DEP tiles covering spec.bbox into the target table.
 
@@ -172,11 +172,11 @@ class ThreeDEPCollector:
         self.logger.info("Collection complete for %r: %s", spec.name, summary)
         return summary
 
-    def generate_ddl(self, spec: ThreeDEPSpec) -> str:
+    def generate_ddl(self, spec: ThreeDEPDatasetSpec) -> str:
         """CREATE TABLE for a 3DEP raster tile table (NAD83)."""
         return raster_table_ddl(spec.target_schema, spec.target_table, THREEDEP_SRID)
 
-    def print_ddl(self, spec: ThreeDEPSpec) -> None:
+    def print_ddl(self, spec: ThreeDEPDatasetSpec) -> None:
         """Generate and print DDL for copy-paste into a migration."""
         print(self.generate_ddl(spec))
 
@@ -184,7 +184,9 @@ class ThreeDEPCollector:
     # Per-tile collection
     # ------------------------------------------------------------------
 
-    def _collect_tile(self, spec: ThreeDEPSpec, name: str, ingested_at: datetime) -> dict[str, int]:
+    def _collect_tile(
+        self, spec: ThreeDEPDatasetSpec, name: str, ingested_at: datetime
+    ) -> dict[str, int]:
         """Download one 1-degree tile to a temp file and ingest it, clipped to the bbox."""
         tmp = tempfile.NamedTemporaryFile(suffix=".tif", prefix=f"3dep_{name}_", delete=False)
         tmp.close()
@@ -209,7 +211,7 @@ class ThreeDEPCollector:
     # Target-table probes
     # ------------------------------------------------------------------
 
-    def _table_exists(self, spec: ThreeDEPSpec) -> bool:
+    def _table_exists(self, spec: ThreeDEPDatasetSpec) -> bool:
         df = self.engine.query(
             """
             select 1 from information_schema.tables
@@ -220,7 +222,7 @@ class ThreeDEPCollector:
         )
         return not df.empty
 
-    def _tile_present(self, spec: ThreeDEPSpec, name: str) -> bool:
+    def _tile_present(self, spec: ThreeDEPDatasetSpec, name: str) -> bool:
         """True if any current sub-tile of this 1-degree tile exists in the target."""
         fqn = f"{spec.target_schema}.{spec.target_table}"
         df = self.engine.query(
@@ -234,7 +236,7 @@ class ThreeDEPCollector:
         return not df.empty
 
 
-def _bbox_bounds(spec: ThreeDEPSpec) -> tuple[float, float, float, float]:
+def _bbox_bounds(spec: ThreeDEPDatasetSpec) -> tuple[float, float, float, float]:
     """(min_x, min_y, max_x, max_y) clip extent in the tiles' CRS (NAD83)."""
     b = spec.bbox
     return (b.west, b.south, b.east, b.north)

--- a/platform/airflow/dags/loci/collectors/threedep/collector.py
+++ b/platform/airflow/dags/loci/collectors/threedep/collector.py
@@ -1,0 +1,240 @@
+# /loci_platform/platform/airflow/dags/loci/collectors/threedep/collector.py
+"""
+USGS 3DEP elevation collection orchestrator.
+
+Wires ThreeDEPSpec + ThreeDEPClient + the raster ingestion tooling into
+the standard collector surface: collect(spec, force) and
+generate_ddl(spec), all ingestion via StagedIngest (SCD2, keyed on
+tile_id).
+
+Update scheme:
+    The unit of work is one 1-degree source tile. The seamless 3DEP
+    products are essentially static (a tile is re-staged only when USGS
+    republishes it), so:
+
+      collect(spec, force=False)  downloads only 1-degree tiles that
+          have no rows yet in the target, then ingests them. This is the
+          cheap path: it avoids re-downloading hundreds of MB per tile
+          that we already hold.
+      collect(spec, force=True)   re-downloads every tile in the bbox
+          and re-ingests. SCD2 dedupes unchanged sub-tiles away and
+          versions any that USGS actually changed, so a forced run is
+          how you pick up re-staged tiles.
+
+    Limitation (deliberate, until needed): presence is judged by whether
+    *any* sub-tile of a 1-degree tile exists in the target. A run that
+    crashed partway through a tile would look "present" and be skipped on
+    an incremental run; re-run with force=True to heal it. We accept this
+    because the source rarely changes and a forced run is cheap to
+    schedule periodically.
+
+Each 1-degree tile is downloaded to a temp file (rasterio reads windows
+off disk, so peak memory is one sub-tile), tiled and clipped to the
+spec's bbox, then dropped. tile_id is namespaced by the 1-degree tile
+name so sub-tiles stay unique across tiles: "<name>/<row>_<col>".
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from loci.collectors.threedep.client import ThreeDEPClient, tiles_for_bbox
+from loci.collectors.threedep.spec import THREEDEP_SRID, ThreeDEPSpec
+from loci.raster.ingest import ingest_raster_file, raster_table_ddl
+from loci.tracking.ingestion_tracker import IngestionTracker
+
+logger = logging.getLogger(__name__)
+
+# Sub-tile edge for the big 1-degree source rasters. 512 keeps a 1-degree
+# 1/3 arc-second tile (~10812 px) to ~480 rows rather than ~1800 at 256,
+# while staying small enough for fast point sampling.
+DEFAULT_TILE_SIZE = 512
+DEFAULT_BATCH_SIZE = 16
+
+
+class ThreeDEPCollector:
+    """
+    Orchestrate 3DEP elevation collection.
+
+    Parameters
+    ----------
+    engine : PostgresEngine
+    client : ThreeDEPClient, optional
+    tracker : IngestionTracker, optional
+    tile_size : int
+        Sub-tile edge in pixels passed to the raster ingester.
+    batch_size : int
+        Sub-tiles per COPY batch. Low by default — each is a large field.
+    """
+
+    SOURCE_NAME = "3dep"
+
+    def __init__(
+        self,
+        engine,
+        client: ThreeDEPClient | None = None,
+        tracker: IngestionTracker | None = None,
+        tile_size: int = DEFAULT_TILE_SIZE,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        self.engine = engine
+        self.client = client or ThreeDEPClient()
+        self.tracker = tracker or IngestionTracker(engine=self.engine)
+        self.tile_size = tile_size
+        self.batch_size = batch_size
+        self.logger = logging.getLogger("threedep_collector")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def collect(self, spec: ThreeDEPSpec, force: bool = False) -> dict[str, Any]:
+        """
+        Collect 3DEP tiles covering spec.bbox into the target table.
+
+        Raises if the target table doesn't exist (run print_ddl first).
+        """
+        fqn = f"{spec.target_schema}.{spec.target_table}"
+        # A missing target table is reported per tile (like the CMS/DKAN
+        # collectors) rather than crashing the run; checked once here.
+        table_ok = self._table_exists(spec)
+
+        ingested_at = datetime.now(UTC)
+        names = tiles_for_bbox(spec.bbox)
+        mode = "full" if force else "incremental"
+
+        self.logger.info(
+            "Collecting %s: mode=%s, product=%s, %d tile(s) over bbox",
+            spec.name,
+            mode,
+            spec.product,
+            len(names),
+        )
+
+        summary: dict[str, Any] = {
+            "spec_name": spec.name,
+            "mode": mode,
+            "product": spec.product,
+            "tiles_total": len(names),
+            "tiles_collected": 0,
+            "tiles_skipped_present": 0,
+            "tiles_missing_at_source": 0,
+            "sub_tiles_read": 0,
+            "rows_merged": 0,
+            "errors": [],
+        }
+
+        run_metadata = {"mode": mode, "product": spec.product, "tiles_total": len(names)}
+        with self.tracker.track(
+            source=self.SOURCE_NAME,
+            dataset_id=spec.name,
+            target_table=fqn,
+            metadata=run_metadata,
+        ) as run:
+            for name in names:
+                try:
+                    if not table_ok:
+                        raise RuntimeError(
+                            f"Target table {fqn} does not exist. "
+                            f"Run print_ddl(spec) and create it first."
+                        )
+                    if not force and self._tile_present(spec, name):
+                        self.logger.info("Skipping %s (already present)", name)
+                        summary["tiles_skipped_present"] += 1
+                        continue
+                    if not self.client.tile_exists(name, spec.product):
+                        self.logger.warning("Tile %s not available at source; skipping", name)
+                        summary["tiles_missing_at_source"] += 1
+                        continue
+
+                    result = self._collect_tile(spec, name, ingested_at)
+                    summary["tiles_collected"] += 1
+                    summary["sub_tiles_read"] += result["tiles_read"]
+                    summary["rows_merged"] += result["rows_merged"]
+                except Exception as e:  # noqa: BLE001 - record and continue per tile
+                    self.logger.error("Failed tile %s: %s", name, e)
+                    summary["errors"].append({"tile": name, "error": str(e)})
+
+            run.rows_merged = summary["rows_merged"]
+            run.metadata.update(
+                {
+                    "tiles_collected": summary["tiles_collected"],
+                    "tiles_skipped_present": summary["tiles_skipped_present"],
+                    "tiles_missing_at_source": summary["tiles_missing_at_source"],
+                    "sub_tiles_read": summary["sub_tiles_read"],
+                }
+            )
+
+        self.logger.info("Collection complete for %r: %s", spec.name, summary)
+        return summary
+
+    def generate_ddl(self, spec: ThreeDEPSpec) -> str:
+        """CREATE TABLE for a 3DEP raster tile table (NAD83)."""
+        return raster_table_ddl(spec.target_schema, spec.target_table, THREEDEP_SRID)
+
+    def print_ddl(self, spec: ThreeDEPSpec) -> None:
+        """Generate and print DDL for copy-paste into a migration."""
+        print(self.generate_ddl(spec))
+
+    # ------------------------------------------------------------------
+    # Per-tile collection
+    # ------------------------------------------------------------------
+
+    def _collect_tile(self, spec: ThreeDEPSpec, name: str, ingested_at: datetime) -> dict[str, int]:
+        """Download one 1-degree tile to a temp file and ingest it, clipped to the bbox."""
+        tmp = tempfile.NamedTemporaryFile(suffix=".tif", prefix=f"3dep_{name}_", delete=False)
+        tmp.close()
+        path = Path(tmp.name)
+        try:
+            self.client.download_tile(name, spec.product, path)
+            return ingest_raster_file(
+                self.engine,
+                str(path),
+                source_id=name,
+                target_schema=spec.target_schema,
+                target_table=spec.target_table,
+                ingested_at=ingested_at,
+                tile_size=self.tile_size,
+                batch_size=self.batch_size,
+                bounds=_bbox_bounds(spec),
+            )
+        finally:
+            path.unlink(missing_ok=True)
+
+    # ------------------------------------------------------------------
+    # Target-table probes
+    # ------------------------------------------------------------------
+
+    def _table_exists(self, spec: ThreeDEPSpec) -> bool:
+        df = self.engine.query(
+            """
+            select 1 from information_schema.tables
+            where table_schema = %(schema)s and table_name = %(table)s
+            limit 1
+            """,
+            {"schema": spec.target_schema, "table": spec.target_table},
+        )
+        return not df.empty
+
+    def _tile_present(self, spec: ThreeDEPSpec, name: str) -> bool:
+        """True if any current sub-tile of this 1-degree tile exists in the target."""
+        fqn = f"{spec.target_schema}.{spec.target_table}"
+        df = self.engine.query(
+            f"""
+            select 1 from {fqn}
+            where "valid_to" is null and "tile_id" like %(prefix)s
+            limit 1
+            """,
+            {"prefix": f"{name}/%"},
+        )
+        return not df.empty
+
+
+def _bbox_bounds(spec: ThreeDEPSpec) -> tuple[float, float, float, float]:
+    """(min_x, min_y, max_x, max_y) clip extent in the tiles' CRS (NAD83)."""
+    b = spec.bbox
+    return (b.west, b.south, b.east, b.north)

--- a/platform/airflow/dags/loci/collectors/threedep/metadata.py
+++ b/platform/airflow/dags/loci/collectors/threedep/metadata.py
@@ -1,0 +1,65 @@
+# /loci_platform/platform/airflow/dags/loci/collectors/threedep/metadata.py
+"""
+Source exploration for USGS 3DEP.
+
+Unlike a catalog-backed source (CMS/DKAN) there's no dataset listing to
+browse — 3DEP exposes a fixed set of seamless products on a fixed tile
+grid. So "explore the source" here means: what products exist, which
+tiles a region needs, and which of those are actually staged (so you can
+catch ocean/gap tiles before a collect run rather than during it).
+
+Usage:
+    meta = ThreeDEPMetadata()
+    meta.products()                       # {'13': '...', '1': '...'}
+    meta.tiles_for_bbox(spec.bbox)        # ['n42w088', 'n43w088']
+    meta.describe(spec.bbox)              # prints a coverage summary
+"""
+
+from __future__ import annotations
+
+import logging
+
+from loci.collectors.threedep.client import (
+    SUPPORTED_PRODUCTS,
+    ThreeDEPClient,
+    tiles_for_bbox,
+)
+from loci.geo import BBox
+
+logger = logging.getLogger(__name__)
+
+
+class ThreeDEPMetadata:
+    """Explore 3DEP products and check tile coverage for a region."""
+
+    def __init__(self, client: ThreeDEPClient | None = None) -> None:
+        self.client = client or ThreeDEPClient()
+
+    def products(self) -> dict[str, str]:
+        """The seamless products this collector can fetch, code -> description."""
+        return dict(SUPPORTED_PRODUCTS)
+
+    def tiles_for_bbox(self, bbox: BBox) -> list[str]:
+        """The 1-degree tiles a bbox needs (pure; no network)."""
+        return tiles_for_bbox(bbox)
+
+    def coverage(self, bbox: BBox, product: str = "13") -> dict[str, bool]:
+        """Map each needed tile to whether it is staged at the source (HEAD checks)."""
+        return {name: self.client.tile_exists(name, product) for name in tiles_for_bbox(bbox)}
+
+    def missing(self, bbox: BBox, product: str = "13") -> list[str]:
+        """Tiles a bbox needs that are not available at the source."""
+        return sorted(n for n, ok in self.coverage(bbox, product).items() if not ok)
+
+    def describe(self, bbox: BBox, product: str = "13") -> dict[str, object]:
+        """Print and return a short coverage summary for notebook use."""
+        cov = self.coverage(bbox, product)
+        present = sorted(n for n, ok in cov.items() if ok)
+        missing = sorted(n for n, ok in cov.items() if not ok)
+
+        print(f"3DEP product {product} ({SUPPORTED_PRODUCTS.get(product, '?')})")
+        print(f"  tiles needed : {len(cov)}")
+        print(f"  available    : {len(present)}  {present}")
+        if missing:
+            print(f"  MISSING      : {len(missing)} {missing}  (likely ocean/gap)")
+        return {"product": product, "needed": len(cov), "present": present, "missing": missing}

--- a/platform/airflow/dags/loci/collectors/threedep/spec.py
+++ b/platform/airflow/dags/loci/collectors/threedep/spec.py
@@ -1,0 +1,95 @@
+# /loci_platform/platform/airflow/dags/loci/collectors/threedep/spec.py
+"""
+Dataset specification for USGS 3DEP elevation collection.
+
+A ThreeDEPSpec declares which region to collect (a BBox), which seamless
+product, and where to land it. One instance per city; the raster lands
+in a per-city table, mirroring the per-city OSM raw tables. SCD2 keying
+is fixed to ["tile_id"] — the raster ingestion path keys every sub-tile
+on its tile_id, so this is not a caller choice.
+
+Example:
+    spec = ThreeDEPSpec(
+        name="chicago_elevation",
+        target_table="chicago_elevation",
+        bbox=BBox(south=41.62, west=-87.97, north=42.05, east=-87.5),
+        product="13",
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from loci.collectors.base_spec import DatasetSpec
+from loci.collectors.threedep.client import SUPPORTED_PRODUCTS
+from loci.geo import BBox
+
+# Native SRID / vertical units of the seamless 3DEP products.
+THREEDEP_SRID = 4269  # NAD83 geographic
+
+_RASTER_ENTITY_KEY = ["tile_id"]
+
+
+@dataclass
+class ThreeDEPSpec(DatasetSpec):
+    """
+    Specification for a 3DEP elevation dataset.
+
+    Parameters
+    ----------
+    name : str
+        Human-readable identifier, conventionally equal to target_table
+        (e.g. "chicago_elevation").
+    target_table : str
+        Per-city destination table name.
+    target_schema : str
+        Destination schema. Default "raw_data".
+    bbox : BBox
+        Region to collect. Tiles intersecting it are fetched, and stored
+        sub-tiles are clipped to it. Expected in NAD83 (EPSG:4269) so it
+        matches the tiles' CRS; the BBox default SRID already is.
+    product : str
+        Seamless product code: "13" (1/3 arc-second, ~10 m; default) or
+        "1" (1 arc-second, ~30 m).
+    entity_key : list[str]
+        Fixed to ["tile_id"]; overriding raises.
+    """
+
+    source: str = field(default="3dep", init=False)
+    name: str = ""
+    target_table: str = ""
+    target_schema: str = "raw_data"
+    bbox: BBox | None = None
+    product: str = "13"
+    entity_key: list[str] = field(default_factory=lambda: list(_RASTER_ENTITY_KEY))
+
+    @property
+    def dataset_id(self) -> str:
+        return self.target_table
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("name is required")
+        if not self.target_table:
+            raise ValueError("target_table is required")
+        if not self.target_schema:
+            raise ValueError("target_schema is required")
+        if self.bbox is None:
+            raise ValueError("bbox is required")
+        if self.product not in SUPPORTED_PRODUCTS:
+            raise ValueError(
+                f"product must be one of {sorted(SUPPORTED_PRODUCTS)}, got {self.product!r}"
+            )
+        if self.entity_key != _RASTER_ENTITY_KEY:
+            raise ValueError(
+                f"entity_key for raster collection is fixed to {_RASTER_ENTITY_KEY}; "
+                f"got {self.entity_key}"
+            )
+        if self.bbox.srid != THREEDEP_SRID:
+            # Not fatal — the collector could transform — but for 3DEP the
+            # tiles are 4269 and a mismatched bbox would mis-clip, so flag it.
+            raise ValueError(
+                f"bbox.srid is {self.bbox.srid}; 3DEP tiles are EPSG:{THREEDEP_SRID}. "
+                f"Provide the bbox in NAD83 so tile selection and clipping line up."
+            )

--- a/platform/airflow/dags/loci/collectors/threedep/spec.py
+++ b/platform/airflow/dags/loci/collectors/threedep/spec.py
@@ -2,14 +2,14 @@
 """
 Dataset specification for USGS 3DEP elevation collection.
 
-A ThreeDEPSpec declares which region to collect (a BBox), which seamless
+A ThreeDEPDatasetSpec declares which region to collect (a BBox), which seamless
 product, and where to land it. One instance per city; the raster lands
 in a per-city table, mirroring the per-city OSM raw tables. SCD2 keying
 is fixed to ["tile_id"] — the raster ingestion path keys every sub-tile
 on its tile_id, so this is not a caller choice.
 
 Example:
-    spec = ThreeDEPSpec(
+    spec = ThreeDEPDatasetSpec(
         name="chicago_elevation",
         target_table="chicago_elevation",
         bbox=BBox(south=41.62, west=-87.97, north=42.05, east=-87.5),
@@ -32,7 +32,7 @@ _RASTER_ENTITY_KEY = ["tile_id"]
 
 
 @dataclass
-class ThreeDEPSpec(DatasetSpec):
+class ThreeDEPDatasetSpec(DatasetSpec):
     """
     Specification for a 3DEP elevation dataset.
 

--- a/platform/airflow/dags/loci/collectors/threedep/taskflow.py
+++ b/platform/airflow/dags/loci/collectors/threedep/taskflow.py
@@ -1,0 +1,55 @@
+# /loci_platform/platform/airflow/dags/loci/collectors/threedep/taskflow.py
+from logging import Logger
+
+from airflow.sdk import task, task_group
+from airflow.sdk.bases.operator import chain
+from loci.collectors.threedep.collector import ThreeDEPCollector
+from loci.db.af_utils import get_postgres_engine
+from loci.sources.update_configs import DatasetUpdateConfig
+from loci.tasks.task_utils import check_ingestion_log, choose_update_mode
+from loci.tracking.ingestion_tracker import IngestionTracker
+
+
+def _get_collector(conn_id: str, task_logger: Logger) -> ThreeDEPCollector:
+    pg_engine = get_postgres_engine(conn_id=conn_id, logger=task_logger)
+    tracker = IngestionTracker(engine=pg_engine)
+    return ThreeDEPCollector(engine=pg_engine, tracker=tracker)
+
+
+@task
+def run_full_update(update_config: DatasetUpdateConfig, conn_id: str, task_logger: Logger) -> bool:
+    collector = _get_collector(conn_id, task_logger)
+    summary_results = collector.collect(spec=update_config.spec, force=True)
+    task_logger.info("Collection summary", extra={"payload": summary_results})
+    return True
+
+
+@task
+def run_incremental_update(
+    update_config: DatasetUpdateConfig, conn_id: str, task_logger: Logger
+) -> bool:
+    collector = _get_collector(conn_id, task_logger)
+    summary_results = collector.collect(spec=update_config.spec, force=False)
+    task_logger.info("Collection summary", extra={"payload": summary_results})
+    return True
+
+
+@task_group
+def update_threedep_table(
+    update_config: DatasetUpdateConfig,
+    conn_id: str,
+    task_logger: Logger,
+) -> None:
+    _update_mode = choose_update_mode(update_config=update_config, task_logger=task_logger)
+    _full_update = run_full_update(
+        conn_id=conn_id, update_config=update_config, task_logger=task_logger
+    )
+    _incremental_update = run_incremental_update(
+        conn_id=conn_id, update_config=update_config, task_logger=task_logger
+    )
+    _check_ingestion_log = check_ingestion_log(
+        conn_id=conn_id, update_config=update_config, task_logger=task_logger
+    )
+
+    chain(_update_mode, _full_update, _check_ingestion_log)
+    chain(_update_mode, _incremental_update, _check_ingestion_log)

--- a/platform/airflow/dags/loci/dev/raster_inspect.py
+++ b/platform/airflow/dags/loci/dev/raster_inspect.py
@@ -1,0 +1,240 @@
+"""
+Inspect and render ingested elevation rasters.
+
+The one rule for querying raster through PostgresEngine.query: never
+select the `rast` column raw — it comes back as an opaque WKB blob.
+Instead wrap it in a PostGIS raster function so the result is something
+query() already understands:
+
+  - scalars (ST_Value, ST_SummaryStats fields) -> ordinary DataFrame cols
+  - ST_Envelope(rast) -> geometry -> query() returns a GeoDataFrame
+  - ST_AsTIFF(...)     -> bytea    -> bytes you can open with rasterio
+
+The functions below are thin wrappers around those patterns plus a
+matplotlib renderer. Everything takes your live PostgresEngine.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+# ----------------------------------------------------------------------
+# Examine (returns DataFrames / GeoDataFrame via your query())
+# ----------------------------------------------------------------------
+
+
+def coverage(engine: Any, table: str, schema: str = "raw_data"):
+    """Tile count and the overall stored extent (uses the extent columns)."""
+    return engine.query(
+        f"""
+        select count(*) as n_tiles,
+               min(min_x) as min_x, min(min_y) as min_y,
+               max(max_x) as max_x, max(max_y) as max_y
+        from {schema}.{table}
+        where "valid_to" is null
+        """
+    )
+
+
+def value_stats(engine: Any, table: str, schema: str = "raw_data"):
+    """
+    Elevation min/max/mean across the whole table. This is the first
+    sanity check: a sane metro range (and no -9999 / -999999 leaking in
+    as the min) tells you nodata is being honored.
+    """
+    return engine.query(
+        f"""
+        select count(*)        as n_tiles,
+               sum((ss).count) as n_pixels,
+               min((ss).min)   as min_elev_m,
+               max((ss).max)   as max_elev_m,
+               avg((ss).mean)  as approx_mean_m
+        from (
+            select ST_SummaryStats(rast) as ss
+            from {schema}.{table}
+            where "valid_to" is null
+        ) t
+        """
+    )
+
+
+def sample_point(
+    engine: Any, table: str, lon: float, lat: float, schema: str = "raw_data", srid: int = 4269
+):
+    """Elevation at a coordinate — index-assisted by ST_Intersects."""
+    return engine.query(
+        f"""
+        select ST_Value(rast, ST_SetSRID(ST_Point(%(lon)s, %(lat)s), {srid}),
+                        resample => 'bilinear') as elevation_m
+        from {schema}.{table}
+        where "valid_to" is null
+          and ST_Intersects(rast, ST_SetSRID(ST_Point(%(lon)s, %(lat)s), {srid}))
+        """,
+        {"lon": lon, "lat": lat},
+    )
+
+
+def footprints(engine: Any, table: str, schema: str = "raw_data"):
+    """
+    Tile footprints as geometry. Because the column is geometry, query()
+    returns a GeoDataFrame — so `footprints(...).plot()` draws the tile
+    grid and instantly shows whether the clip worked and there are no gaps.
+    """
+    return engine.query(
+        f"""
+        select tile_id, ST_Envelope(rast) as geom
+        from {schema}.{table}
+        where "valid_to" is null
+        """
+    )
+
+
+# ----------------------------------------------------------------------
+# Fetch pixels into a numpy array (for rendering)
+# ----------------------------------------------------------------------
+
+
+def fetch_array(
+    engine: Any,
+    table: str,
+    schema: str = "raw_data",
+    srid: int = 4269,
+    bbox: tuple[float, float, float, float] | None = None,
+):
+    """
+    Pull the current sub-tiles and mosaic them into one masked numpy
+    array client-side — no server-side ST_Union, and no GDAL drivers.
+
+    Why not ST_Union: it requires every raster share an exact pixel
+    alignment (same scale/skew, origins an integer number of pixels
+    apart). 3DEP publishes each 1-degree tile independently, and their
+    geotransforms aren't guaranteed bit-identical, so a region spanning
+    more than one source tile trips ST_Union with
+    "rt_raster_from_two_rasters: ... do not have the same alignment".
+    Mosaicking here snaps each sub-tile to a common grid (nearest cell),
+    which sidesteps that. (Also avoids ST_AsTIFF, which needs PostGIS's
+    GDAL output drivers — disabled by default.)
+
+    Returns (array, extent) with extent=(west, east, south, north) for
+    matplotlib imshow. nodata pixels come back as NULL and are masked.
+
+    Pass a small bbox=(w, s, e, n) while iterating so the pull stays cheap.
+    """
+    if bbox is not None:
+        w, s, e, n = bbox
+        rast = "ST_Clip(rast, env.g)"  # crops to the bbox, preserves grid
+        frm = (
+            f"from {schema}.{table}, "
+            f"lateral (select ST_MakeEnvelope({w}, {s}, {e}, {n}, {srid}) as g) env "
+            f'where "valid_to" is null and ST_Intersects(rast, env.g)'
+        )
+    else:
+        rast = "rast"
+        frm = f'from {schema}.{table} where "valid_to" is null'
+
+    rows = engine.query(
+        f"""
+        select ST_DumpValues({rast}, 1) as vals,
+               ST_UpperLeftX({rast}) as ulx,
+               ST_UpperLeftY({rast}) as uly,
+               ST_ScaleX({rast})     as sx,
+               ST_ScaleY({rast})     as sy
+        {frm}
+        """,
+        as_dicts=True,
+    )
+
+    tiles = [
+        (_to_masked_array(r["vals"]), float(r["ulx"]), float(r["uly"]))
+        for r in rows
+        if r["vals"] is not None
+    ]
+    if not tiles:
+        raise ValueError("no raster returned (empty table or bbox outside coverage)")
+
+    return _mosaic(tiles, sx=float(rows[0]["sx"]), sy=float(rows[0]["sy"]))
+
+
+def _mosaic(tiles: list, sx: float, sy: float):
+    """
+    Place each (masked array, upper-left x, upper-left y) onto one canvas
+    on a shared grid. sx > 0, sy < 0 (north-up). Sub-tiles are snapped to
+    the nearest cell, so minor cross-tile geotransform drift is absorbed;
+    overlapping collars don't overwrite good data with nodata.
+    """
+    ph = -sy  # pixel height, positive
+    global_ulx = min(ulx for _, ulx, _ in tiles)
+    global_uly = max(uly for _, _, uly in tiles)
+
+    placed, nrows, ncols = [], 0, 0
+    for arr, ulx, uly in tiles:
+        col0 = int(round((ulx - global_ulx) / sx))
+        row0 = int(round((global_uly - uly) / ph))
+        h, w = arr.shape
+        placed.append((arr, row0, col0, h, w))
+        nrows, ncols = max(nrows, row0 + h), max(ncols, col0 + w)
+
+    master = np.full((nrows, ncols), np.nan, dtype="float64")
+    for arr, row0, col0, h, w in placed:
+        filled = arr.filled(np.nan)
+        have = ~np.isnan(filled)
+        master[row0 : row0 + h, col0 : col0 + w][have] = filled[have]
+
+    arr = np.ma.masked_invalid(master)
+    extent = (global_ulx, global_ulx + ncols * sx, global_uly + nrows * sy, global_uly)
+    return arr, extent
+
+
+def _to_masked_array(vals: list) -> np.ma.MaskedArray:
+    """
+    Turn ST_DumpValues output (a nested list, with None for nodata/NULL
+    pixels — psycopg2's rendering of a Postgres double precision[][]) into
+    a masked float array.
+    """
+    a = np.array(
+        [[np.nan if v is None else float(v) for v in row] for row in vals],
+        dtype="float64",
+    )
+    return np.ma.masked_invalid(a)
+
+
+# ----------------------------------------------------------------------
+# Render
+# ----------------------------------------------------------------------
+
+
+def plot_elevation(
+    arr, extent=None, *, title="Elevation (m)", hillshade=True, cmap="terrain", ax=None
+):
+    """
+    Render an elevation array. Pass the (array, extent) from fetch_array.
+    Draws a colored elevation map, optionally blended with a hillshade
+    for relief (hillshade is invisible on truly flat terrain, which is
+    itself informative — e.g. Chicago vs Denver).
+    """
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import LightSource
+
+    masked = np.ma.masked_invalid(arr)
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(7, 6))
+
+    if hillshade and masked.count() > 0:
+        ls = LightSource(azdeg=315, altdeg=45)
+        filled = masked.filled(np.ma.median(masked))
+        shade = ls.hillshade(filled, vert_exag=10)
+        ax.imshow(shade, extent=extent, cmap="gray", alpha=1.0, origin="upper", aspect="auto")
+        im = ax.imshow(masked, extent=extent, cmap=cmap, alpha=0.6, origin="upper", aspect="auto")
+    else:
+        im = ax.imshow(masked, extent=extent, cmap=cmap, origin="upper", aspect="auto")
+
+    cbar = ax.figure.colorbar(im, ax=ax, shrink=0.8)
+    cbar.set_label("meters")
+    ax.set_title(title)
+    if extent is not None:
+        ax.set_xlabel("lon")
+        ax.set_ylabel("lat")
+    return ax

--- a/platform/airflow/dags/loci/exports/graph_export.py
+++ b/platform/airflow/dags/loci/exports/graph_export.py
@@ -73,6 +73,8 @@ class RoutingGraphExporter:
             crash_cost,
             intersection_cost_at_start,
             intersection_cost_at_end,
+            elevation_cost_forward,
+            elevation_cost_backward,
             start_is_intersection,
             end_is_intersection,
             highway_class,
@@ -209,6 +211,8 @@ class RoutingGraphExporter:
                     "crash_cost": _f(row["crash_cost"]),
                     "intersection_cost_at_start": _f(row["intersection_cost_at_start"]),
                     "intersection_cost_at_end": _f(row["intersection_cost_at_end"]),
+                    "elevation_cost_forward": _f(row["elevation_cost_forward"]),
+                    "elevation_cost_backward": _f(row["elevation_cost_backward"]),
                     # Carried as graph attributes for the heuristic-floor
                     # pass and possible future use; not written to the
                     # binary edge record (which carries only the composed
@@ -427,9 +431,11 @@ def build_edges_and_strings(
         crash = _coerce_cost(data.get("crash_cost"))
         if forward:
             intersection = _coerce_cost(data.get("intersection_cost_at_end"))
+            elevation = _coerce_cost(data.get("elevation_cost_forward"))
         else:
             intersection = _coerce_cost(data.get("intersection_cost_at_start"))
-        stress_cost = physical + crash + intersection
+            elevation = _coerce_cost(data.get("elevation_cost_backward"))
+        stress_cost = physical + crash + intersection + elevation
 
         edges.append(
             WriteEdge(
@@ -448,6 +454,7 @@ def build_edges_and_strings(
                 # baked into `stress_cost`.
                 intersection_cost=f32_or_nan(intersection),
                 crash_cost=f32_or_nan(data.get("crash_cost")),
+                elevation_cost=f32_or_nan(elevation),
             )
         )
 

--- a/platform/airflow/dags/loci/exports/graph_export.py
+++ b/platform/airflow/dags/loci/exports/graph_export.py
@@ -216,7 +216,7 @@ class RoutingGraphExporter:
                     # Carried as graph attributes for the heuristic-floor
                     # pass and possible future use; not written to the
                     # binary edge record (which carries only the composed
-                    # stress_cost and its physical/intersection/crash parts).
+                    # stress_cost and its physical/intersection/crash/elevation parts).
                     "highway_class": row["highway_class"],
                     "infra_tier": row["infra_tier"],
                     "base_stress_per_meter": _f(row["base_stress_per_meter"]),
@@ -395,8 +395,8 @@ def build_edges_and_strings(
     deduplicated string table.
 
     Per-direction stress composition:
-      forward edge:  physical_cost + crash_cost + intersection_cost_at_end
-      backward edge: physical_cost + crash_cost + intersection_cost_at_start
+      forward edge:  physical_cost + crash_cost + intersection_cost_at_end + elevation_cost_forward
+      backward edge: physical_cost + crash_cost + intersection_cost_at_start + elevation_cost_backward
 
     The returned `strings` dict preserves first-insertion order; its
     keys form the canonical string table (the writer takes `list(strings)`

--- a/platform/airflow/dags/loci/exports/graph_format.py
+++ b/platform/airflow/dags/loci/exports/graph_format.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/airflow/dags/loci/exports/graph_format.py
 """
 Binary writer for the routing graph format.
 
@@ -17,7 +18,9 @@ Format v2 changes from v1:
     (speed/road_type/infrastructure/tunnel/surface/lighting), shrinking
     from 68 to 44 bytes. The additive cost model that replaced them
     keeps only physical_cost, intersection_cost, and crash_cost.
-The header, string table, and CSR offsets are unchanged.
+
+Format v3 changes from v2:
+  - The edge record is now 48 bytes; gained elevation_cost
 """
 
 from __future__ import annotations
@@ -28,7 +31,7 @@ from dataclasses import dataclass
 from typing import IO
 
 MAGIC = b"LOCI"
-FORMAT_VERSION = 2
+FORMAT_VERSION = 3
 NULL_STR_IDX = 0xFFFFFFFF
 EDGE_FLAG_FORWARD = 0b0000_0001
 
@@ -84,6 +87,7 @@ class WriteEdge:
     physical_cost: float
     intersection_cost: float
     crash_cost: float
+    elevation_cost: float
 
 
 @dataclass
@@ -188,6 +192,7 @@ def _write_edge(out: IO[bytes], e: WriteEdge) -> None:
     out.write(_F32_LE.pack(e.physical_cost))
     out.write(_F32_LE.pack(e.intersection_cost))
     out.write(_F32_LE.pack(e.crash_cost))
+    out.write(_F32_LE.pack(e.elevation_cost))
 
 
 def _validate_edge_ordering(edges: list[WriteEdge]) -> None:

--- a/platform/airflow/dags/loci/geo.py
+++ b/platform/airflow/dags/loci/geo.py
@@ -56,3 +56,32 @@ class BBox:
     def to_st_makeenvelope(self) -> str:
         """Render as a PostGIS ST_MakeEnvelope(xmin, ymin, xmax, ymax, srid) call."""
         return f"ST_MakeEnvelope({self.west}, {self.south}, {self.east}, {self.north}, {self.srid})"
+
+
+@dataclass(frozen=True)
+class Gate:
+    """A line segment used as a geometric route assertion.
+
+    Endpoints are (lat, lon) in degrees, matching RouteTestCase's
+    origin/destination convention. A route "crosses" the gate when one of
+    its legs transversally intersects this segment — used to assert that a
+    route passes through (must_cross) or avoids (must_not_cross) a specific
+    corridor, independent of street names.
+    """
+
+    start: tuple[float, float]  # (lat, lon)
+    end: tuple[float, float]  # (lat, lon)
+
+    def __post_init__(self) -> None:
+        for label, (lat, lon) in (("start", self.start), ("end", self.end)):
+            if not -90.0 <= lat <= 90.0:
+                raise ValueError(
+                    f"Gate {label} latitude {lat} out of range [-90, 90]. "
+                    f"Are the endpoints (lat, lon) rather than (lon, lat)?"
+                )
+            if not -180.0 <= lon <= 180.0:
+                raise ValueError(f"Gate {label} longitude {lon} out of range [-180, 180].")
+        if self.start == self.end:
+            raise ValueError(
+                f"Gate endpoints are identical ({self.start}); a gate must have length."
+            )

--- a/platform/airflow/dags/loci/geo.py
+++ b/platform/airflow/dags/loci/geo.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/airflow/dags/loci/geo.py
 """Geographic bounding box.
 
 A small named type for bounding boxes so callers can't silently swap

--- a/platform/airflow/dags/loci/raster/ingest.py
+++ b/platform/airflow/dags/loci/raster/ingest.py
@@ -1,0 +1,305 @@
+# /loci_platform/platform/airflow/dags/loci/raster/ingest.py
+"""
+Ingest a local raster file into a PostGIS `raster` table via StagedIngest.
+
+The flow mirrors the OSM collector: a reader yields row dicts, the
+orchestrator batches them into engine.staged_ingest in SCD2 mode. The
+only thing that makes this a *raster* ingest is that one column (`rast`)
+carries a PostGIS raster hex-WKB string instead of a scalar; PostGIS
+parses it on COPY exactly as it parses geometry WKT.
+
+Design choices, in keeping with the rest of the platform:
+
+- We tile in Python with rasterio windowed reads, one tile at a time, so
+  peak memory is one tile, not the whole file. This is why download-to-
+  file-then-ingest is the right shape: rasterio reads windows from the
+  file on disk; we never hold the full raster in memory.
+
+- SCD2 keys on `tile_id` (stable across runs for the same geographic
+  tile) and detects change via a cheap `checksum` column (md5 of the
+  tile's raw bytes). `rast` itself is excluded from the hash — hashing
+  the multi-hundred-KB raster text on every row would be wasteful, and
+  the checksum already captures content change.
+
+- generate_ddl is built per source-collector elsewhere (as with OSM and
+  CMS); raster_table_ddl is the shared helper those collectors call so
+  the column set and the GiST index on ST_ConvexHull(rast) stay
+  consistent.
+
+A `raster` table is the natural fit for downstream sampling:
+
+    select n.node_id,
+           ST_Value(r.rast, n.geom, resample => 'bilinear') as elevation_m
+    from   <raster_table> r
+    join   nodes n on ST_Intersects(r.rast, n.geom);
+
+The ST_Intersects is served by the GiST index, so each node resolves to
+its one tile.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import rasterio
+from loci.raster.wkb import to_hexwkb
+from rasterio.windows import Window
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TILE_SIZE = 256
+
+# Columns the database fills in (SCD2 bookkeeping); excluded from the
+# COPY column list by StagedIngest.
+METADATA_COLUMNS: set[str] = {"record_hash", "valid_from", "valid_to"}
+
+# Excluded from the record hash. `rast` is excluded because `checksum`
+# already carries the content-change signal far more cheaply than
+# hashing the raster text. `ingested_at` is excluded so re-runs don't
+# spuriously version every tile.
+HASH_EXCLUDE_COLUMNS: set[str] = METADATA_COLUMNS | {"rast", "ingested_at"}
+
+
+@dataclass(frozen=True)
+class RasterTile:
+    """One tile read from a raster file, ready to become an ingest row."""
+
+    tile_id: str
+    rast_hexwkb: str
+    checksum: str
+    srid: int
+    # Tile extent in the raster's CRS, handy for debugging / sanity joins.
+    min_x: float
+    min_y: float
+    max_x: float
+    max_y: float
+
+
+def iter_tiles(
+    path: str,
+    *,
+    source_id: str,
+    band: int = 1,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    bounds: tuple[float, float, float, float] | None = None,
+) -> Iterator[RasterTile]:
+    """
+    Yield non-overlapping tiles covering the raster at `path`.
+
+    Parameters
+    ----------
+    path : str
+        Local path to a GDAL-readable raster (e.g. a downloaded GeoTIFF
+        or COG).
+    source_id : str
+        Stable identifier for this source file/region, used to build
+        tile_id. Must be stable across runs so SCD2 recognizes the same
+        geographic tile (e.g. the DEM tile name or "<city>").
+    band : int
+        1-based band index to read. DEMs are single-band; default 1.
+    tile_size : int
+        Tile edge in pixels. Edge tiles are smaller. 256 keeps each
+        tile's index entry tight without too many rows.
+    bounds : tuple[float, float, float, float] | None
+        Optional (min_x, min_y, max_x, max_y) clip extent, IN THE
+        RASTER'S OWN CRS. Tiles whose extent does not intersect it are
+        skipped (and their pixels never read). Use this to keep only the
+        sub-tiles covering a city, rather than a whole source block. The
+        caller is responsible for expressing the extent in the raster's
+        CRS — for 3DEP (EPSG:4269) a NAD83 BBox is already correct.
+
+    Yields
+    ------
+    RasterTile
+        One per tile, row-major over the raster (top-left first).
+    """
+    with rasterio.open(path) as ds:
+        srid = _resolve_srid(ds)
+        nodata = ds.nodata
+
+        for row_off in range(0, ds.height, tile_size):
+            for col_off in range(0, ds.width, tile_size):
+                w = min(tile_size, ds.width - col_off)
+                h = min(tile_size, ds.height - row_off)
+                window = Window(col_off, row_off, w, h)
+                transform = ds.window_transform(window)
+
+                # Tile extent first, so a clipped-out tile costs no read.
+                left, top = transform * (0, 0)
+                right, bottom = transform * (w, h)
+                min_x, max_x = min(left, right), max(left, right)
+                min_y, max_y = min(top, bottom), max(top, bottom)
+
+                if bounds is not None and not _intersects((min_x, min_y, max_x, max_y), bounds):
+                    continue
+
+                pixels = ds.read(band, window=window)
+
+                # affine: a=scale_x, b=skew_x, c=ip_x, d=skew_y, e=scale_y, f=ip_y
+                rast_hexwkb = to_hexwkb(
+                    pixels,
+                    scale_x=transform.a,
+                    scale_y=transform.e,
+                    ip_x=transform.c,
+                    ip_y=transform.f,
+                    srid=srid,
+                    nodata=nodata,
+                    skew_x=transform.b,
+                    skew_y=transform.d,
+                )
+
+                # Content checksum over the raw tile bytes + the
+                # georeference, so a tile that moves or changes values
+                # gets a new SCD2 version.
+                checksum = _tile_checksum(pixels, transform, srid)
+
+                yield RasterTile(
+                    tile_id=f"{source_id}/{row_off}_{col_off}",
+                    rast_hexwkb=rast_hexwkb,
+                    checksum=checksum,
+                    srid=srid,
+                    min_x=min_x,
+                    min_y=min_y,
+                    max_x=max_x,
+                    max_y=max_y,
+                )
+
+
+def _intersects(a: tuple[float, float, float, float], b: tuple[float, float, float, float]) -> bool:
+    """True if two (min_x, min_y, max_x, max_y) extents overlap (touching counts)."""
+    return not (a[2] < b[0] or a[0] > b[2] or a[3] < b[1] or a[1] > b[3])
+
+
+def tile_to_row(tile: RasterTile, ingested_at: Any) -> dict[str, Any]:
+    """Turn a RasterTile into a staged_ingest row dict."""
+    return {
+        "tile_id": tile.tile_id,
+        "rast": tile.rast_hexwkb,
+        "checksum": tile.checksum,
+        "srid": tile.srid,
+        "min_x": tile.min_x,
+        "min_y": tile.min_y,
+        "max_x": tile.max_x,
+        "max_y": tile.max_y,
+        "ingested_at": ingested_at,
+    }
+
+
+def raster_table_ddl(target_schema: str, target_table: str, srid: int) -> str:
+    """
+    CREATE TABLE plus constraint/index DDL for a raster tile table.
+
+    The shape mirrors the OSM/CMS DDL: data columns, SCD2 metadata
+    columns, the (entity_key, record_hash) uniqueness constraint, a
+    partial current-rows index, and — the raster-specific part — a GiST
+    index on ST_ConvexHull(rast) restricted to current rows, which is
+    what makes ST_Intersects(rast, point) sampling fast.
+
+    No AddRasterConstraints call: the strict srid/scale/alignment
+    constraints are optional, add friction to SCD2 inserts, and are not
+    needed for ST_Value sampling. Add them later if a coverage-level
+    invariant becomes useful.
+    """
+    fqn = f"{target_schema}.{target_table}"
+    ek = '"tile_id"'
+
+    lines = [
+        f"create table if not exists {fqn} (",
+        '    "tile_id" text not null,',
+        '    "rast" raster not null,',
+        '    "checksum" text not null,',
+        '    "srid" integer not null,',
+        '    "min_x" double precision,',
+        '    "min_y" double precision,',
+        '    "max_x" double precision,',
+        '    "max_y" double precision,',
+        "    \"ingested_at\" timestamptz not null default (now() at time zone 'UTC'),",
+        '    "record_hash" text not null,',
+        "    \"valid_from\" timestamptz not null default (now() at time zone 'UTC'),",
+        '    "valid_to" timestamptz',
+        ");",
+        "",
+        f"alter table {fqn}",
+        f"    add constraint uq_{target_table}_entity_hash",
+        f'    unique ({ek}, "record_hash");',
+        "",
+        f"create index if not exists ix_{target_table}_current",
+        f"    on {fqn} ({ek})",
+        '    where "valid_to" is null;',
+        "",
+        f"create index if not exists ix_{target_table}_rast",
+        f"    on {fqn} using gist (ST_ConvexHull(rast))",
+        '    where "valid_to" is null;',
+    ]
+    return "\n".join(lines)
+
+
+def ingest_raster_file(
+    engine: Any,
+    path: str,
+    *,
+    source_id: str,
+    target_schema: str,
+    target_table: str,
+    ingested_at: Any,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    batch_size: int = 32,
+    bounds: tuple[float, float, float, float] | None = None,
+) -> dict[str, int]:
+    """
+    Tile a local raster and SCD2-merge its tiles into the target table.
+
+    Returns a small summary dict. batch_size is intentionally low: each
+    raster tile is a large COPY field, so a handful per batch keeps the
+    staging buffer modest. `bounds` (in the raster's CRS) clips the tiles
+    to a region of interest; see iter_tiles.
+    """
+    rows: list[dict[str, Any]] = []
+    tiles_read = 0
+
+    with engine.staged_ingest(
+        target_table=target_table,
+        target_schema=target_schema,
+        entity_key=["tile_id"],
+        metadata_columns=METADATA_COLUMNS,
+        hash_exclude_columns=HASH_EXCLUDE_COLUMNS,
+    ) as stager:
+        for tile in iter_tiles(path, source_id=source_id, tile_size=tile_size, bounds=bounds):
+            rows.append(tile_to_row(tile, ingested_at))
+            tiles_read += 1
+            if len(rows) >= batch_size:
+                stager.write_batch(rows)
+                rows = []
+        if rows:
+            stager.write_batch(rows)
+
+    return {
+        "tiles_read": tiles_read,
+        "rows_staged": stager.rows_staged,
+        "rows_merged": stager.rows_merged,
+    }
+
+
+def _resolve_srid(ds: rasterio.DatasetReader) -> int:
+    if ds.crs is None:
+        raise ValueError("raster has no CRS; cannot determine srid")
+    epsg = ds.crs.to_epsg()
+    if epsg is None:
+        raise ValueError(f"raster CRS {ds.crs} has no EPSG code; reproject before ingest")
+    return int(epsg)
+
+
+def _tile_checksum(pixels: np.ndarray, transform, srid: int) -> str:
+    h = hashlib.md5()
+    h.update(np.ascontiguousarray(pixels, dtype="<f4").tobytes())
+    h.update(
+        repr(
+            (transform.a, transform.b, transform.c, transform.d, transform.e, transform.f, srid)
+        ).encode()
+    )
+    return h.hexdigest()

--- a/platform/airflow/dags/loci/raster/wkb.py
+++ b/platform/airflow/dags/loci/raster/wkb.py
@@ -1,0 +1,119 @@
+"""
+Serialize a 2D elevation array into a PostGIS raster hex-WKB string.
+
+This is the one primitive that lets us ingest rasters through the
+existing StagedIngest path: PostGIS's `raster` input function parses a
+hex-WKB literal, exactly like `geometry` parses WKT. So we produce the
+hex string here, hand it to staged_ingest as the value of a `raster`
+column, and the COPY -> SCD2 merge path handles the rest unchanged.
+
+Only the single-band, in-db case we need for DEMs is implemented. Every
+band is emitted as 32-bit float (PT_32BF): elevation fits in float32
+with room to spare, and emitting one pixel type keeps this simple and
+keeps the SCD2 checksum stable across sources that happen to store
+integers vs floats.
+
+Format reference: PostGIS raster serialized WKB (rt_raster_serialize).
+Layout, little-endian (NDR):
+
+    uint8   endianness   1 = NDR (little-endian)
+    uint16  version      0
+    uint16  n_bands      1
+    float64 scale_x
+    float64 scale_y
+    float64 ip_x         upper-left corner X of the upper-left pixel
+    float64 ip_y         upper-left corner Y of the upper-left pixel
+    float64 skew_x
+    float64 skew_y
+    int32   srid
+    uint16  width
+    uint16  height
+    -- per band:
+    uint8   band_header  bit6 (0x40) = has nodata; bits0-3 = pixel type
+    float32 nodata       (sized to the pixel type; 32BF here)
+    float32[width*height] pixel data, row-major (top row first)
+"""
+
+from __future__ import annotations
+
+import struct
+
+import numpy as np
+
+# PostGIS rt_pixtype value for 32-bit float. We always emit this.
+_PT_32BF = 10
+_HAS_NODATA_FLAG = 0x40
+
+# A nodata value to use when the source raster declares none. PostGIS
+# requires *some* value in the band header; we set the flag off so it is
+# never interpreted as nodata, but still write a placeholder.
+_NO_NODATA_PLACEHOLDER = 0.0
+
+
+def to_hexwkb(
+    pixels: np.ndarray,
+    *,
+    scale_x: float,
+    scale_y: float,
+    ip_x: float,
+    ip_y: float,
+    srid: int,
+    nodata: float | None,
+    skew_x: float = 0.0,
+    skew_y: float = 0.0,
+) -> str:
+    """
+    Serialize a 2D array into a single-band 32BF PostGIS raster hex-WKB.
+
+    Parameters
+    ----------
+    pixels : np.ndarray
+        2D array, shape (height, width). Cast to float32 on the way out.
+    scale_x, scale_y : float
+        Pixel size in CRS units. scale_y is normally negative (north-up).
+    ip_x, ip_y : float
+        Upper-left corner of the upper-left pixel (the GDAL/affine origin).
+    srid : int
+        Spatial reference id of the raster's CRS.
+    nodata : float | None
+        Band nodata value, or None if the source declares none.
+    skew_x, skew_y : float
+        Rotation terms. Zero for north-up rasters.
+
+    Returns
+    -------
+    str
+        Hex-WKB string (lowercase, no leading 0x) suitable as the value
+        of a `raster` column in a text-format COPY.
+    """
+    if pixels.ndim != 2:
+        raise ValueError(f"pixels must be 2D (height, width); got shape {pixels.shape}")
+
+    height, width = pixels.shape
+    if width > 0xFFFF or height > 0xFFFF:
+        raise ValueError(
+            f"tile {width}x{height} exceeds the uint16 raster dimension limit (65535); "
+            "use a smaller tile size"
+        )
+
+    has_nodata = nodata is not None
+    nodata_value = float(nodata) if has_nodata else _NO_NODATA_PLACEHOLDER
+    band_header = _PT_32BF | (_HAS_NODATA_FLAG if has_nodata else 0)
+
+    out = bytearray()
+    out += struct.pack("<B", 1)  # endianness: NDR
+    out += struct.pack("<H", 0)  # version
+    out += struct.pack("<H", 1)  # n_bands
+    out += struct.pack("<dddddd", scale_x, scale_y, ip_x, ip_y, skew_x, skew_y)
+    out += struct.pack("<i", srid)
+    out += struct.pack("<H", width)
+    out += struct.pack("<H", height)
+    out += struct.pack("<B", band_header)
+    out += struct.pack("<f", nodata_value)
+
+    # Row-major, top row first. numpy C-order already matches; force
+    # little-endian float32 so the byte layout is explicit, not
+    # platform-dependent.
+    out += np.ascontiguousarray(pixels, dtype="<f4").tobytes()
+
+    return out.hex()

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -10,6 +10,7 @@ from loci.collectors.osm.spec import OSMDatasetSpec
 from loci.collectors.osmnx.spec import OsmnxDatasetSpec
 from loci.collectors.socrata.spec import SocrataDatasetSpec
 from loci.collectors.static.spec import FileRef, StaticFileDatasetSpec
+from loci.collectors.threedep.spec import ThreeDEPDatasetSpec
 from loci.collectors.tiger.spec import TigerDatasetSpec
 from loci.geo import BBox
 
@@ -1749,3 +1750,30 @@ AHRQ_HEALTH_SYSTEMS_SPEC = StaticFileDatasetSpec(
         FileRef(url=f"{AHRQ_BASE}/chsp-compendium-2023-rev.csv", vintage="2023", encoding="cp1252"),
     ],
 )
+
+
+#######################################################################################
+#    USGS 3DEP Elevation                                                              #
+#######################################################################################
+
+
+def generate_3dep_elevation_spec(city: str, bbox: BBox, product: str = "13") -> ThreeDEPDatasetSpec:
+    """Build a USGS 3DEP elevation spec for a given US city."""
+    return ThreeDEPDatasetSpec(
+        name=f"{city}_3dep_elevation",
+        target_table=f"{city}_3dep_elevation",
+        target_schema="raw_data",
+        bbox=bbox,
+        product=product,
+    )
+
+
+BOSTON_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="boston", bbox=BOSTON_BBOX)
+CHICAGO_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="chicago", bbox=CHICAGO_BBOX)
+DC_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="dc", bbox=WASHINGTON_DC_BBOX)
+DENVER_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="denver", bbox=DENVER_BBOX)
+DETROIT_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="detroit", bbox=DENVER_BBOX)
+MADISON_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="madison", bbox=MADISON_BBOX)
+NOLA_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="nola", bbox=NEW_ORLEANS_BBOX)
+PORTLAND_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="portland", bbox=PORTLAND_BBOX)
+SF_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="sf", bbox=SAN_FRANCISCO_BBOX)

--- a/platform/airflow/dags/loci/sources/update_configs.py
+++ b/platform/airflow/dags/loci/sources/update_configs.py
@@ -1011,6 +1011,75 @@ AHRQ_HEALTH_SYSTEMS_UC = DatasetUpdateConfig(
 
 
 #######################################################################################
+#    USGS 3DEP Elevation                                                              #
+#######################################################################################
+
+
+BOSTON_3DEP_ELEVATION_UC = DatasetUpdateConfig(
+    spec=specs.BOSTON_3DEP_ELEVATION_SPEC,
+    update_cron="0 3 10 1 *",
+    full_update_week_of_month=1,
+    full_update_day_of_week=6,
+)
+
+CHICAGO_3DEP_ELEVATION_UC = DatasetUpdateConfig(
+    spec=specs.CHICAGO_3DEP_ELEVATION_SPEC,
+    update_cron="10 3 10 1 *",
+    full_update_week_of_month=1,
+    full_update_day_of_week=6,
+)
+
+DC_3DEP_ELEVATION_UC = DatasetUpdateConfig(
+    spec=specs.DC_3DEP_ELEVATION_SPEC,
+    update_cron="20 3 10 1 *",
+    full_update_week_of_month=1,
+    full_update_day_of_week=6,
+)
+
+DENVER_3DEP_ELEVATION_UC = DatasetUpdateConfig(
+    spec=specs.DENVER_3DEP_ELEVATION_SPEC,
+    update_cron="30 3 10 1 *",
+    full_update_week_of_month=1,
+    full_update_day_of_week=6,
+)
+
+DETROIT_3DEP_ELEVATION_UC = DatasetUpdateConfig(
+    spec=specs.DETROIT_3DEP_ELEVATION_SPEC,
+    update_cron="40 3 10 1 *",
+    full_update_week_of_month=1,
+    full_update_day_of_week=6,
+)
+
+MADISON_3DEP_ELEVATION_UC = DatasetUpdateConfig(
+    spec=specs.MADISON_3DEP_ELEVATION_SPEC,
+    update_cron="50 3 10 1 *",
+    full_update_week_of_month=1,
+    full_update_day_of_week=6,
+)
+
+NOLA_3DEP_ELEVATION_UC = DatasetUpdateConfig(
+    spec=specs.NOLA_3DEP_ELEVATION_SPEC,
+    update_cron="0 4 10 1 *",
+    full_update_week_of_month=1,
+    full_update_day_of_week=6,
+)
+
+PORTLAND_3DEP_ELEVATION_UC = DatasetUpdateConfig(
+    spec=specs.PORTLAND_3DEP_ELEVATION_SPEC,
+    update_cron="10 4 10 1 *",
+    full_update_week_of_month=1,
+    full_update_day_of_week=6,
+)
+
+SF_3DEP_ELEVATION_UC = DatasetUpdateConfig(
+    spec=specs.SF_3DEP_ELEVATION_SPEC,
+    update_cron="20 4 10 1 *",
+    full_update_week_of_month=1,
+    full_update_day_of_week=6,
+)
+
+
+#######################################################################################
 #    OSMnx                                                                            #
 #######################################################################################
 

--- a/platform/airflow/dags/loci/tasks/testing/route_tests.py
+++ b/platform/airflow/dags/loci/tasks/testing/route_tests.py
@@ -31,6 +31,8 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from loci.geo import Gate
+
 logger = logging.getLogger(__name__)
 
 # Path inside the Airflow worker where chunk 7's compose mount lands.
@@ -51,6 +53,8 @@ class RouteTestCase:
         destination: (lat, lon) tuple.
         must_use: Street names the route MUST include (any partial match).
         must_avoid: Street names the route must NOT include (any partial match).
+        must_cross: the route must pass through every gate listed.
+        must_not_cross: the route must pass through none of them.
         max_cost: Optional upper bound on total_cost (catches cost explosions).
     """
 
@@ -59,6 +63,8 @@ class RouteTestCase:
     destination: tuple[float, float]
     must_use: list[str] = field(default_factory=list)
     must_avoid: list[str] = field(default_factory=list)
+    must_cross: list[Gate] = field(default_factory=list)
+    must_not_cross: list[Gate] = field(default_factory=list)
     max_cost: float | None = None
 
 
@@ -251,6 +257,18 @@ def _check_single_assertions(case: RouteTestCase, cli_result: dict) -> TestResul
         if _street_name_matches(street_names, forbidden):
             failures.append(f"Route should avoid {forbidden!r} but it was used")
 
+    for i, gate in enumerate(case.must_cross):
+        if not _route_crosses_gate(route, gate):
+            failures.append(
+                f"Expected route to cross gate {i} ({gate.start} -> {gate.end}) but it didn't"
+            )
+
+    for i, gate in enumerate(case.must_not_cross):
+        if _route_crosses_gate(route, gate):
+            failures.append(
+                f"Route should not cross gate {i} ({gate.start} -> {gate.end}) but it did"
+            )
+
     if case.max_cost is not None:
         total_cost = float(route.get("total_cost", float("inf")))
         if total_cost > case.max_cost:
@@ -281,3 +299,62 @@ def _street_name_matches(route_names: set[str], pattern: str) -> bool:
     """Case-insensitive substring match against the route's street names."""
     pattern_lower = pattern.lower()
     return any(pattern_lower in name.lower() for name in route_names)
+
+
+def _segments_cross(
+    a: tuple[float, float],
+    b: tuple[float, float],
+    c: tuple[float, float],
+    d: tuple[float, float],
+) -> bool:
+    """True if open segment a-b transversally crosses open segment c-d.
+
+    All points are (x, y). We find where the two infinite lines meet,
+    expressed as a fraction along each segment — t along a-b, u along c-d —
+    then the segments cross iff that point lies strictly inside both
+    (0 < t < 1 and 0 < u < 1).
+
+    Strict inequalities make this transversal-only: a leg that merely
+    touches a gate's endpoint, or runs collinear with it, does NOT count.
+    A gate is meant to be crossed cleanly; ambiguous grazes should be fixed
+    by moving the gate, not resolved here. Parallel segments (zero
+    denominator) never cross.
+
+    Planar assumption: over a single route leg and a hand-placed gate (tens
+    to hundreds of meters) the error from ignoring earth curvature is far
+    below the precision at which gates are placed. This mirrors the planar
+    assumption the Rust KD-tree already makes for nearest-node lookup.
+    """
+    (ax, ay), (bx, by) = a, b
+    (cx, cy), (dx, dy) = c, d
+
+    # Direction vectors of each segment.
+    r = (bx - ax, by - ay)
+    s = (dx - cx, dy - cy)
+
+    denom = r[0] * s[1] - r[1] * s[0]
+    if denom == 0.0:
+        return False  # parallel or collinear
+
+    # Vector from a to c, and the two fractional positions of the crossing.
+    ac = (cx - ax, cy - ay)
+    t = (ac[0] * s[1] - ac[1] * s[0]) / denom
+    u = (ac[0] * r[1] - ac[1] * r[0]) / denom
+
+    return 0.0 < t < 1.0 and 0.0 < u < 1.0
+
+
+def _route_crosses_gate(route: dict, gate: Gate) -> bool:
+    """True if any leg of the route's geometry crosses `gate`."""
+    # Gate endpoints are (lat, lon); route coordinates are (lon, lat) per
+    # the graph format. Convert the gate once, here, to (lon, lat) so the
+    # primitive works in a single consistent coordinate order.
+    g1 = (gate.start[1], gate.start[0])
+    g2 = (gate.end[1], gate.end[0])
+
+    for seg in route.get("segments", []):
+        coords = seg.get("coordinates", [])
+        for p1, p2 in zip(coords, coords[1:], strict=False):
+            if _segments_cross(tuple(p1), tuple(p2), g1, g2):
+                return True
+    return False

--- a/platform/airflow/dags/loci/transform/generators/bike_map.py
+++ b/platform/airflow/dags/loci/transform/generators/bike_map.py
@@ -394,7 +394,7 @@ class BikeStressPipelineBuilder(CityPipelineBuilder):
     ]
 ) }}}}
 
-{{{{ generate_city_bike_stress_weighted_segments_model('{city}', include_crashes={include_crashes}) }}}}
+{{{{ generate_city_bike_stress_weighted_segments_model('{city}', include_crashes={include_crashes}, include_elevation={include_elevation}) }}}}
 """,
     }
 
@@ -816,6 +816,22 @@ class BikeStressPipelineBuilder(CityPipelineBuilder):
                 },
                 {
                     "dbt_utils.expression_is_true": {
+                        "arguments": {"expression": "elevation_cost_forward >= 0"},
+                        "config": {
+                            "name": "{city}_stress_weighted_elevation_cost_forward_non_negative",
+                        },
+                    },
+                },
+                {
+                    "dbt_utils.expression_is_true": {
+                        "arguments": {"expression": "elevation_cost_backward >= 0"},
+                        "config": {
+                            "name": "{city}_stress_weighted_elevation_cost_backward_non_negative",
+                        },
+                    },
+                },
+                {
+                    "dbt_utils.expression_is_true": {
                         "arguments": {"expression": "intersection_cost_at_start >= 0"},
                         "config": {
                             "name": "{city}_intersection_cost_at_start_non_negative",
@@ -855,6 +871,8 @@ class BikeStressPipelineBuilder(CityPipelineBuilder):
                 {"name": "geom", "data_tests": ["not_null"]},
                 {"name": "physical_cost", "data_tests": ["not_null"]},
                 {"name": "crash_cost", "data_tests": ["not_null"]},
+                {"name": "elevation_cost_forward", "data_tests": ["not_null"]},
+                {"name": "elevation_cost_backward", "data_tests": ["not_null"]},
                 {
                     "name": "intersection_cost_at_start",
                     "description": (
@@ -898,6 +916,7 @@ class BikeStressPipelineBuilder(CityPipelineBuilder):
         city: str,
         include_crashes: bool,
         include_all_sidewalks: bool,
+        include_elevation: bool = True,
         overwrite: bool = False,
         overwrite_tests: bool = False,
     ) -> list[Path]:
@@ -927,6 +946,7 @@ class BikeStressPipelineBuilder(CityPipelineBuilder):
             fmt_kwargs={
                 "include_crashes": jinja_bool(include_crashes),
                 "include_all_sidewalks": jinja_bool(include_all_sidewalks),
+                "include_elevation": jinja_bool(include_elevation),
             },
             marts_models=marts_models,
         )
@@ -1030,6 +1050,224 @@ class OsmBikeParkingPipelineBuilder(CityPipelineBuilder):
             overwrite: when True, overwrite existing .sql files.
         """
         return self._generate_pipeline(city=city, overwrite=overwrite)
+
+
+class ElevationCostPipelineBuilder(CityPipelineBuilder):
+    """Generates the dbt model files and test ymls for a city's elevation-cost
+    pipeline.
+
+    Pipeline shape: two staging models that lift the city's 3DEP raster into a
+    GiST-indexed tile-footprint lookup and a per-node elevation table, then one
+    marts model that turns endpoint elevation deltas into directional,
+    quadratic-in-grade elevation costs. All steps delegate to parameterized
+    dbt macros.
+
+    This is a separate stream from the bike-stress pipeline: it reads
+    stg_<city>_bike_segments (for node geometry) and produces
+    <city>_segment_elevation_costs, which the bike-stress assembly model joins
+    in when generated with include_elevation=True. Run this builder for a city
+    in addition to BikeStressPipelineBuilder; dbt refs sequence the two streams.
+
+    Usage:
+        builder = ElevationCostPipelineBuilder("/path/to/dbt")
+        builder.generate(city="portland")
+    """
+
+    DOMAIN = "cycling"
+    SOURCE_NAME = "threedep"
+    SOURCE_TABLES = ["{city}_3dep_elevation"]
+
+    STAGING_MODELS: dict[str, str] = {
+        "stg_{city}_elevation_tiles": """\
+{{{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{{{ this }}}} USING GIST (hull)",
+        "ANALYZE {{{{ this }}}}"
+    ]
+) }}}}
+
+{{{{ generate_stg_city_elevation_tiles_model('{city}') }}}}
+""",
+        "stg_{city}_node_elevations": """\
+{{{{ config(materialized='table') }}}}
+
+{{{{ generate_stg_city_node_elevations_model('{city}') }}}}
+""",
+    }
+
+    MARTS_MODELS: dict[str, str] = {
+        "{city}_segment_elevation_costs": """\
+{{{{ config(materialized='table') }}}}
+
+{{{{ generate_city_segment_elevation_costs_model('{city}') }}}}
+""",
+    }
+
+    STAGING_TESTS: list[dict] = [
+        {
+            "name": "stg_{city}_elevation_tiles",
+            "description": (
+                "Precomputed convex-hull footprints for the current 3DEP "
+                "sub-tiles, used for indexed node-to-tile resolution during "
+                "elevation sampling. One row per current tile_id."
+            ),
+            "columns": [
+                {
+                    "name": "tile_id",
+                    "description": (
+                        "Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>)."
+                    ),
+                    "data_tests": ["not_null", "unique"],
+                },
+                {
+                    "name": "hull",
+                    "description": (
+                        "Tile convex hull (geometry, 4269). NULL would silently "
+                        "drop the tile's coverage."
+                    ),
+                    "data_tests": ["not_null"],
+                },
+            ],
+        },
+        {
+            "name": "stg_{city}_node_elevations",
+            "description": (
+                "One row per routing-graph node with its bare-earth elevation "
+                "sampled from the city's 3DEP DEM. elevation_m is intentionally "
+                "nullable: a node outside coverage or on a nodata pixel (e.g. "
+                "open water) is NULL and treated as flat downstream."
+            ),
+            "columns": [
+                {
+                    "name": "node_id",
+                    "description": (
+                        "OSM node id. unique is the regression guard for the "
+                        "one-row-per-node grain the lateral limit-1 resolution "
+                        "guarantees."
+                    ),
+                    "data_tests": ["not_null", "unique"],
+                },
+                {"name": "geom", "data_tests": ["not_null"]},
+                {
+                    "name": "elevation_m",
+                    "description": (
+                        "NAVD88 meters, or NULL on a coverage gap. The range "
+                        "bound catches nodata sentinels (-9999, +/-3.4e38) "
+                        "leaking through as numbers and gross unit errors; "
+                        "checked only on non-null rows. Bounds are loose on "
+                        "purpose: they span every target metro (Denver sits near "
+                        "1600 m), so they flag sentinels, not tight validation."
+                    ),
+                    "data_tests": [
+                        {
+                            "dbt_utils.accepted_range": {
+                                "arguments": {"min_value": -100, "max_value": 4500},
+                                "config": {"where": "elevation_m is not null"},
+                            },
+                        },
+                        {
+                            "dbt_utils.not_null_proportion": {
+                                "arguments": {"at_least": 0.98},
+                                "config": {"severity": "warn"},
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    ]
+
+    MARTS_TESTS: list[dict] = [
+        {
+            "name": "{city}_segment_elevation_costs",
+            "description": (
+                "Directional elevation cost per segment from the endpoint "
+                "elevation delta, quadratic in grade with separate up/down "
+                "coefficients. One row per segment_id. Costs coalesce to 0 on a "
+                "coverage gap (treated as flat)."
+            ),
+            "data_tests": [
+                {
+                    "dbt_utils.equal_rowcount": {
+                        "arguments": {"compare_model": "ref('stg_{city}_bike_segments')"},
+                    },
+                },
+                {
+                    "dbt_utils.expression_is_true": {
+                        "arguments": {"expression": "elevation_cost_forward >= 0"},
+                        "config": {
+                            "name": "{city}_elevation_cost_forward_non_negative",
+                        },
+                    },
+                },
+                {
+                    "dbt_utils.expression_is_true": {
+                        "arguments": {"expression": "elevation_cost_backward >= 0"},
+                        "config": {
+                            "name": "{city}_elevation_cost_backward_non_negative",
+                        },
+                    },
+                },
+            ],
+            "columns": [
+                {"name": "segment_id", "data_tests": ["not_null", "unique"]},
+                {
+                    "name": "start_node_id",
+                    "description": (
+                        "Completeness check — every endpoint must resolve in node_elevations."
+                    ),
+                    "data_tests": [
+                        "not_null",
+                        {
+                            "relationships": {
+                                "arguments": {
+                                    "to": "ref('stg_{city}_node_elevations')",
+                                    "field": "node_id",
+                                },
+                            },
+                        },
+                    ],
+                },
+                {
+                    "name": "end_node_id",
+                    "data_tests": [
+                        "not_null",
+                        {
+                            "relationships": {
+                                "arguments": {
+                                    "to": "ref('stg_{city}_node_elevations')",
+                                    "field": "node_id",
+                                },
+                            },
+                        },
+                    ],
+                },
+                {"name": "elevation_cost_forward", "data_tests": ["not_null"]},
+                {"name": "elevation_cost_backward", "data_tests": ["not_null"]},
+            ],
+        },
+    ]
+
+    def generate(
+        self,
+        city: str,
+        overwrite: bool = False,
+        overwrite_tests: bool = False,
+    ) -> list[Path]:
+        """Generate all dbt files for a city's elevation-cost pipeline.
+
+        Args:
+            city: city name.
+            overwrite: when True, overwrite existing .sql files.
+            overwrite_tests: when True, replace existing yml model entries whose
+                name matches an entry in STAGING_TESTS / MARTS_TESTS.
+        """
+        return self._generate_pipeline(
+            city=city,
+            overwrite=overwrite,
+            overwrite_tests=overwrite_tests,
+        )
 
 
 # =====================================================================

--- a/platform/dbt/macros/elevation/generate_city_segment_elevation_costs_model.sql
+++ b/platform/dbt/macros/elevation/generate_city_segment_elevation_costs_model.sql
@@ -1,0 +1,70 @@
+{#
+    Directional elevation cost per segment from the endpoint elevation delta.
+    Quadratic in grade (steep costs disproportionately more than shallow);
+    separate up/down coefficients (climbing penalized more than descending).
+
+    grade_forward = (end_elev - start_elev) / length_m. Backward is the mirror;
+    grade² is sign-independent, so only the coefficient differs by direction.
+
+    A NULL elevation at either endpoint (coverage gap) -> NULL grade -> cost
+    coalesces to 0 (treated as flat). start/end elevation and grade are carried
+    through for tuning visibility.
+
+    Coefficients are dbt vars so you can tune without editing the macro:
+      elevation_uphill_coeff   (default 150)
+      elevation_downhill_coeff (default 60)
+
+    Source: stg_<city>_bike_segments, <city>_node_elevations
+    Grain: one row per segment_id.
+#}
+{% macro generate_city_segment_elevation_costs_model(city) %}
+
+{% set uphill_coeff   = var('elevation_uphill_coeff', 150) %}
+{% set downhill_coeff = var('elevation_downhill_coeff', 60) %}
+
+with segments as (
+    select
+        s.segment_id,
+        s.start_node_id,
+        s.end_node_id,
+        s.length_m,
+        ns.elevation_m as start_elevation_m,
+        ne.elevation_m as end_elevation_m
+    from {{ ref('stg_' ~ city ~ '_bike_segments') }} s
+    left join {{ ref('stg_' ~ city ~ '_node_elevations') }} ns on ns.node_id = s.start_node_id
+    left join {{ ref('stg_' ~ city ~ '_node_elevations') }} ne on ne.node_id = s.end_node_id
+),
+graded as (
+    select
+        *,
+        (end_elevation_m - start_elevation_m) as rise_forward_m,
+        (end_elevation_m - start_elevation_m) / nullif(length_m, 0) as grade_forward
+    from segments
+)
+select
+    segment_id,
+    start_node_id,
+    end_node_id,
+    start_elevation_m,
+    end_elevation_m,
+    rise_forward_m,
+    grade_forward,
+
+    -- Forward: climb when grade_forward > 0. coalesce(...,0): gap -> flat.
+    coalesce(
+        case when grade_forward > 0
+             then {{ uphill_coeff }}   * grade_forward * grade_forward * length_m
+             else {{ downhill_coeff }} * grade_forward * grade_forward * length_m
+        end, 0
+    ) as elevation_cost_forward,
+
+    -- Backward: climb when grade_forward < 0 (the reverse traversal ascends).
+    coalesce(
+        case when grade_forward < 0
+             then {{ uphill_coeff }}   * grade_forward * grade_forward * length_m
+             else {{ downhill_coeff }} * grade_forward * grade_forward * length_m
+        end, 0
+    ) as elevation_cost_backward
+from graded
+
+{% endmacro %}

--- a/platform/dbt/macros/elevation/generate_stg_city_elevation_tiles_model.sql
+++ b/platform/dbt/macros/elevation/generate_stg_city_elevation_tiles_model.sql
@@ -1,5 +1,22 @@
+{#
+    Precomputed tile footprints for elevation sampling. One row per current
+    sub-tile of the region's 3DEP raster, carrying the tile's convex hull as a
+    plain geometry. Exists so node-to-tile resolution is an indexed hull probe
+    instead of a brute-force ST_Intersects that detoasts every raster per node.
+
+    The hull is computed once here (detoasting each tile a single time at build)
+    and GiST-indexed via the model's post_hook, so downstream sampling never
+    touches the raster pixels just to figure out which tile a point lands in.
+
+    Source: source('threedep', '<city>_3dep_elevation')
+    Grain: one row per tile_id (current rows only).
+#}
 {% macro generate_stg_city_elevation_tiles_model(city) %}
-select tile_id, ST_ConvexHull(rast) as hull
+
+select
+    tile_id,
+    ST_ConvexHull(rast) as hull
 from {{ source('threedep', city ~ '_3dep_elevation') }}
 where valid_to is null
+
 {% endmacro %}

--- a/platform/dbt/macros/elevation/generate_stg_city_elevation_tiles_model.sql
+++ b/platform/dbt/macros/elevation/generate_stg_city_elevation_tiles_model.sql
@@ -1,0 +1,5 @@
+{% macro generate_stg_city_elevation_tiles_model(city) %}
+select tile_id, ST_ConvexHull(rast) as hull
+from {{ source('threedep', city ~ '_3dep_elevation') }}
+where valid_to is null
+{% endmacro %}

--- a/platform/dbt/macros/elevation/generate_stg_city_node_elevations_model.sql
+++ b/platform/dbt/macros/elevation/generate_stg_city_node_elevations_model.sql
@@ -7,24 +7,25 @@
     ST_EndPoint. OSM geometries are SRID 4326; the raster is NAD83 / 4269
     (NAVD88 meters), so points are transformed to 4269 before sampling.
 
-    elevation_m is left NULL where the point falls outside raster coverage or
-    on a nodata pixel (e.g. open water). The cost model treats NULL as flat; the
-    geom column is kept so NULL nodes can be inspected on a map.
+    Tile resolution goes through stg_<city>_elevation_tiles (precomputed,
+    GiST-indexed hulls) via a lateral limit-1 probe, so each node resolves to
+    exactly one tile before any sampling and ST_Value is evaluated once per
+    node. The matching raster is then fetched by tile_id (uses the source's
+    current-rows btree) and the pixel read with bilinear resampling.
 
-    Source: stg_<city>_bike_segments, source('threedep', '<city>_3dep_elevation')
+    elevation_m is left NULL where the point falls outside raster coverage or
+    on a nodata pixel (e.g. open water): a node with no intersecting hull gets
+    a NULL tile_id, the raster join finds nothing, and ST_Value returns NULL.
+    The cost model treats NULL as flat; geom is kept so NULL nodes can be
+    inspected on a map.
+
+    Source: stg_<city>_bike_segments, stg_<city>_elevation_tiles,
+            source('threedep', '<city>_3dep_elevation')
     Grain: one row per node_id.
 #}
 {% macro generate_stg_city_node_elevations_model(city) %}
 
-with tile_hulls as materialized (
-    -- Compute each current tile's footprint ONCE (60 rows, 60 detoasts total).
-    -- Without `materialized` the planner inlines this and recomputes the hull
-    -- per point, which is the brute-force detoast that made this slow.
-    select tile_id, ST_ConvexHull(rast) as hull
-    from {{ source('threedep', city ~ '_3dep_elevation') }}
-    where valid_to is null
-),
-node_points as (
+with node_points as (
     select start_node_id as node_id, ST_StartPoint(geom) as geom
     from {{ ref('stg_' ~ city ~ '_bike_segments') }}
     union all
@@ -32,6 +33,8 @@ node_points as (
     from {{ ref('stg_' ~ city ~ '_bike_segments') }}
 ),
 distinct_nodes as (
+    -- One point per node. Adjacent segments share the exact OSM vertex, so a
+    -- node_id always resolves to a single geometry.
     select distinct on (node_id) node_id, geom
     from node_points
     order by node_id
@@ -41,15 +44,25 @@ points_4269 as (
     from distinct_nodes
 ),
 node_tiles as (
-    -- Resolve each node to its tile against the cheap precomputed hulls.
-    select p.node_id, p.geom, p.geom_4269, h.tile_id
+    -- Resolve each node to exactly one tile via an indexed hull probe.
+    -- The && uses the GiST index on stg_<city>_elevation_tiles.hull; the
+    -- distance order + limit 1 picks a single tile and kills the boundary
+    -- fan-out that would otherwise multiply ST_Value calls. Nodes outside
+    -- all hulls get a NULL tile_id (left join lateral preserves the row).
+    select p.node_id, p.geom, p.geom_4269, t.tile_id
     from points_4269 p
-    left join tile_hulls h
-        on ST_Intersects(h.hull, p.geom_4269)
+    left join lateral (
+        select th.tile_id
+        from {{ ref('stg_' ~ city ~ '_elevation_tiles') }} th
+        where th.hull && p.geom_4269
+        order by th.hull <-> p.geom_4269
+        limit 1
+    ) t on true
 ),
 sampled as (
-    -- Now fetch the one matching raster by tile_id (uses the existing
-    -- ix_<city>_3dep_elevation_current btree) and read the pixel.
+    -- Fetch the one matching raster by tile_id and read the pixel. Band 1
+    -- (single-band DEM); the band arg is required to reach the ST_Value
+    -- overload that accepts resample.
     select
         nt.node_id,
         nt.geom,
@@ -59,9 +72,10 @@ sampled as (
         on r.valid_to is null
        and r.tile_id = nt.tile_id
 )
-select distinct on (node_id)
-    node_id, geom, elevation_m
+select
+    node_id,
+    geom,
+    elevation_m
 from sampled
-order by node_id, (elevation_m is null)
 
 {% endmacro %}

--- a/platform/dbt/macros/elevation/generate_stg_city_node_elevations_model.sql
+++ b/platform/dbt/macros/elevation/generate_stg_city_node_elevations_model.sql
@@ -1,0 +1,67 @@
+{#
+    One row per routing-graph node with its bare-earth elevation, sampled from
+    the region's USGS 3DEP DEM (raw_data.<city>_3dep_elevation).
+
+    Node geometry comes from the segment endpoints: segment geom is ordered
+    start -> end, so the start node is ST_StartPoint and the end node is
+    ST_EndPoint. OSM geometries are SRID 4326; the raster is NAD83 / 4269
+    (NAVD88 meters), so points are transformed to 4269 before sampling.
+
+    elevation_m is left NULL where the point falls outside raster coverage or
+    on a nodata pixel (e.g. open water). The cost model treats NULL as flat; the
+    geom column is kept so NULL nodes can be inspected on a map.
+
+    Source: stg_<city>_bike_segments, source('threedep', '<city>_3dep_elevation')
+    Grain: one row per node_id.
+#}
+{% macro generate_stg_city_node_elevations_model(city) %}
+
+with tile_hulls as materialized (
+    -- Compute each current tile's footprint ONCE (60 rows, 60 detoasts total).
+    -- Without `materialized` the planner inlines this and recomputes the hull
+    -- per point, which is the brute-force detoast that made this slow.
+    select tile_id, ST_ConvexHull(rast) as hull
+    from {{ source('threedep', city ~ '_3dep_elevation') }}
+    where valid_to is null
+),
+node_points as (
+    select start_node_id as node_id, ST_StartPoint(geom) as geom
+    from {{ ref('stg_' ~ city ~ '_bike_segments') }}
+    union all
+    select end_node_id as node_id, ST_EndPoint(geom) as geom
+    from {{ ref('stg_' ~ city ~ '_bike_segments') }}
+),
+distinct_nodes as (
+    select distinct on (node_id) node_id, geom
+    from node_points
+    order by node_id
+),
+points_4269 as (
+    select node_id, geom, ST_Transform(geom, 4269) as geom_4269
+    from distinct_nodes
+),
+node_tiles as (
+    -- Resolve each node to its tile against the cheap precomputed hulls.
+    select p.node_id, p.geom, p.geom_4269, h.tile_id
+    from points_4269 p
+    left join tile_hulls h
+        on ST_Intersects(h.hull, p.geom_4269)
+),
+sampled as (
+    -- Now fetch the one matching raster by tile_id (uses the existing
+    -- ix_<city>_3dep_elevation_current btree) and read the pixel.
+    select
+        nt.node_id,
+        nt.geom,
+        ST_Value(r.rast, 1, nt.geom_4269, resample => 'bilinear') as elevation_m
+    from node_tiles nt
+    left join {{ source('threedep', city ~ '_3dep_elevation') }} r
+        on r.valid_to is null
+       and r.tile_id = nt.tile_id
+)
+select distinct on (node_id)
+    node_id, geom, elevation_m
+from sampled
+order by node_id, (elevation_m is null)
+
+{% endmacro %}

--- a/platform/dbt/macros/osm/generate_city_bike_stress_weighted_segments_model.sql
+++ b/platform/dbt/macros/osm/generate_city_bike_stress_weighted_segments_model.sql
@@ -25,7 +25,7 @@
       include_crashes: when true, joins crash costs. Set to false for
         cities without a bike-crash data source.
 #}
-{% macro generate_city_bike_stress_weighted_segments_model(city, include_crashes=true) %}
+{% macro generate_city_bike_stress_weighted_segments_model(city, include_crashes=true, include_elevation=false) %}
 
 with segment_costs as (
     select * from {{ ref(city ~ '_segment_costs') }}
@@ -33,6 +33,11 @@ with segment_costs as (
 {% if include_crashes %}
 crash_costs as (
     select * from {{ ref(city ~ '_segment_crash_costs') }}
+),
+{% endif %}
+{% if include_elevation %}
+elevation_costs as (
+    select * from {{ ref(city ~ '_segment_elevation_costs') }}
 ),
 {% endif %}
 intersection_costs as (
@@ -98,6 +103,22 @@ select
     0 as crash_cost,
     {% endif %}
 
+    -- Elevation: directional costs selected by the exporter per direction.
+    -- start/end elevation and grade carried for tuning visibility.
+    {% if include_elevation %}
+    ec.start_elevation_m,
+    ec.end_elevation_m,
+    ec.grade_forward,
+    coalesce(ec.elevation_cost_forward, 0)  as elevation_cost_forward,
+    coalesce(ec.elevation_cost_backward, 0) as elevation_cost_backward,
+    {% else %}
+    null::double precision as start_elevation_m,
+    null::double precision as end_elevation_m,
+    null::double precision as grade_forward,
+    0 as elevation_cost_forward,
+    0 as elevation_cost_backward,
+    {% endif %}
+
     -- Intersection costs at both endpoints. The exporter selects the
     -- right one per direction. NULL endpoints (nodes that aren't
     -- logical intersections) default to 0.
@@ -114,6 +135,9 @@ select
 from segment_costs sc
 {% if include_crashes %}
 left join crash_costs cc on cc.segment_id = sc.segment_id
+{% endif %}
+{% if include_elevation %}
+left join elevation_costs ec on ec.segment_id = sc.segment_id
 {% endif %}
 left join intersection_costs ic_start on ic_start.osmid = sc.start_node_id
 left join intersection_costs ic_end   on ic_end.osmid   = sc.end_node_id

--- a/platform/dbt/models/_threedep_sources.yml
+++ b/platform/dbt/models/_threedep_sources.yml
@@ -1,0 +1,16 @@
+sources:
+  - name: threedep
+    database: loci
+    schema: raw_data
+    tags:
+      - raw
+    tables:
+      - name: boston_3dep_elevation
+      - name: chicago_3dep_elevation
+      - name: dc_3dep_elevation
+      - name: denver_3dep_elevation
+      - name: detroit_3dep_elevation
+      - name: madison_3dep_elevation
+      - name: nola_3dep_elevation
+      - name: portland_3dep_elevation
+      - name: sf_3dep_elevation

--- a/platform/dbt/models/_threedep_sources.yml
+++ b/platform/dbt/models/_threedep_sources.yml
@@ -5,6 +5,7 @@ sources:
     tags:
       - raw
     tables:
+      - name: Chicago_3dep_elevation
       - name: boston_3dep_elevation
       - name: chicago_3dep_elevation
       - name: dc_3dep_elevation

--- a/platform/dbt/models/marts/cycling/boston/_marts_boston_cycling.yml
+++ b/platform/dbt/models/marts/cycling/boston/_marts_boston_cycling.yml
@@ -226,6 +226,16 @@ models:
             name: boston_crash_cost_non_negative
       - dbt_utils.expression_is_true:
           arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: boston_stress_weighted_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: boston_stress_weighted_elevation_cost_backward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
             expression: intersection_cost_at_start >= 0
           config:
             name: boston_intersection_cost_at_start_non_negative
@@ -267,6 +277,12 @@ models:
       - name: crash_cost
         data_tests:
           - not_null
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null
       - name: intersection_cost_at_start
         description: Intersection cost at the start of the segment. Paid by backward-direction
           edges (which approach the start).
@@ -296,5 +312,49 @@ models:
         data_tests:
           - not_null
       - name: lighting_penalty
+        data_tests:
+          - not_null
+  - name: boston_segment_elevation_costs
+    description: Directional elevation cost per segment from the endpoint elevation
+      delta, quadratic in grade with separate up/down coefficients. One row per segment_id.
+      Costs coalesce to 0 on a coverage gap (treated as flat).
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_boston_bike_segments')
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: boston_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: boston_elevation_cost_backward_non_negative
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        description: "Completeness check \u2014 every endpoint must resolve in node_elevations."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_boston_node_elevations')
+                field: node_id
+      - name: end_node_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_boston_node_elevations')
+                field: node_id
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
         data_tests:
           - not_null

--- a/platform/dbt/models/marts/cycling/boston/boston_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/boston/boston_bike_stress_weighted_segments.sql
@@ -10,4 +10,4 @@
     ]
 ) }}
 
-{{ generate_city_bike_stress_weighted_segments_model('boston', include_crashes=false) }}
+{{ generate_city_bike_stress_weighted_segments_model('boston', include_crashes=false, include_elevation=true) }}

--- a/platform/dbt/models/marts/cycling/boston/boston_segment_elevation_costs.sql
+++ b/platform/dbt/models/marts/cycling/boston/boston_segment_elevation_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_elevation_costs_model('boston') }}

--- a/platform/dbt/models/marts/cycling/chicago/_marts_chicago_cycling.yml
+++ b/platform/dbt/models/marts/cycling/chicago/_marts_chicago_cycling.yml
@@ -30,6 +30,16 @@ models:
             name: chicago_intersection_cost_at_start_non_negative
       - dbt_utils.expression_is_true:
           arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: chicago_stress_weighted_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: chicago_stress_weighted_elevation_cost_backward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
             expression: intersection_cost_at_end >= 0
           config:
             name: chicago_intersection_cost_at_end_non_negative
@@ -97,6 +107,13 @@ models:
       - name: lighting_penalty
         data_tests:
           - not_null
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null
+
   - name: chicago_bike_crash_hotspots
     description: 'Bike crash data with severity scores, deduplicated to one row per
       crash.
@@ -321,3 +338,47 @@ models:
                   - path
               config:
                 where: infra_category is not null
+  - name: chicago_segment_elevation_costs
+    description: Directional elevation cost per segment from the endpoint elevation
+      delta, quadratic in grade with separate up/down coefficients. One row per segment_id.
+      Costs coalesce to 0 on a coverage gap (treated as flat).
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_chicago_bike_segments')
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: chicago_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: chicago_elevation_cost_backward_non_negative
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        description: "Completeness check \u2014 every endpoint must resolve in node_elevations."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_chicago_node_elevations')
+                field: node_id
+      - name: end_node_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_chicago_node_elevations')
+                field: node_id
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null

--- a/platform/dbt/models/marts/cycling/chicago/chicago_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/chicago/chicago_bike_stress_weighted_segments.sql
@@ -10,4 +10,4 @@
     ]
 ) }}
 
-{{ generate_city_bike_stress_weighted_segments_model('chicago', include_crashes=true) }}
+{{ generate_city_bike_stress_weighted_segments_model('chicago', include_crashes=true, include_elevation=true) }}

--- a/platform/dbt/models/marts/cycling/chicago/chicago_segment_elevation_costs.sql
+++ b/platform/dbt/models/marts/cycling/chicago/chicago_segment_elevation_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_elevation_costs_model('chicago') }}

--- a/platform/dbt/models/marts/cycling/dc/_marts_dc_cycling.yml
+++ b/platform/dbt/models/marts/cycling/dc/_marts_dc_cycling.yml
@@ -226,6 +226,16 @@ models:
             name: dc_crash_cost_non_negative
       - dbt_utils.expression_is_true:
           arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: dc_stress_weighted_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: dc_stress_weighted_elevation_cost_backward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
             expression: intersection_cost_at_start >= 0
           config:
             name: dc_intersection_cost_at_start_non_negative
@@ -267,6 +277,12 @@ models:
       - name: crash_cost
         data_tests:
           - not_null
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null
       - name: intersection_cost_at_start
         description: Intersection cost at the start of the segment. Paid by backward-direction
           edges (which approach the start).
@@ -296,5 +312,49 @@ models:
         data_tests:
           - not_null
       - name: lighting_penalty
+        data_tests:
+          - not_null
+  - name: dc_segment_elevation_costs
+    description: Directional elevation cost per segment from the endpoint elevation
+      delta, quadratic in grade with separate up/down coefficients. One row per segment_id.
+      Costs coalesce to 0 on a coverage gap (treated as flat).
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_dc_bike_segments')
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: dc_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: dc_elevation_cost_backward_non_negative
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        description: "Completeness check \u2014 every endpoint must resolve in node_elevations."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_dc_node_elevations')
+                field: node_id
+      - name: end_node_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_dc_node_elevations')
+                field: node_id
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
         data_tests:
           - not_null

--- a/platform/dbt/models/marts/cycling/dc/dc_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/dc/dc_bike_stress_weighted_segments.sql
@@ -10,4 +10,4 @@
     ]
 ) }}
 
-{{ generate_city_bike_stress_weighted_segments_model('dc', include_crashes=false) }}
+{{ generate_city_bike_stress_weighted_segments_model('dc', include_crashes=false, include_elevation=true) }}

--- a/platform/dbt/models/marts/cycling/dc/dc_segment_elevation_costs.sql
+++ b/platform/dbt/models/marts/cycling/dc/dc_segment_elevation_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_elevation_costs_model('dc') }}

--- a/platform/dbt/models/marts/cycling/denver/_marts_denver_cycling.yml
+++ b/platform/dbt/models/marts/cycling/denver/_marts_denver_cycling.yml
@@ -226,6 +226,16 @@ models:
             name: denver_crash_cost_non_negative
       - dbt_utils.expression_is_true:
           arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: denver_stress_weighted_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: denver_stress_weighted_elevation_cost_backward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
             expression: intersection_cost_at_start >= 0
           config:
             name: denver_intersection_cost_at_start_non_negative
@@ -267,6 +277,12 @@ models:
       - name: crash_cost
         data_tests:
           - not_null
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null
       - name: intersection_cost_at_start
         description: Intersection cost at the start of the segment. Paid by backward-direction
           edges (which approach the start).
@@ -296,5 +312,49 @@ models:
         data_tests:
           - not_null
       - name: lighting_penalty
+        data_tests:
+          - not_null
+  - name: denver_segment_elevation_costs
+    description: Directional elevation cost per segment from the endpoint elevation
+      delta, quadratic in grade with separate up/down coefficients. One row per segment_id.
+      Costs coalesce to 0 on a coverage gap (treated as flat).
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_denver_bike_segments')
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: denver_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: denver_elevation_cost_backward_non_negative
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        description: "Completeness check \u2014 every endpoint must resolve in node_elevations."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_denver_node_elevations')
+                field: node_id
+      - name: end_node_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_denver_node_elevations')
+                field: node_id
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
         data_tests:
           - not_null

--- a/platform/dbt/models/marts/cycling/denver/denver_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/denver/denver_bike_stress_weighted_segments.sql
@@ -10,4 +10,4 @@
     ]
 ) }}
 
-{{ generate_city_bike_stress_weighted_segments_model('denver', include_crashes=false) }}
+{{ generate_city_bike_stress_weighted_segments_model('denver', include_crashes=false, include_elevation=true) }}

--- a/platform/dbt/models/marts/cycling/denver/denver_segment_elevation_costs.sql
+++ b/platform/dbt/models/marts/cycling/denver/denver_segment_elevation_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_elevation_costs_model('denver') }}

--- a/platform/dbt/models/marts/cycling/detroit/_marts_detroit_cycling.yml
+++ b/platform/dbt/models/marts/cycling/detroit/_marts_detroit_cycling.yml
@@ -226,6 +226,16 @@ models:
             name: detroit_crash_cost_non_negative
       - dbt_utils.expression_is_true:
           arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: detroit_stress_weighted_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: detroit_stress_weighted_elevation_cost_backward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
             expression: intersection_cost_at_start >= 0
           config:
             name: detroit_intersection_cost_at_start_non_negative
@@ -267,6 +277,12 @@ models:
       - name: crash_cost
         data_tests:
           - not_null
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null
       - name: intersection_cost_at_start
         description: Intersection cost at the start of the segment. Paid by backward-direction
           edges (which approach the start).
@@ -296,5 +312,49 @@ models:
         data_tests:
           - not_null
       - name: lighting_penalty
+        data_tests:
+          - not_null
+  - name: detroit_segment_elevation_costs
+    description: Directional elevation cost per segment from the endpoint elevation
+      delta, quadratic in grade with separate up/down coefficients. One row per segment_id.
+      Costs coalesce to 0 on a coverage gap (treated as flat).
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_detroit_bike_segments')
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: detroit_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: detroit_elevation_cost_backward_non_negative
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        description: "Completeness check \u2014 every endpoint must resolve in node_elevations."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_detroit_node_elevations')
+                field: node_id
+      - name: end_node_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_detroit_node_elevations')
+                field: node_id
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
         data_tests:
           - not_null

--- a/platform/dbt/models/marts/cycling/detroit/_marts_detroit_cycling.yml
+++ b/platform/dbt/models/marts/cycling/detroit/_marts_detroit_cycling.yml
@@ -38,7 +38,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_between:
               arguments:
                 min_value: 0
-                strictly: true
+                strictly: false
       - name: geom
         data_tests:
           - not_null
@@ -267,7 +267,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_between:
               arguments:
                 min_value: 0
-                strictly: true
+                strictly: false
       - name: geom
         data_tests:
           - not_null

--- a/platform/dbt/models/marts/cycling/detroit/detroit_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/detroit/detroit_bike_stress_weighted_segments.sql
@@ -10,4 +10,4 @@
     ]
 ) }}
 
-{{ generate_city_bike_stress_weighted_segments_model('detroit', include_crashes=false) }}
+{{ generate_city_bike_stress_weighted_segments_model('detroit', include_crashes=false, include_elevation=true) }}

--- a/platform/dbt/models/marts/cycling/detroit/detroit_segment_elevation_costs.sql
+++ b/platform/dbt/models/marts/cycling/detroit/detroit_segment_elevation_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_elevation_costs_model('detroit') }}

--- a/platform/dbt/models/marts/cycling/madison/_marts_madison_cycling.yml
+++ b/platform/dbt/models/marts/cycling/madison/_marts_madison_cycling.yml
@@ -226,6 +226,16 @@ models:
             name: madison_crash_cost_non_negative
       - dbt_utils.expression_is_true:
           arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: madison_stress_weighted_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: madison_stress_weighted_elevation_cost_backward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
             expression: intersection_cost_at_start >= 0
           config:
             name: madison_intersection_cost_at_start_non_negative
@@ -267,6 +277,12 @@ models:
       - name: crash_cost
         data_tests:
           - not_null
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null
       - name: intersection_cost_at_start
         description: Intersection cost at the start of the segment. Paid by backward-direction
           edges (which approach the start).
@@ -296,5 +312,49 @@ models:
         data_tests:
           - not_null
       - name: lighting_penalty
+        data_tests:
+          - not_null
+  - name: madison_segment_elevation_costs
+    description: Directional elevation cost per segment from the endpoint elevation
+      delta, quadratic in grade with separate up/down coefficients. One row per segment_id.
+      Costs coalesce to 0 on a coverage gap (treated as flat).
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_madison_bike_segments')
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: madison_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: madison_elevation_cost_backward_non_negative
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        description: "Completeness check \u2014 every endpoint must resolve in node_elevations."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_madison_node_elevations')
+                field: node_id
+      - name: end_node_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_madison_node_elevations')
+                field: node_id
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
         data_tests:
           - not_null

--- a/platform/dbt/models/marts/cycling/madison/madison_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/madison/madison_bike_stress_weighted_segments.sql
@@ -10,4 +10,4 @@
     ]
 ) }}
 
-{{ generate_city_bike_stress_weighted_segments_model('madison', include_crashes=false) }}
+{{ generate_city_bike_stress_weighted_segments_model('madison', include_crashes=false, include_elevation=true) }}

--- a/platform/dbt/models/marts/cycling/madison/madison_segment_elevation_costs.sql
+++ b/platform/dbt/models/marts/cycling/madison/madison_segment_elevation_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_elevation_costs_model('madison') }}

--- a/platform/dbt/models/marts/cycling/nola/_marts_nola_cycling.yml
+++ b/platform/dbt/models/marts/cycling/nola/_marts_nola_cycling.yml
@@ -226,6 +226,16 @@ models:
             name: nola_crash_cost_non_negative
       - dbt_utils.expression_is_true:
           arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: nola_stress_weighted_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: nola_stress_weighted_elevation_cost_backward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
             expression: intersection_cost_at_start >= 0
           config:
             name: nola_intersection_cost_at_start_non_negative
@@ -267,6 +277,12 @@ models:
       - name: crash_cost
         data_tests:
           - not_null
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null
       - name: intersection_cost_at_start
         description: Intersection cost at the start of the segment. Paid by backward-direction
           edges (which approach the start).
@@ -296,5 +312,49 @@ models:
         data_tests:
           - not_null
       - name: lighting_penalty
+        data_tests:
+          - not_null
+  - name: nola_segment_elevation_costs
+    description: Directional elevation cost per segment from the endpoint elevation
+      delta, quadratic in grade with separate up/down coefficients. One row per segment_id.
+      Costs coalesce to 0 on a coverage gap (treated as flat).
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_nola_bike_segments')
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: nola_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: nola_elevation_cost_backward_non_negative
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        description: "Completeness check \u2014 every endpoint must resolve in node_elevations."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_nola_node_elevations')
+                field: node_id
+      - name: end_node_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_nola_node_elevations')
+                field: node_id
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
         data_tests:
           - not_null

--- a/platform/dbt/models/marts/cycling/nola/nola_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/nola/nola_bike_stress_weighted_segments.sql
@@ -10,4 +10,4 @@
     ]
 ) }}
 
-{{ generate_city_bike_stress_weighted_segments_model('nola', include_crashes=false) }}
+{{ generate_city_bike_stress_weighted_segments_model('nola', include_crashes=false, include_elevation=true) }}

--- a/platform/dbt/models/marts/cycling/nola/nola_segment_elevation_costs.sql
+++ b/platform/dbt/models/marts/cycling/nola/nola_segment_elevation_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_elevation_costs_model('nola') }}

--- a/platform/dbt/models/marts/cycling/portland/_marts_portland_cycling.yml
+++ b/platform/dbt/models/marts/cycling/portland/_marts_portland_cycling.yml
@@ -226,6 +226,16 @@ models:
             name: portland_crash_cost_non_negative
       - dbt_utils.expression_is_true:
           arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: portland_stress_weighted_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: portland_stress_weighted_elevation_cost_backward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
             expression: intersection_cost_at_start >= 0
           config:
             name: portland_intersection_cost_at_start_non_negative
@@ -267,6 +277,12 @@ models:
       - name: crash_cost
         data_tests:
           - not_null
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null
       - name: intersection_cost_at_start
         description: Intersection cost at the start of the segment. Paid by backward-direction
           edges (which approach the start).
@@ -296,5 +312,49 @@ models:
         data_tests:
           - not_null
       - name: lighting_penalty
+        data_tests:
+          - not_null
+  - name: portland_segment_elevation_costs
+    description: Directional elevation cost per segment from the endpoint elevation
+      delta, quadratic in grade with separate up/down coefficients. One row per segment_id.
+      Costs coalesce to 0 on a coverage gap (treated as flat).
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_portland_bike_segments')
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: portland_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: portland_elevation_cost_backward_non_negative
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        description: "Completeness check \u2014 every endpoint must resolve in node_elevations."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_portland_node_elevations')
+                field: node_id
+      - name: end_node_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_portland_node_elevations')
+                field: node_id
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
         data_tests:
           - not_null

--- a/platform/dbt/models/marts/cycling/portland/portland_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/portland/portland_bike_stress_weighted_segments.sql
@@ -10,4 +10,4 @@
     ]
 ) }}
 
-{{ generate_city_bike_stress_weighted_segments_model('portland', include_crashes=false) }}
+{{ generate_city_bike_stress_weighted_segments_model('portland', include_crashes=false, include_elevation=true) }}

--- a/platform/dbt/models/marts/cycling/portland/portland_segment_elevation_costs.sql
+++ b/platform/dbt/models/marts/cycling/portland/portland_segment_elevation_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_elevation_costs_model('portland') }}

--- a/platform/dbt/models/marts/cycling/sf/_marts_sf_cycling.yml
+++ b/platform/dbt/models/marts/cycling/sf/_marts_sf_cycling.yml
@@ -226,6 +226,16 @@ models:
             name: sf_crash_cost_non_negative
       - dbt_utils.expression_is_true:
           arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: sf_stress_weighted_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: sf_stress_weighted_elevation_cost_backward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
             expression: intersection_cost_at_start >= 0
           config:
             name: sf_intersection_cost_at_start_non_negative
@@ -267,6 +277,12 @@ models:
       - name: crash_cost
         data_tests:
           - not_null
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null
       - name: intersection_cost_at_start
         description: Intersection cost at the start of the segment. Paid by backward-direction
           edges (which approach the start).
@@ -296,5 +312,49 @@ models:
         data_tests:
           - not_null
       - name: lighting_penalty
+        data_tests:
+          - not_null
+  - name: sf_segment_elevation_costs
+    description: Directional elevation cost per segment from the endpoint elevation
+      delta, quadratic in grade with separate up/down coefficients. One row per segment_id.
+      Costs coalesce to 0 on a coverage gap (treated as flat).
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_sf_bike_segments')
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: sf_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: sf_elevation_cost_backward_non_negative
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        description: "Completeness check \u2014 every endpoint must resolve in node_elevations."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_sf_node_elevations')
+                field: node_id
+      - name: end_node_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_sf_node_elevations')
+                field: node_id
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
         data_tests:
           - not_null

--- a/platform/dbt/models/marts/cycling/sf/sf_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/sf/sf_bike_stress_weighted_segments.sql
@@ -10,4 +10,4 @@
     ]
 ) }}
 
-{{ generate_city_bike_stress_weighted_segments_model('sf', include_crashes=false) }}
+{{ generate_city_bike_stress_weighted_segments_model('sf', include_crashes=false, include_elevation=true) }}

--- a/platform/dbt/models/marts/cycling/sf/sf_segment_elevation_costs.sql
+++ b/platform/dbt/models/marts/cycling/sf/sf_segment_elevation_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_elevation_costs_model('sf') }}

--- a/platform/dbt/models/staging/cycling/boston/_stg_boston_cycling.yml
+++ b/platform/dbt/models/staging/cycling/boston/_stg_boston_cycling.yml
@@ -66,3 +66,51 @@ models:
       - segment_geom_endpoints_match_node_positions:
           arguments:
             ways_model: ref('stg_boston_bike_ways')
+  - name: stg_boston_elevation_tiles
+    description: Precomputed convex-hull footprints for the current 3DEP sub-tiles,
+      used for indexed node-to-tile resolution during elevation sampling. One row
+      per current tile_id.
+    columns:
+      - name: tile_id
+        description: Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>).
+        data_tests:
+          - not_null
+          - unique
+      - name: hull
+        description: Tile convex hull (geometry, 4269). NULL would silently drop the
+          tile's coverage.
+        data_tests:
+          - not_null
+  - name: stg_boston_node_elevations
+    description: 'One row per routing-graph node with its bare-earth elevation sampled
+      from the city''s 3DEP DEM. elevation_m is intentionally nullable: a node outside
+      coverage or on a nodata pixel (e.g. open water) is NULL and treated as flat
+      downstream.'
+    columns:
+      - name: node_id
+        description: OSM node id. unique is the regression guard for the one-row-per-node
+          grain the lateral limit-1 resolution guarantees.
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: elevation_m
+        description: 'NAVD88 meters, or NULL on a coverage gap. The range bound catches
+          nodata sentinels (-9999, +/-3.4e38) leaking through as numbers and gross
+          unit errors; checked only on non-null rows. Bounds are loose on purpose:
+          they span every target metro (Denver sits near 1600 m), so they flag sentinels,
+          not tight validation.'
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -100
+                max_value: 4500
+              config:
+                where: elevation_m is not null
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.98
+              config:
+                severity: warn

--- a/platform/dbt/models/staging/cycling/boston/stg_boston_elevation_tiles.sql
+++ b/platform/dbt/models/staging/cycling/boston/stg_boston_elevation_tiles.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} USING GIST (hull)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_elevation_tiles_model('boston') }}

--- a/platform/dbt/models/staging/cycling/boston/stg_boston_node_elevations.sql
+++ b/platform/dbt/models/staging/cycling/boston/stg_boston_node_elevations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_node_elevations_model('boston') }}

--- a/platform/dbt/models/staging/cycling/chicago/_stg_chicago_cycling.yml
+++ b/platform/dbt/models/staging/cycling/chicago/_stg_chicago_cycling.yml
@@ -66,3 +66,51 @@ models:
       - segment_geom_endpoints_match_node_positions:
           arguments:
             ways_model: ref('stg_chicago_bike_ways')
+  - name: stg_chicago_elevation_tiles
+    description: Precomputed convex-hull footprints for the current 3DEP sub-tiles,
+      used for indexed node-to-tile resolution during elevation sampling. One row
+      per current tile_id.
+    columns:
+      - name: tile_id
+        description: Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>).
+        data_tests:
+          - not_null
+          - unique
+      - name: hull
+        description: Tile convex hull (geometry, 4269). NULL would silently drop the
+          tile's coverage.
+        data_tests:
+          - not_null
+  - name: stg_chicago_node_elevations
+    description: 'One row per routing-graph node with its bare-earth elevation sampled
+      from the city''s 3DEP DEM. elevation_m is intentionally nullable: a node outside
+      coverage or on a nodata pixel (e.g. open water) is NULL and treated as flat
+      downstream.'
+    columns:
+      - name: node_id
+        description: OSM node id. unique is the regression guard for the one-row-per-node
+          grain the lateral limit-1 resolution guarantees.
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: elevation_m
+        description: 'NAVD88 meters, or NULL on a coverage gap. The range bound catches
+          nodata sentinels (-9999, +/-3.4e38) leaking through as numbers and gross
+          unit errors; checked only on non-null rows. Bounds are loose on purpose:
+          they span every target metro (Denver sits near 1600 m), so they flag sentinels,
+          not tight validation.'
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -100
+                max_value: 4500
+              config:
+                where: elevation_m is not null
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.98
+              config:
+                severity: warn

--- a/platform/dbt/models/staging/cycling/chicago/stg_chicago_elevation_tiles.sql
+++ b/platform/dbt/models/staging/cycling/chicago/stg_chicago_elevation_tiles.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} USING GIST (hull)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_elevation_tiles_model('chicago') }}

--- a/platform/dbt/models/staging/cycling/chicago/stg_chicago_node_elevations.sql
+++ b/platform/dbt/models/staging/cycling/chicago/stg_chicago_node_elevations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_node_elevations_model('chicago') }}

--- a/platform/dbt/models/staging/cycling/dc/_stg_dc_cycling.yml
+++ b/platform/dbt/models/staging/cycling/dc/_stg_dc_cycling.yml
@@ -66,3 +66,51 @@ models:
       - segment_geom_endpoints_match_node_positions:
           arguments:
             ways_model: ref('stg_dc_bike_ways')
+  - name: stg_dc_elevation_tiles
+    description: Precomputed convex-hull footprints for the current 3DEP sub-tiles,
+      used for indexed node-to-tile resolution during elevation sampling. One row
+      per current tile_id.
+    columns:
+      - name: tile_id
+        description: Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>).
+        data_tests:
+          - not_null
+          - unique
+      - name: hull
+        description: Tile convex hull (geometry, 4269). NULL would silently drop the
+          tile's coverage.
+        data_tests:
+          - not_null
+  - name: stg_dc_node_elevations
+    description: 'One row per routing-graph node with its bare-earth elevation sampled
+      from the city''s 3DEP DEM. elevation_m is intentionally nullable: a node outside
+      coverage or on a nodata pixel (e.g. open water) is NULL and treated as flat
+      downstream.'
+    columns:
+      - name: node_id
+        description: OSM node id. unique is the regression guard for the one-row-per-node
+          grain the lateral limit-1 resolution guarantees.
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: elevation_m
+        description: 'NAVD88 meters, or NULL on a coverage gap. The range bound catches
+          nodata sentinels (-9999, +/-3.4e38) leaking through as numbers and gross
+          unit errors; checked only on non-null rows. Bounds are loose on purpose:
+          they span every target metro (Denver sits near 1600 m), so they flag sentinels,
+          not tight validation.'
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -100
+                max_value: 4500
+              config:
+                where: elevation_m is not null
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.98
+              config:
+                severity: warn

--- a/platform/dbt/models/staging/cycling/dc/stg_dc_elevation_tiles.sql
+++ b/platform/dbt/models/staging/cycling/dc/stg_dc_elevation_tiles.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} USING GIST (hull)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_elevation_tiles_model('dc') }}

--- a/platform/dbt/models/staging/cycling/dc/stg_dc_node_elevations.sql
+++ b/platform/dbt/models/staging/cycling/dc/stg_dc_node_elevations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_node_elevations_model('dc') }}

--- a/platform/dbt/models/staging/cycling/denver/_stg_denver_cycling.yml
+++ b/platform/dbt/models/staging/cycling/denver/_stg_denver_cycling.yml
@@ -66,3 +66,51 @@ models:
       - segment_geom_endpoints_match_node_positions:
           arguments:
             ways_model: ref('stg_denver_bike_ways')
+  - name: stg_denver_elevation_tiles
+    description: Precomputed convex-hull footprints for the current 3DEP sub-tiles,
+      used for indexed node-to-tile resolution during elevation sampling. One row
+      per current tile_id.
+    columns:
+      - name: tile_id
+        description: Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>).
+        data_tests:
+          - not_null
+          - unique
+      - name: hull
+        description: Tile convex hull (geometry, 4269). NULL would silently drop the
+          tile's coverage.
+        data_tests:
+          - not_null
+  - name: stg_denver_node_elevations
+    description: 'One row per routing-graph node with its bare-earth elevation sampled
+      from the city''s 3DEP DEM. elevation_m is intentionally nullable: a node outside
+      coverage or on a nodata pixel (e.g. open water) is NULL and treated as flat
+      downstream.'
+    columns:
+      - name: node_id
+        description: OSM node id. unique is the regression guard for the one-row-per-node
+          grain the lateral limit-1 resolution guarantees.
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: elevation_m
+        description: 'NAVD88 meters, or NULL on a coverage gap. The range bound catches
+          nodata sentinels (-9999, +/-3.4e38) leaking through as numbers and gross
+          unit errors; checked only on non-null rows. Bounds are loose on purpose:
+          they span every target metro (Denver sits near 1600 m), so they flag sentinels,
+          not tight validation.'
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -100
+                max_value: 4500
+              config:
+                where: elevation_m is not null
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.98
+              config:
+                severity: warn

--- a/platform/dbt/models/staging/cycling/denver/stg_denver_elevation_tiles.sql
+++ b/platform/dbt/models/staging/cycling/denver/stg_denver_elevation_tiles.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} USING GIST (hull)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_elevation_tiles_model('denver') }}

--- a/platform/dbt/models/staging/cycling/denver/stg_denver_node_elevations.sql
+++ b/platform/dbt/models/staging/cycling/denver/stg_denver_node_elevations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_node_elevations_model('denver') }}

--- a/platform/dbt/models/staging/cycling/detroit/_stg_detroit_cycling.yml
+++ b/platform/dbt/models/staging/cycling/detroit/_stg_detroit_cycling.yml
@@ -66,3 +66,51 @@ models:
       - segment_geom_endpoints_match_node_positions:
           arguments:
             ways_model: ref('stg_detroit_bike_ways')
+  - name: stg_detroit_elevation_tiles
+    description: Precomputed convex-hull footprints for the current 3DEP sub-tiles,
+      used for indexed node-to-tile resolution during elevation sampling. One row
+      per current tile_id.
+    columns:
+      - name: tile_id
+        description: Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>).
+        data_tests:
+          - not_null
+          - unique
+      - name: hull
+        description: Tile convex hull (geometry, 4269). NULL would silently drop the
+          tile's coverage.
+        data_tests:
+          - not_null
+  - name: stg_detroit_node_elevations
+    description: 'One row per routing-graph node with its bare-earth elevation sampled
+      from the city''s 3DEP DEM. elevation_m is intentionally nullable: a node outside
+      coverage or on a nodata pixel (e.g. open water) is NULL and treated as flat
+      downstream.'
+    columns:
+      - name: node_id
+        description: OSM node id. unique is the regression guard for the one-row-per-node
+          grain the lateral limit-1 resolution guarantees.
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: elevation_m
+        description: 'NAVD88 meters, or NULL on a coverage gap. The range bound catches
+          nodata sentinels (-9999, +/-3.4e38) leaking through as numbers and gross
+          unit errors; checked only on non-null rows. Bounds are loose on purpose:
+          they span every target metro (Denver sits near 1600 m), so they flag sentinels,
+          not tight validation.'
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -100
+                max_value: 4500
+              config:
+                where: elevation_m is not null
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.98
+              config:
+                severity: warn

--- a/platform/dbt/models/staging/cycling/detroit/stg_detroit_bike_segments.sql
+++ b/platform/dbt/models/staging/cycling/detroit/stg_detroit_bike_segments.sql
@@ -9,5 +9,4 @@
     ]
 ) }}
 
-
 {{ generate_stg_city_bike_segments_model('detroit') }}

--- a/platform/dbt/models/staging/cycling/detroit/stg_detroit_elevation_tiles.sql
+++ b/platform/dbt/models/staging/cycling/detroit/stg_detroit_elevation_tiles.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} USING GIST (hull)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_elevation_tiles_model('detroit') }}

--- a/platform/dbt/models/staging/cycling/detroit/stg_detroit_node_elevations.sql
+++ b/platform/dbt/models/staging/cycling/detroit/stg_detroit_node_elevations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_node_elevations_model('detroit') }}

--- a/platform/dbt/models/staging/cycling/madison/_stg_madison_cycling.yml
+++ b/platform/dbt/models/staging/cycling/madison/_stg_madison_cycling.yml
@@ -66,3 +66,51 @@ models:
       - segment_geom_endpoints_match_node_positions:
           arguments:
             ways_model: ref('stg_madison_bike_ways')
+  - name: stg_madison_elevation_tiles
+    description: Precomputed convex-hull footprints for the current 3DEP sub-tiles,
+      used for indexed node-to-tile resolution during elevation sampling. One row
+      per current tile_id.
+    columns:
+      - name: tile_id
+        description: Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>).
+        data_tests:
+          - not_null
+          - unique
+      - name: hull
+        description: Tile convex hull (geometry, 4269). NULL would silently drop the
+          tile's coverage.
+        data_tests:
+          - not_null
+  - name: stg_madison_node_elevations
+    description: 'One row per routing-graph node with its bare-earth elevation sampled
+      from the city''s 3DEP DEM. elevation_m is intentionally nullable: a node outside
+      coverage or on a nodata pixel (e.g. open water) is NULL and treated as flat
+      downstream.'
+    columns:
+      - name: node_id
+        description: OSM node id. unique is the regression guard for the one-row-per-node
+          grain the lateral limit-1 resolution guarantees.
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: elevation_m
+        description: 'NAVD88 meters, or NULL on a coverage gap. The range bound catches
+          nodata sentinels (-9999, +/-3.4e38) leaking through as numbers and gross
+          unit errors; checked only on non-null rows. Bounds are loose on purpose:
+          they span every target metro (Denver sits near 1600 m), so they flag sentinels,
+          not tight validation.'
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -100
+                max_value: 4500
+              config:
+                where: elevation_m is not null
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.98
+              config:
+                severity: warn

--- a/platform/dbt/models/staging/cycling/madison/stg_madison_elevation_tiles.sql
+++ b/platform/dbt/models/staging/cycling/madison/stg_madison_elevation_tiles.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} USING GIST (hull)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_elevation_tiles_model('madison') }}

--- a/platform/dbt/models/staging/cycling/madison/stg_madison_node_elevations.sql
+++ b/platform/dbt/models/staging/cycling/madison/stg_madison_node_elevations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_node_elevations_model('madison') }}

--- a/platform/dbt/models/staging/cycling/nola/_stg_nola_cycling.yml
+++ b/platform/dbt/models/staging/cycling/nola/_stg_nola_cycling.yml
@@ -66,3 +66,51 @@ models:
       - segment_geom_endpoints_match_node_positions:
           arguments:
             ways_model: ref('stg_nola_bike_ways')
+  - name: stg_nola_elevation_tiles
+    description: Precomputed convex-hull footprints for the current 3DEP sub-tiles,
+      used for indexed node-to-tile resolution during elevation sampling. One row
+      per current tile_id.
+    columns:
+      - name: tile_id
+        description: Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>).
+        data_tests:
+          - not_null
+          - unique
+      - name: hull
+        description: Tile convex hull (geometry, 4269). NULL would silently drop the
+          tile's coverage.
+        data_tests:
+          - not_null
+  - name: stg_nola_node_elevations
+    description: 'One row per routing-graph node with its bare-earth elevation sampled
+      from the city''s 3DEP DEM. elevation_m is intentionally nullable: a node outside
+      coverage or on a nodata pixel (e.g. open water) is NULL and treated as flat
+      downstream.'
+    columns:
+      - name: node_id
+        description: OSM node id. unique is the regression guard for the one-row-per-node
+          grain the lateral limit-1 resolution guarantees.
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: elevation_m
+        description: 'NAVD88 meters, or NULL on a coverage gap. The range bound catches
+          nodata sentinels (-9999, +/-3.4e38) leaking through as numbers and gross
+          unit errors; checked only on non-null rows. Bounds are loose on purpose:
+          they span every target metro (Denver sits near 1600 m), so they flag sentinels,
+          not tight validation.'
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -100
+                max_value: 4500
+              config:
+                where: elevation_m is not null
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.98
+              config:
+                severity: warn

--- a/platform/dbt/models/staging/cycling/nola/stg_nola_elevation_tiles.sql
+++ b/platform/dbt/models/staging/cycling/nola/stg_nola_elevation_tiles.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} USING GIST (hull)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_elevation_tiles_model('nola') }}

--- a/platform/dbt/models/staging/cycling/nola/stg_nola_node_elevations.sql
+++ b/platform/dbt/models/staging/cycling/nola/stg_nola_node_elevations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_node_elevations_model('nola') }}

--- a/platform/dbt/models/staging/cycling/portland/_stg_portland_cycling.yml
+++ b/platform/dbt/models/staging/cycling/portland/_stg_portland_cycling.yml
@@ -66,3 +66,51 @@ models:
       - segment_geom_endpoints_match_node_positions:
           arguments:
             ways_model: ref('stg_portland_bike_ways')
+  - name: stg_portland_elevation_tiles
+    description: Precomputed convex-hull footprints for the current 3DEP sub-tiles,
+      used for indexed node-to-tile resolution during elevation sampling. One row
+      per current tile_id.
+    columns:
+      - name: tile_id
+        description: Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>).
+        data_tests:
+          - not_null
+          - unique
+      - name: hull
+        description: Tile convex hull (geometry, 4269). NULL would silently drop the
+          tile's coverage.
+        data_tests:
+          - not_null
+  - name: stg_portland_node_elevations
+    description: 'One row per routing-graph node with its bare-earth elevation sampled
+      from the city''s 3DEP DEM. elevation_m is intentionally nullable: a node outside
+      coverage or on a nodata pixel (e.g. open water) is NULL and treated as flat
+      downstream.'
+    columns:
+      - name: node_id
+        description: OSM node id. unique is the regression guard for the one-row-per-node
+          grain the lateral limit-1 resolution guarantees.
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: elevation_m
+        description: 'NAVD88 meters, or NULL on a coverage gap. The range bound catches
+          nodata sentinels (-9999, +/-3.4e38) leaking through as numbers and gross
+          unit errors; checked only on non-null rows. Bounds are loose on purpose:
+          they span every target metro (Denver sits near 1600 m), so they flag sentinels,
+          not tight validation.'
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -100
+                max_value: 4500
+              config:
+                where: elevation_m is not null
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.98
+              config:
+                severity: warn

--- a/platform/dbt/models/staging/cycling/portland/stg_portland_elevation_tiles.sql
+++ b/platform/dbt/models/staging/cycling/portland/stg_portland_elevation_tiles.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='table', post_hook=[
+    "CREATE INDEX ON {{ this }} USING GIST (hull)",
+    "ANALYZE {{ this }}"
+]) }}
+
+{{ generate_stg_city_elevation_tiles_model('portland') }}

--- a/platform/dbt/models/staging/cycling/portland/stg_portland_node_elevations.sql
+++ b/platform/dbt/models/staging/cycling/portland/stg_portland_node_elevations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_node_elevations_model('portland') }}

--- a/platform/dbt/models/staging/cycling/sf/_stg_sf_cycling.yml
+++ b/platform/dbt/models/staging/cycling/sf/_stg_sf_cycling.yml
@@ -66,3 +66,51 @@ models:
       - segment_geom_endpoints_match_node_positions:
           arguments:
             ways_model: ref('stg_sf_bike_ways')
+  - name: stg_sf_elevation_tiles
+    description: Precomputed convex-hull footprints for the current 3DEP sub-tiles,
+      used for indexed node-to-tile resolution during elevation sampling. One row
+      per current tile_id.
+    columns:
+      - name: tile_id
+        description: Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>).
+        data_tests:
+          - not_null
+          - unique
+      - name: hull
+        description: Tile convex hull (geometry, 4269). NULL would silently drop the
+          tile's coverage.
+        data_tests:
+          - not_null
+  - name: stg_sf_node_elevations
+    description: 'One row per routing-graph node with its bare-earth elevation sampled
+      from the city''s 3DEP DEM. elevation_m is intentionally nullable: a node outside
+      coverage or on a nodata pixel (e.g. open water) is NULL and treated as flat
+      downstream.'
+    columns:
+      - name: node_id
+        description: OSM node id. unique is the regression guard for the one-row-per-node
+          grain the lateral limit-1 resolution guarantees.
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: elevation_m
+        description: 'NAVD88 meters, or NULL on a coverage gap. The range bound catches
+          nodata sentinels (-9999, +/-3.4e38) leaking through as numbers and gross
+          unit errors; checked only on non-null rows. Bounds are loose on purpose:
+          they span every target metro (Denver sits near 1600 m), so they flag sentinels,
+          not tight validation.'
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -100
+                max_value: 4500
+              config:
+                where: elevation_m is not null
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.98
+              config:
+                severity: warn

--- a/platform/dbt/models/staging/cycling/sf/stg_sf_elevation_tiles.sql
+++ b/platform/dbt/models/staging/cycling/sf/stg_sf_elevation_tiles.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} USING GIST (hull)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_elevation_tiles_model('sf') }}

--- a/platform/dbt/models/staging/cycling/sf/stg_sf_node_elevations.sql
+++ b/platform/dbt/models/staging/cycling/sf/stg_sf_node_elevations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_node_elevations_model('sf') }}

--- a/platform/migrations/postgres/V56__adds_static_file_tables.sql
+++ b/platform/migrations/postgres/V56__adds_static_file_tables.sql
@@ -1,0 +1,97 @@
+create table if not exists raw_data.ahrq_chsp_health_systems (
+    "health_sys_id" text,
+    "health_sys_name" text,
+    "health_sys_city" text,
+    "health_sys_state" text,
+    "in_onekey" text,
+    "in_aha" text,
+    "onekey_id" text,
+    "aha_sysid" text,
+    "total_mds" text,
+    "prim_care_mds" text,
+    "total_nps" text,
+    "total_pas" text,
+    "grp_cnt" text,
+    "grp_cnt_restricted" text,
+    "hosp_cnt" text,
+    "acutehosp_cnt" text,
+    "nh_cnt" text,
+    "nh_cnt_restricted" text,
+    "hhco_cnt" text,
+    "hhco_cnt_restricted" text,
+    "sys_multistate" text,
+    "sys_beds" text,
+    "sys_dsch" text,
+    "sys_res" text,
+    "deg_children" text,
+    "sys_incl_majteachhosp" text,
+    "sys_incl_vmajteachhosp" text,
+    "sys_teachint" text,
+    "sys_incl_highdpphosp" text,
+    "sys_highucburden" text,
+    "sys_incl_highuchosp" text,
+    "sys_anyins_product" text,
+    "sys_mcare_adv" text,
+    "sys_mcaid_mngcare" text,
+    "sys_healthins_mktplc" text,
+    "sys_ma_plan_contracts" text,
+    "sys_ma_plan_enroll" text,
+    "sys_ownership" text,
+    "hos_net_revenue" text,
+    "hos_total_revenue" text,
+    "vintage" text not null,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.ahrq_chsp_health_systems
+    add constraint uq_ahrq_chsp_health_systems_entity_hash
+    unique ("health_sys_id", "vintage", "record_hash");
+create index if not exists ix_ahrq_chsp_health_systems_current
+    on raw_data.ahrq_chsp_health_systems ("health_sys_id", "vintage")
+    where valid_to is null;
+
+
+create table if not exists raw_data.ahrq_chsp_hospital_linkage (
+    "compendium_hospital_id" text,
+    "ccn" text,
+    "hospital_name" text,
+    "hospital_street" text,
+    "hospital_city" text,
+    "hospital_state" text,
+    "hospital_zip" text,
+    "acutehosp_flag" text,
+    "health_sys_id" text,
+    "health_sys_name" text,
+    "health_sys_city" text,
+    "health_sys_state" text,
+    "corp_parent_id" text,
+    "corp_parent_name" text,
+    "corp_parent_type" text,
+    "hos_beds" text,
+    "hos_dsch" text,
+    "hos_res" text,
+    "hos_children" text,
+    "hos_majteach" text,
+    "hos_vmajteach" text,
+    "hos_teachint" text,
+    "hos_highdpp" text,
+    "hos_ucburden" text,
+    "hos_highuc" text,
+    "hos_ownership" text,
+    "hos_net_revenue" text,
+    "hos_total_revenue" text,
+    "vintage" text not null,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.ahrq_chsp_hospital_linkage
+    add constraint uq_ahrq_chsp_hospital_linkage_entity_hash
+    unique ("ccn", "vintage", "record_hash");
+create index if not exists ix_ahrq_chsp_hospital_linkage_current
+    on raw_data.ahrq_chsp_hospital_linkage ("ccn", "vintage")
+    where valid_to is null;
+

--- a/platform/migrations/postgres/V57__adds_usgs_3dep_elevation_tables.sql
+++ b/platform/migrations/postgres/V57__adds_usgs_3dep_elevation_tables.sql
@@ -1,0 +1,223 @@
+create table if not exists raw_data.boston_3dep_elevation (
+    "tile_id" text not null,
+    "rast" raster not null,
+    "checksum" text not null,
+    "srid" integer not null,
+    "min_x" double precision,
+    "min_y" double precision,
+    "max_x" double precision,
+    "max_y" double precision,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.boston_3dep_elevation
+    add constraint uq_boston_3dep_elevation_entity_hash
+    unique ("tile_id", "record_hash");
+create index if not exists ix_boston_3dep_elevation_current
+    on raw_data.boston_3dep_elevation ("tile_id")
+    where "valid_to" is null;
+create index if not exists ix_boston_3dep_elevation_rast
+    on raw_data.boston_3dep_elevation using gist (ST_ConvexHull(rast))
+    where "valid_to" is null;
+
+
+create table if not exists raw_data.chicago_3dep_elevation (
+    "tile_id" text not null,
+    "rast" raster not null,
+    "checksum" text not null,
+    "srid" integer not null,
+    "min_x" double precision,
+    "min_y" double precision,
+    "max_x" double precision,
+    "max_y" double precision,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.chicago_3dep_elevation
+    add constraint uq_chicago_3dep_elevation_entity_hash
+    unique ("tile_id", "record_hash");
+create index if not exists ix_chicago_3dep_elevation_current
+    on raw_data.chicago_3dep_elevation ("tile_id")
+    where "valid_to" is null;
+create index if not exists ix_chicago_3dep_elevation_rast
+    on raw_data.chicago_3dep_elevation using gist (ST_ConvexHull(rast))
+    where "valid_to" is null;
+
+
+create table if not exists raw_data.dc_3dep_elevation (
+    "tile_id" text not null,
+    "rast" raster not null,
+    "checksum" text not null,
+    "srid" integer not null,
+    "min_x" double precision,
+    "min_y" double precision,
+    "max_x" double precision,
+    "max_y" double precision,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.dc_3dep_elevation
+    add constraint uq_dc_3dep_elevation_entity_hash
+    unique ("tile_id", "record_hash");
+create index if not exists ix_dc_3dep_elevation_current
+    on raw_data.dc_3dep_elevation ("tile_id")
+    where "valid_to" is null;
+create index if not exists ix_dc_3dep_elevation_rast
+    on raw_data.dc_3dep_elevation using gist (ST_ConvexHull(rast))
+    where "valid_to" is null;
+
+
+create table if not exists raw_data.denver_3dep_elevation (
+    "tile_id" text not null,
+    "rast" raster not null,
+    "checksum" text not null,
+    "srid" integer not null,
+    "min_x" double precision,
+    "min_y" double precision,
+    "max_x" double precision,
+    "max_y" double precision,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.denver_3dep_elevation
+    add constraint uq_denver_3dep_elevation_entity_hash
+    unique ("tile_id", "record_hash");
+create index if not exists ix_denver_3dep_elevation_current
+    on raw_data.denver_3dep_elevation ("tile_id")
+    where "valid_to" is null;
+create index if not exists ix_denver_3dep_elevation_rast
+    on raw_data.denver_3dep_elevation using gist (ST_ConvexHull(rast))
+    where "valid_to" is null;
+
+
+create table if not exists raw_data.detroit_3dep_elevation (
+    "tile_id" text not null,
+    "rast" raster not null,
+    "checksum" text not null,
+    "srid" integer not null,
+    "min_x" double precision,
+    "min_y" double precision,
+    "max_x" double precision,
+    "max_y" double precision,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.detroit_3dep_elevation
+    add constraint uq_detroit_3dep_elevation_entity_hash
+    unique ("tile_id", "record_hash");
+create index if not exists ix_detroit_3dep_elevation_current
+    on raw_data.detroit_3dep_elevation ("tile_id")
+    where "valid_to" is null;
+create index if not exists ix_detroit_3dep_elevation_rast
+    on raw_data.detroit_3dep_elevation using gist (ST_ConvexHull(rast))
+    where "valid_to" is null;
+
+
+create table if not exists raw_data.madison_3dep_elevation (
+    "tile_id" text not null,
+    "rast" raster not null,
+    "checksum" text not null,
+    "srid" integer not null,
+    "min_x" double precision,
+    "min_y" double precision,
+    "max_x" double precision,
+    "max_y" double precision,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.madison_3dep_elevation
+    add constraint uq_madison_3dep_elevation_entity_hash
+    unique ("tile_id", "record_hash");
+create index if not exists ix_madison_3dep_elevation_current
+    on raw_data.madison_3dep_elevation ("tile_id")
+    where "valid_to" is null;
+create index if not exists ix_madison_3dep_elevation_rast
+    on raw_data.madison_3dep_elevation using gist (ST_ConvexHull(rast))
+    where "valid_to" is null;
+
+
+create table if not exists raw_data.nola_3dep_elevation (
+    "tile_id" text not null,
+    "rast" raster not null,
+    "checksum" text not null,
+    "srid" integer not null,
+    "min_x" double precision,
+    "min_y" double precision,
+    "max_x" double precision,
+    "max_y" double precision,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.nola_3dep_elevation
+    add constraint uq_nola_3dep_elevation_entity_hash
+    unique ("tile_id", "record_hash");
+create index if not exists ix_nola_3dep_elevation_current
+    on raw_data.nola_3dep_elevation ("tile_id")
+    where "valid_to" is null;
+create index if not exists ix_nola_3dep_elevation_rast
+    on raw_data.nola_3dep_elevation using gist (ST_ConvexHull(rast))
+    where "valid_to" is null;
+
+
+create table if not exists raw_data.portland_3dep_elevation (
+    "tile_id" text not null,
+    "rast" raster not null,
+    "checksum" text not null,
+    "srid" integer not null,
+    "min_x" double precision,
+    "min_y" double precision,
+    "max_x" double precision,
+    "max_y" double precision,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.portland_3dep_elevation
+    add constraint uq_portland_3dep_elevation_entity_hash
+    unique ("tile_id", "record_hash");
+create index if not exists ix_portland_3dep_elevation_current
+    on raw_data.portland_3dep_elevation ("tile_id")
+    where "valid_to" is null;
+create index if not exists ix_portland_3dep_elevation_rast
+    on raw_data.portland_3dep_elevation using gist (ST_ConvexHull(rast))
+    where "valid_to" is null;
+
+
+create table if not exists raw_data.sf_3dep_elevation (
+    "tile_id" text not null,
+    "rast" raster not null,
+    "checksum" text not null,
+    "srid" integer not null,
+    "min_x" double precision,
+    "min_y" double precision,
+    "max_x" double precision,
+    "max_y" double precision,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.sf_3dep_elevation
+    add constraint uq_sf_3dep_elevation_entity_hash
+    unique ("tile_id", "record_hash");
+create index if not exists ix_sf_3dep_elevation_current
+    on raw_data.sf_3dep_elevation ("tile_id")
+    where "valid_to" is null;
+create index if not exists ix_sf_3dep_elevation_rast
+    on raw_data.sf_3dep_elevation using gist (ST_ConvexHull(rast))
+    where "valid_to" is null;

--- a/platform/podman/orchestration/requirements.txt
+++ b/platform/podman/orchestration/requirements.txt
@@ -13,6 +13,7 @@ pandas
 psycopg2-binary
 pyarrow
 PyMySQL
+rasterio
 requests
 scipy
 shapely

--- a/platform/tests/collectors/cms/conftest.py
+++ b/platform/tests/collectors/cms/conftest.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/collectors/cms/conftest.py
 """
 CMS-specific fixtures. Shared fixtures (engine, schema) come from the
 parent conftest; shared code (NoopTracker) from ..common.

--- a/platform/tests/collectors/cms/helpers.py
+++ b/platform/tests/collectors/cms/helpers.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/collectors/cms/helpers.py
 """
 Fakes and test-data helpers for the CMS collector tests.
 

--- a/platform/tests/collectors/cms/test_collector.py
+++ b/platform/tests/collectors/cms/test_collector.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/collectors/cms/test_collector.py
 """
 Critical observable behaviors of CMSCollector, tested end to end against
 a real Postgres (real StagedIngest SCD2 semantics) with a fake CMS API.

--- a/platform/tests/collectors/cms/test_unit.py
+++ b/platform/tests/collectors/cms/test_unit.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/collectors/cms/test_unit.py
 """
 Unit behaviors of the CMS tooling that need neither a database nor HTTP:
 spec validation, catalog version parsing, and the DDL contract.

--- a/platform/tests/collectors/conftest.py
+++ b/platform/tests/collectors/conftest.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/collectors/conftest.py
 """
 Shared fixtures for the collector test suites (cms, dkan, ...).
 

--- a/platform/tests/collectors/dkan/conftest.py
+++ b/platform/tests/collectors/dkan/conftest.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/collectors/dkan/conftest.py
 """
 DKAN-specific fixtures. Shared fixtures (engine, schema) come from the
 parent conftest; shared code (NoopTracker) from ..common.

--- a/platform/tests/collectors/dkan/helpers.py
+++ b/platform/tests/collectors/dkan/helpers.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/collectors/dkan/helpers.py
 """
 Fakes and test-data helpers for the DKAN collector tests.
 

--- a/platform/tests/collectors/dkan/test_collector.py
+++ b/platform/tests/collectors/dkan/test_collector.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/collectors/dkan/test_collector.py
 """
 Critical observable behaviors of DKANCollector, tested end to end
 against a real Postgres (real StagedIngest SCD2 semantics) with a fake

--- a/platform/tests/collectors/dkan/test_unit.py
+++ b/platform/tests/collectors/dkan/test_unit.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/collectors/dkan/test_unit.py
 """
 Unit behaviors of the DKAN tooling that need neither a database nor
 HTTP: spec validation, catalog/distribution parsing, and the DDL

--- a/platform/tests/collectors/threedep/conftest.py
+++ b/platform/tests/collectors/threedep/conftest.py
@@ -1,0 +1,37 @@
+# /loci_platform/platform/tests/collectors/threedep/conftest.py
+"""
+3DEP-specific fixtures. Shared fixtures (engine, schema) come from the
+parent conftest; shared code (NoopTracker) from ..common.
+"""
+
+from __future__ import annotations
+
+import pytest
+from loci.collectors.threedep.collector import ThreeDEPCollector
+
+from ..common import NoopTracker
+from .helpers import SUB_TILE, FakeThreeDEPClient
+
+
+@pytest.fixture
+def warehouse(engine):
+    """
+    Factory: given a spec and its FakeThreeDEPSource, return a collector
+    with the fake client, and the target table created from the
+    collector's own generated DDL — so every DB test also exercises DDL
+    ingest-readiness. A small sub-tile size is used so a clip to a
+    sub-degree bbox visibly drops sub-tiles.
+    """
+
+    def build(spec, source, create_table=True):
+        collector = ThreeDEPCollector(
+            engine=engine,
+            client=FakeThreeDEPClient(source),
+            tracker=NoopTracker(),
+            tile_size=SUB_TILE,
+        )
+        if create_table:
+            engine.execute(collector.generate_ddl(spec))
+        return collector
+
+    return build

--- a/platform/tests/collectors/threedep/helpers.py
+++ b/platform/tests/collectors/threedep/helpers.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import numpy as np
 import rasterio
-from loci.collectors.threedep.spec import ThreeDEPSpec
+from loci.collectors.threedep.spec import ThreeDEPDatasetSpec
 from loci.geo import BBox
 from rasterio.transform import from_origin
 
@@ -91,9 +91,16 @@ def _write_synthetic_tile(dest_path, name: str, base_value: float) -> None:
     cols = np.arange(PX).reshape(1, -1)
     arr = (base_value + rows + cols).astype("float32")
     with rasterio.open(
-        dest_path, "w", driver="GTiff", height=PX, width=PX, count=1,
-        dtype="float32", crs=f"EPSG:{SRID}",
-        transform=from_origin(west, north, res, res), nodata=NODATA,
+        dest_path,
+        "w",
+        driver="GTiff",
+        height=PX,
+        width=PX,
+        count=1,
+        dtype="float32",
+        crs=f"EPSG:{SRID}",
+        transform=from_origin(west, north, res, res),
+        nodata=NODATA,
     ) as dst:
         dst.write(arr, 1)
 
@@ -110,7 +117,9 @@ def seeded_source(tiles=("n42w088",), base_value: float = 1000.0) -> FakeThreeDE
     return source
 
 
-def make_elevation_spec(schema: str, bbox: BBox = SINGLE_TILE_BBOX, **overrides) -> ThreeDEPSpec:
+def make_elevation_spec(
+    schema: str, bbox: BBox = SINGLE_TILE_BBOX, **overrides
+) -> ThreeDEPDatasetSpec:
     kwargs = dict(
         name="fake_elevation",
         target_table="fake_elevation",
@@ -118,4 +127,4 @@ def make_elevation_spec(schema: str, bbox: BBox = SINGLE_TILE_BBOX, **overrides)
         bbox=bbox,
     )
     kwargs.update(overrides)
-    return ThreeDEPSpec(**kwargs)
+    return ThreeDEPDatasetSpec(**kwargs)

--- a/platform/tests/collectors/threedep/helpers.py
+++ b/platform/tests/collectors/threedep/helpers.py
@@ -1,0 +1,121 @@
+# /loci_platform/platform/tests/collectors/threedep/helpers.py
+"""
+Fakes and test-data helpers for the 3DEP collector tests.
+
+The boundary that gets faked is HTTP (FakeThreeDEPClient duck-types
+ThreeDEPClient); ingestion in the DB-backed tests runs against a real
+Postgres so StagedIngest's actual SCD2 semantics and the raster
+COPY/ST_Value path are part of the behavior under test.
+
+A "source" here is the set of 1-degree tiles USGS has staged. Each
+served tile is a small synthetic GeoTIFF georeferenced to that tile's
+true 1-degree extent, with a position ramp offset by a per-tile base
+value — so a re-staged tile (new base value) produces different pixels
+and a different checksum, exactly as a real re-stage would.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+import rasterio
+from loci.collectors.threedep.spec import ThreeDEPSpec
+from loci.geo import BBox
+from rasterio.transform import from_origin
+
+# Synthetic tile is coarse (a 1-degree cell in PX pixels); SUB_TILE is the
+# small sub-tile edge the collector tiles with in tests, so a clip to a
+# sub-degree bbox visibly drops sub-tiles.
+PX = 120
+SUB_TILE = 32
+NODATA = -9999.0
+SRID = 4269
+
+# A bbox wholly inside one 1-degree cell (n42w088), for clean assertions.
+SINGLE_TILE_BBOX = BBox(south=41.7, west=-87.8, north=41.9, east=-87.6)
+# A bbox crossing two cells (n42w088 + n43w088).
+TWO_TILE_BBOX = BBox(south=41.62, west=-87.97, north=42.05, east=-87.5)
+
+_NAME_RE = re.compile(r"n(\d+)w(\d+)")
+
+
+def tile_extent(name: str) -> tuple[float, float, float, float]:
+    """(west, south, east, north) of a 1-degree tile from its NW-corner name."""
+    m = _NAME_RE.fullmatch(name)
+    north = int(m.group(1))
+    west = -int(m.group(2))
+    return west, north - 1, west + 1, north
+
+
+# ---------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------
+
+
+class FakeThreeDEPSource:
+    """In-memory stand-in for the staged tiles: tile name -> base value."""
+
+    def __init__(self):
+        self.tiles: dict[str, float] = {}
+
+    def set_tile(self, name: str, base_value: float = 1000.0) -> None:
+        """Stage or re-stage a tile (a new base value == changed pixels)."""
+        self.tiles[name] = base_value
+
+
+class FakeThreeDEPClient:
+    """Duck-types ThreeDEPClient against a FakeThreeDEPSource. No HTTP."""
+
+    def __init__(self, source: FakeThreeDEPSource):
+        self.source = source
+        self.downloaded: list[str] = []
+        self.fail_tiles: set[str] = set()
+
+    def tile_exists(self, name: str, product: str = "13") -> bool:
+        return name in self.source.tiles
+
+    def download_tile(self, name: str, product: str, dest_path) -> Path:
+        if name in self.fail_tiles:
+            raise RuntimeError(f"Injected failure for {name}")
+        _write_synthetic_tile(dest_path, name, self.source.tiles[name])
+        self.downloaded.append(name)
+        return Path(dest_path)
+
+
+def _write_synthetic_tile(dest_path, name: str, base_value: float) -> None:
+    west, _south, _east, north = tile_extent(name)
+    res = 1.0 / PX
+    rows = np.arange(PX).reshape(-1, 1)
+    cols = np.arange(PX).reshape(1, -1)
+    arr = (base_value + rows + cols).astype("float32")
+    with rasterio.open(
+        dest_path, "w", driver="GTiff", height=PX, width=PX, count=1,
+        dtype="float32", crs=f"EPSG:{SRID}",
+        transform=from_origin(west, north, res, res), nodata=NODATA,
+    ) as dst:
+        dst.write(arr, 1)
+
+
+# ---------------------------------------------------------------------
+# Test data helpers
+# ---------------------------------------------------------------------
+
+
+def seeded_source(tiles=("n42w088",), base_value: float = 1000.0) -> FakeThreeDEPSource:
+    source = FakeThreeDEPSource()
+    for name in tiles:
+        source.set_tile(name, base_value)
+    return source
+
+
+def make_elevation_spec(schema: str, bbox: BBox = SINGLE_TILE_BBOX, **overrides) -> ThreeDEPSpec:
+    kwargs = dict(
+        name="fake_elevation",
+        target_table="fake_elevation",
+        target_schema=schema,
+        bbox=bbox,
+    )
+    kwargs.update(overrides)
+    return ThreeDEPSpec(**kwargs)

--- a/platform/tests/collectors/threedep/test_client.py
+++ b/platform/tests/collectors/threedep/test_client.py
@@ -14,7 +14,7 @@ from loci.collectors.threedep.client import (
     tile_url,
     tiles_for_bbox,
 )
-from loci.collectors.threedep.spec import ThreeDEPSpec
+from loci.collectors.threedep.spec import ThreeDEPDatasetSpec
 from loci.geo import BBox
 from loci.raster.ingest import iter_tiles
 from rasterio.transform import from_origin
@@ -22,6 +22,7 @@ from rasterio.transform import from_origin
 # --------------------------------------------------------------------------
 # tile_name
 # --------------------------------------------------------------------------
+
 
 def test_tile_name_zero_pads():
     assert tile_name(42, -88) == "n42w088"
@@ -40,6 +41,7 @@ def test_tile_name_rejects_eastern_or_southern():
 # tiles_for_bbox
 # --------------------------------------------------------------------------
 
+
 def test_chicago_spans_two_lat_tiles():
     # north 42.05 crosses into the [42,43] cell -> n42 and n43.
     bbox = BBox(south=41.62, west=-87.97, north=42.05, east=-87.5)
@@ -55,7 +57,10 @@ def test_bbox_spanning_grid_yields_all_cells():
     # lat [37,39): n38,n39 ; lon [-123,-121): w123,w122 -> 4 tiles
     bbox = BBox(south=37.2, west=-122.6, north=38.5, east=-121.7)
     assert tiles_for_bbox(bbox) == [
-        "n38w122", "n38w123", "n39w122", "n39w123",
+        "n38w122",
+        "n38w123",
+        "n39w122",
+        "n39w123",
     ]
 
 
@@ -74,13 +79,12 @@ def test_single_cell_bbox():
 # tile_url
 # --------------------------------------------------------------------------
 
+
 def test_tile_url_for_each_product():
     assert tile_url("n42w088", "13").endswith(
         "/Elevation/13/TIFF/current/n42w088/USGS_13_n42w088.tif"
     )
-    assert tile_url("n42w088", "1").endswith(
-        "/Elevation/1/TIFF/current/n42w088/USGS_1_n42w088.tif"
-    )
+    assert tile_url("n42w088", "1").endswith("/Elevation/1/TIFF/current/n42w088/USGS_1_n42w088.tif")
 
 
 def test_tile_url_rejects_unsupported_product():
@@ -89,15 +93,18 @@ def test_tile_url_rejects_unsupported_product():
 
 
 # --------------------------------------------------------------------------
-# ThreeDEPSpec
+# ThreeDEPDatasetSpec
 # --------------------------------------------------------------------------
+
 
 def _bbox():
     return BBox(south=41.62, west=-87.97, north=42.05, east=-87.5)
 
 
 def test_spec_defaults():
-    spec = ThreeDEPSpec(name="chicago_elevation", target_table="chicago_elevation", bbox=_bbox())
+    spec = ThreeDEPDatasetSpec(
+        name="chicago_elevation", target_table="chicago_elevation", bbox=_bbox()
+    )
     assert spec.source == "3dep"
     assert spec.target_schema == "raw_data"
     assert spec.product == "13"
@@ -107,23 +114,24 @@ def test_spec_defaults():
 
 def test_spec_requires_bbox():
     with pytest.raises(ValueError, match="bbox is required"):
-        ThreeDEPSpec(name="x", target_table="x")
+        ThreeDEPDatasetSpec(name="x", target_table="x")
 
 
 def test_spec_rejects_bad_product():
     with pytest.raises(ValueError, match="product must be"):
-        ThreeDEPSpec(name="x", target_table="x", bbox=_bbox(), product="1m")
+        ThreeDEPDatasetSpec(name="x", target_table="x", bbox=_bbox(), product="1m")
 
 
 def test_spec_rejects_overridden_entity_key():
     with pytest.raises(ValueError, match="fixed to"):
-        ThreeDEPSpec(name="x", target_table="x", bbox=_bbox(), entity_key=["foo"])
+        ThreeDEPDatasetSpec(name="x", target_table="x", bbox=_bbox(), entity_key=["foo"])
 
 
 def test_spec_rejects_non_nad83_bbox():
     with pytest.raises(ValueError, match="NAD83"):
-        ThreeDEPSpec(
-            name="x", target_table="x",
+        ThreeDEPDatasetSpec(
+            name="x",
+            target_table="x",
             bbox=BBox(south=41.62, west=-87.97, north=42.05, east=-87.5, srid=4326),
         )
 
@@ -132,14 +140,22 @@ def test_spec_rejects_non_nad83_bbox():
 # bounds clip filter on iter_tiles
 # --------------------------------------------------------------------------
 
+
 @pytest.fixture
 def small_dem(tmp_path):
     # 100x100 at 0.01 deg, origin (-88, 42) north-up -> covers lon [-88,-87], lat [41,42]
     arr = np.arange(100 * 100, dtype=np.float32).reshape(100, 100)
     path = tmp_path / "d.tif"
     with rasterio.open(
-        path, "w", driver="GTiff", height=100, width=100, count=1, dtype="float32",
-        crs="EPSG:4269", transform=from_origin(-88.0, 42.0, 0.01, 0.01),
+        path,
+        "w",
+        driver="GTiff",
+        height=100,
+        width=100,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4269",
+        transform=from_origin(-88.0, 42.0, 0.01, 0.01),
     ) as d:
         d.write(arr, 1)
     return str(path)
@@ -156,8 +172,9 @@ def test_bounds_keeps_only_intersecting_tiles(small_dem):
     assert 0 < len(clipped) < len(all_tiles)
     # Every returned tile actually intersects the clip extent.
     for t in clipped:
-        assert not (t.max_x < clip[0] or t.min_x > clip[2]
-                    or t.max_y < clip[1] or t.min_y > clip[3])
+        assert not (
+            t.max_x < clip[0] or t.min_x > clip[2] or t.max_y < clip[1] or t.min_y > clip[3]
+        )
 
 
 def test_bounds_none_is_unfiltered(small_dem):

--- a/platform/tests/collectors/threedep/test_client.py
+++ b/platform/tests/collectors/threedep/test_client.py
@@ -1,0 +1,166 @@
+"""
+Offline tests for the 3DEP client's tile addressing, the spec, and the
+raster bounds-clip filter. Network calls (tile_exists/download_tile) are
+not exercised here — those belong in a live smoke test.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import rasterio
+from loci.collectors.threedep.client import (
+    tile_name,
+    tile_url,
+    tiles_for_bbox,
+)
+from loci.collectors.threedep.spec import ThreeDEPSpec
+from loci.geo import BBox
+from loci.raster.ingest import iter_tiles
+from rasterio.transform import from_origin
+
+# --------------------------------------------------------------------------
+# tile_name
+# --------------------------------------------------------------------------
+
+def test_tile_name_zero_pads():
+    assert tile_name(42, -88) == "n42w088"
+    assert tile_name(7, -9) == "n07w009"
+    assert tile_name(38, -123) == "n38w123"
+
+
+def test_tile_name_rejects_eastern_or_southern():
+    with pytest.raises(ValueError, match="western"):
+        tile_name(42, 5)
+    with pytest.raises(ValueError, match="northern"):
+        tile_name(-1, -88)
+
+
+# --------------------------------------------------------------------------
+# tiles_for_bbox
+# --------------------------------------------------------------------------
+
+def test_chicago_spans_two_lat_tiles():
+    # north 42.05 crosses into the [42,43] cell -> n42 and n43.
+    bbox = BBox(south=41.62, west=-87.97, north=42.05, east=-87.5)
+    assert tiles_for_bbox(bbox) == ["n42w088", "n43w088"]
+
+
+def test_detroit_spans_two_lon_tiles():
+    bbox = BBox(south=42.24, west=-83.29, north=42.46, east=-82.89)
+    assert tiles_for_bbox(bbox) == ["n43w083", "n43w084"]
+
+
+def test_bbox_spanning_grid_yields_all_cells():
+    # lat [37,39): n38,n39 ; lon [-123,-121): w123,w122 -> 4 tiles
+    bbox = BBox(south=37.2, west=-122.6, north=38.5, east=-121.7)
+    assert tiles_for_bbox(bbox) == [
+        "n38w122", "n38w123", "n39w122", "n39w123",
+    ]
+
+
+def test_integer_north_edge_does_not_pull_extra_tile():
+    # north exactly 42.0 stays within [41,42] -> only n42, not n43.
+    bbox = BBox(south=41.6, west=-87.9, north=42.0, east=-87.5)
+    assert tiles_for_bbox(bbox) == ["n42w088"]
+
+
+def test_single_cell_bbox():
+    bbox = BBox(south=41.7, west=-87.8, north=41.9, east=-87.6)
+    assert tiles_for_bbox(bbox) == ["n42w088"]
+
+
+# --------------------------------------------------------------------------
+# tile_url
+# --------------------------------------------------------------------------
+
+def test_tile_url_for_each_product():
+    assert tile_url("n42w088", "13").endswith(
+        "/Elevation/13/TIFF/current/n42w088/USGS_13_n42w088.tif"
+    )
+    assert tile_url("n42w088", "1").endswith(
+        "/Elevation/1/TIFF/current/n42w088/USGS_1_n42w088.tif"
+    )
+
+
+def test_tile_url_rejects_unsupported_product():
+    with pytest.raises(ValueError, match="unsupported product"):
+        tile_url("n42w088", "1m")
+
+
+# --------------------------------------------------------------------------
+# ThreeDEPSpec
+# --------------------------------------------------------------------------
+
+def _bbox():
+    return BBox(south=41.62, west=-87.97, north=42.05, east=-87.5)
+
+
+def test_spec_defaults():
+    spec = ThreeDEPSpec(name="chicago_elevation", target_table="chicago_elevation", bbox=_bbox())
+    assert spec.source == "3dep"
+    assert spec.target_schema == "raw_data"
+    assert spec.product == "13"
+    assert spec.entity_key == ["tile_id"]
+    assert spec.dataset_id == "chicago_elevation"
+
+
+def test_spec_requires_bbox():
+    with pytest.raises(ValueError, match="bbox is required"):
+        ThreeDEPSpec(name="x", target_table="x")
+
+
+def test_spec_rejects_bad_product():
+    with pytest.raises(ValueError, match="product must be"):
+        ThreeDEPSpec(name="x", target_table="x", bbox=_bbox(), product="1m")
+
+
+def test_spec_rejects_overridden_entity_key():
+    with pytest.raises(ValueError, match="fixed to"):
+        ThreeDEPSpec(name="x", target_table="x", bbox=_bbox(), entity_key=["foo"])
+
+
+def test_spec_rejects_non_nad83_bbox():
+    with pytest.raises(ValueError, match="NAD83"):
+        ThreeDEPSpec(
+            name="x", target_table="x",
+            bbox=BBox(south=41.62, west=-87.97, north=42.05, east=-87.5, srid=4326),
+        )
+
+
+# --------------------------------------------------------------------------
+# bounds clip filter on iter_tiles
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def small_dem(tmp_path):
+    # 100x100 at 0.01 deg, origin (-88, 42) north-up -> covers lon [-88,-87], lat [41,42]
+    arr = np.arange(100 * 100, dtype=np.float32).reshape(100, 100)
+    path = tmp_path / "d.tif"
+    with rasterio.open(
+        path, "w", driver="GTiff", height=100, width=100, count=1, dtype="float32",
+        crs="EPSG:4269", transform=from_origin(-88.0, 42.0, 0.01, 0.01),
+    ) as d:
+        d.write(arr, 1)
+    return str(path)
+
+
+def test_bounds_keeps_only_intersecting_tiles(small_dem):
+    all_tiles = list(iter_tiles(small_dem, source_id="d", tile_size=25))
+    assert len(all_tiles) == 16  # 4x4 grid of 25px tiles
+
+    # Clip to the top-left quarter of the raster's extent.
+    clip = (-88.0, 41.75, -87.75, 42.0)  # min_x, min_y, max_x, max_y
+    clipped = list(iter_tiles(small_dem, source_id="d", tile_size=25, bounds=clip))
+
+    assert 0 < len(clipped) < len(all_tiles)
+    # Every returned tile actually intersects the clip extent.
+    for t in clipped:
+        assert not (t.max_x < clip[0] or t.min_x > clip[2]
+                    or t.max_y < clip[1] or t.min_y > clip[3])
+
+
+def test_bounds_none_is_unfiltered(small_dem):
+    a = list(iter_tiles(small_dem, source_id="d", tile_size=25))
+    b = list(iter_tiles(small_dem, source_id="d", tile_size=25, bounds=None))
+    assert len(a) == len(b) == 16

--- a/platform/tests/collectors/threedep/test_collector.py
+++ b/platform/tests/collectors/threedep/test_collector.py
@@ -69,8 +69,12 @@ def test_first_collect_ingests_clips_and_samples(engine, schema, warehouse):
     assert len(rows) > 0
     b = SINGLE_TILE_BBOX
     for r in rows:
-        assert not (r["max_x"] < b.west or r["min_x"] > b.east
-                    or r["max_y"] < b.south or r["min_y"] > b.north)
+        assert not (
+            r["max_x"] < b.west
+            or r["min_x"] > b.east
+            or r["max_y"] < b.south
+            or r["min_y"] > b.north
+        )
 
     cx, cy = (b.west + b.east) / 2, (b.south + b.north) / 2
     assert sample_elev(engine, schema, cx, cy) is not None
@@ -133,8 +137,8 @@ def test_restaged_tile_versions_then_resettles(engine, schema, warehouse):
     source.set_tile("n42w088", base_value=5000.0)  # USGS re-stages with new values
     summary = collector.collect(spec, force=True)
 
-    assert summary["rows_merged"] == current_before          # every sub-tile changed
-    assert current_count(engine, schema) == current_before   # one current per sub-tile
+    assert summary["rows_merged"] == current_before  # every sub-tile changed
+    assert current_count(engine, schema) == current_before  # one current per sub-tile
     assert total_count(engine, schema) == total_before + current_before  # old versions kept
 
     assert collector.collect(spec, force=True)["rows_merged"] == 0  # resettled

--- a/platform/tests/collectors/threedep/test_collector.py
+++ b/platform/tests/collectors/threedep/test_collector.py
@@ -1,0 +1,192 @@
+# /loci_platform/platform/tests/collectors/threedep/test_collector.py
+"""
+Critical observable behaviors of ThreeDEPCollector, tested end to end
+against a real Postgres (real StagedIngest SCD2 semantics and the raster
+COPY/ST_Value path) with a fake source at the HTTP boundary.
+
+Each test names one behavior the tooling must keep exhibiting. The
+assertions look only at the target table and the collect() summary, so
+the implementation underneath is free to change.
+"""
+
+from __future__ import annotations
+
+from .helpers import (
+    SINGLE_TILE_BBOX,
+    TWO_TILE_BBOX,
+    make_elevation_spec,
+    seeded_source,
+)
+
+TABLE = "fake_elevation"
+
+
+def total_count(engine, schema) -> int:
+    df = engine.query(f"select count(*) as n from {schema}.{TABLE}")
+    return int(df["n"].iloc[0])
+
+
+def current_count(engine, schema) -> int:
+    df = engine.query(f'select count(*) as n from {schema}.{TABLE} where "valid_to" is null')
+    return int(df["n"].iloc[0])
+
+
+def sample_elev(engine, schema, lon, lat, srid=4269):
+    df = engine.query(
+        f"""
+        select ST_Value(rast, ST_SetSRID(ST_Point(%(x)s, %(y)s), {srid})) as elev
+        from {schema}.{TABLE}
+        where "valid_to" is null
+          and ST_Intersects(rast, ST_SetSRID(ST_Point(%(x)s, %(y)s), {srid}))
+        """,
+        {"x": lon, "y": lat},
+    )
+    return None if df.empty else df.iloc[0]["elev"]
+
+
+# ---------------------------------------------------------------------
+# Behavior 1: a first collect ingests the tiles covering the bbox,
+# clips the stored sub-tiles to it, and the result samples a finite
+# elevation at a point inside the region.
+# ---------------------------------------------------------------------
+
+
+def test_first_collect_ingests_clips_and_samples(engine, schema, warehouse):
+    spec = make_elevation_spec(schema, bbox=SINGLE_TILE_BBOX)
+    collector = warehouse(spec, seeded_source(["n42w088"]))
+
+    summary = collector.collect(spec, force=True)
+
+    assert summary["errors"] == []
+    assert summary["tiles_collected"] == 1
+    assert summary["rows_merged"] > 0
+
+    # Clip: every stored sub-tile intersects the bbox.
+    rows = engine.query(
+        f'select min_x, min_y, max_x, max_y from {schema}.{TABLE} where "valid_to" is null',
+        as_dicts=True,
+    )
+    assert len(rows) > 0
+    b = SINGLE_TILE_BBOX
+    for r in rows:
+        assert not (r["max_x"] < b.west or r["min_x"] > b.east
+                    or r["max_y"] < b.south or r["min_y"] > b.north)
+
+    cx, cy = (b.west + b.east) / 2, (b.south + b.north) / 2
+    assert sample_elev(engine, schema, cx, cy) is not None
+
+
+# ---------------------------------------------------------------------
+# Behavior 2: an incremental re-run skips tiles already present, without
+# re-downloading them.
+# ---------------------------------------------------------------------
+
+
+def test_incremental_skips_present_without_download(engine, schema, warehouse):
+    spec = make_elevation_spec(schema, bbox=SINGLE_TILE_BBOX)
+    collector = warehouse(spec, seeded_source(["n42w088"]))
+    collector.collect(spec, force=True)
+
+    collector.client.downloaded.clear()
+    summary = collector.collect(spec)  # incremental
+
+    assert summary["mode"] == "incremental"
+    assert summary["tiles_skipped_present"] == 1
+    assert summary["tiles_collected"] == 0
+    assert collector.client.downloaded == []
+
+
+# ---------------------------------------------------------------------
+# Behavior 3: recollection (force) never duplicates data.
+# ---------------------------------------------------------------------
+
+
+def test_force_recollect_creates_no_duplicates(engine, schema, warehouse):
+    spec = make_elevation_spec(schema, bbox=SINGLE_TILE_BBOX)
+    collector = warehouse(spec, seeded_source(["n42w088"]))
+    collector.collect(spec, force=True)
+    n = total_count(engine, schema)
+
+    summary = collector.collect(spec, force=True)
+
+    assert summary["rows_merged"] == 0
+    assert total_count(engine, schema) == n
+
+
+# ---------------------------------------------------------------------
+# Behavior 4: a re-staged tile (changed pixels) versions the changed
+# sub-tiles on a forced run, then resettles. (Incremental skips present
+# tiles, so force is how a re-stage is picked up — the documented
+# semantics.)
+# ---------------------------------------------------------------------
+
+
+def test_restaged_tile_versions_then_resettles(engine, schema, warehouse):
+    spec = make_elevation_spec(schema, bbox=SINGLE_TILE_BBOX)
+    source = seeded_source(["n42w088"])
+    collector = warehouse(spec, source)
+    collector.collect(spec, force=True)
+
+    current_before = current_count(engine, schema)
+    total_before = total_count(engine, schema)
+
+    source.set_tile("n42w088", base_value=5000.0)  # USGS re-stages with new values
+    summary = collector.collect(spec, force=True)
+
+    assert summary["rows_merged"] == current_before          # every sub-tile changed
+    assert current_count(engine, schema) == current_before   # one current per sub-tile
+    assert total_count(engine, schema) == total_before + current_before  # old versions kept
+
+    assert collector.collect(spec, force=True)["rows_merged"] == 0  # resettled
+
+
+# ---------------------------------------------------------------------
+# Behavior 5: a tile not staged at the source is skipped, not fatal.
+# ---------------------------------------------------------------------
+
+
+def test_missing_at_source_tile_is_skipped_not_fatal(engine, schema, warehouse):
+    spec = make_elevation_spec(schema, bbox=TWO_TILE_BBOX)  # needs n42w088 + n43w088
+    collector = warehouse(spec, seeded_source(["n42w088"]))  # only one staged
+
+    summary = collector.collect(spec, force=True)
+
+    assert summary["tiles_collected"] == 1
+    assert summary["tiles_missing_at_source"] == 1
+    assert summary["errors"] == []
+    assert total_count(engine, schema) > 0
+
+
+# ---------------------------------------------------------------------
+# Behavior 6: a failing tile doesn't block the others; the failure is
+# reported in the summary.
+# ---------------------------------------------------------------------
+
+
+def test_failure_in_one_tile_does_not_block_others(engine, schema, warehouse):
+    spec = make_elevation_spec(schema, bbox=TWO_TILE_BBOX)
+    collector = warehouse(spec, seeded_source(["n42w088", "n43w088"]))
+    collector.client.fail_tiles.add("n42w088")
+
+    summary = collector.collect(spec, force=True)
+
+    assert summary["tiles_collected"] == 1
+    assert len(summary["errors"]) == 1
+    assert summary["errors"][0]["tile"] == "n42w088"
+    assert total_count(engine, schema) > 0  # n43w088 still landed
+
+
+# ---------------------------------------------------------------------
+# Behavior 7: collecting into a missing target table fails per-tile with
+# reported errors, not an unhandled crash.
+# ---------------------------------------------------------------------
+
+
+def test_collect_without_target_table_reports_errors_not_crash(engine, schema, warehouse):
+    spec = make_elevation_spec(schema, bbox=TWO_TILE_BBOX)
+    collector = warehouse(spec, seeded_source(["n42w088", "n43w088"]), create_table=False)
+
+    summary = collector.collect(spec, force=True)
+
+    assert summary["tiles_collected"] == 0
+    assert len(summary["errors"]) == 2

--- a/platform/tests/collectors/threedep/test_unit.py
+++ b/platform/tests/collectors/threedep/test_unit.py
@@ -1,0 +1,112 @@
+"""
+Unit behaviors of the 3DEP tooling that need neither a database nor
+HTTP: spec validation, tile addressing, and the DDL contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+from loci.collectors.threedep.client import tile_name, tile_url, tiles_for_bbox
+from loci.collectors.threedep.collector import ThreeDEPCollector
+from loci.geo import BBox
+
+from ..common import NoopTracker
+from .helpers import FakeThreeDEPClient, FakeThreeDEPSource, make_elevation_spec
+
+# ---------------------------------------------------------------------
+# Behavior: specs that can't be executed safely fail loudly at
+# construction time.
+# ---------------------------------------------------------------------
+
+
+def test_spec_requires_bbox():
+    with pytest.raises(ValueError, match="bbox"):
+        make_elevation_spec("raw_data", bbox=None)
+
+
+def test_spec_rejects_unknown_product():
+    with pytest.raises(ValueError, match="product"):
+        make_elevation_spec("raw_data", product="1m")
+
+
+def test_spec_rejects_overridden_entity_key():
+    with pytest.raises(ValueError, match="fixed"):
+        make_elevation_spec("raw_data", entity_key=["foo"])
+
+
+def test_spec_rejects_non_nad83_bbox():
+    with pytest.raises(ValueError, match="NAD83"):
+        make_elevation_spec(
+            "raw_data",
+            bbox=BBox(south=41.7, west=-87.8, north=41.9, east=-87.6, srid=4326),
+        )
+
+
+# ---------------------------------------------------------------------
+# Behavior: a BBox maps to the correct staged 1-degree tiles (NW-corner
+# naming, zero-padded), at 1-degree selection granularity.
+# ---------------------------------------------------------------------
+
+
+def test_tile_name_is_nw_corner_zero_padded():
+    assert tile_name(42, -88) == "n42w088"
+    assert tile_name(38, -123) == "n38w123"
+
+
+def test_tile_name_rejects_eastern_or_southern():
+    with pytest.raises(ValueError, match="western"):
+        tile_name(42, 5)
+    with pytest.raises(ValueError, match="northern"):
+        tile_name(-1, -88)
+
+
+def test_bbox_spanning_two_lat_cells():
+    bbox = BBox(south=41.62, west=-87.97, north=42.05, east=-87.5)
+    assert tiles_for_bbox(bbox) == ["n42w088", "n43w088"]
+
+
+def test_bbox_spanning_grid_yields_all_cells():
+    bbox = BBox(south=37.2, west=-122.6, north=38.5, east=-121.7)
+    assert tiles_for_bbox(bbox) == ["n38w122", "n38w123", "n39w122", "n39w123"]
+
+
+def test_integer_north_edge_does_not_pull_extra_tile():
+    bbox = BBox(south=41.6, west=-87.9, north=42.0, east=-87.5)
+    assert tiles_for_bbox(bbox) == ["n42w088"]
+
+
+def test_tile_url_per_product():
+    assert tile_url("n42w088", "13").endswith("/13/TIFF/current/n42w088/USGS_13_n42w088.tif")
+    assert tile_url("n42w088", "1").endswith("/1/TIFF/current/n42w088/USGS_1_n42w088.tif")
+
+
+def test_tile_url_rejects_unsupported_product():
+    with pytest.raises(ValueError, match="unsupported product"):
+        tile_url("n42w088", "1m")
+
+
+# ---------------------------------------------------------------------
+# Behavior: generated DDL defines a raster table the collector can
+# ingest into directly — a raster column, the convex-hull GiST index
+# that makes ST_Value sampling fast, the extent/provenance columns, and
+# SCD2 uniqueness on (tile_id, record_hash).
+# ---------------------------------------------------------------------
+
+
+def _ddl_collector():
+    return ThreeDEPCollector(
+        engine=object(),
+        client=FakeThreeDEPClient(FakeThreeDEPSource()),
+        tracker=NoopTracker(),
+    )
+
+
+def test_ddl_is_raster_table_with_convex_hull_index_and_scd2():
+    ddl = _ddl_collector().generate_ddl(make_elevation_spec("raw_data"))
+
+    assert '"rast" raster not null' in ddl
+    assert "using gist (ST_ConvexHull(rast))" in ddl
+    assert 'unique ("tile_id", "record_hash")' in ddl
+    assert 'where "valid_to" is null' in ddl
+    for col in ("tile_id", "checksum", "min_x", "max_y", "ingested_at"):
+        assert f'"{col}"' in ddl

--- a/platform/tests/collectors/tiger/test_metadata.py
+++ b/platform/tests/collectors/tiger/test_metadata.py
@@ -170,6 +170,7 @@ class TestListCartographicFiles:
 # ------------------------------------------------------------------ #
 
 
+@pytest.mark.network
 class TestGetDownloadUrl:
     """Test that constructed URLs match the Census naming conventions."""
 

--- a/platform/tests/exports/test_graph_export.py
+++ b/platform/tests/exports/test_graph_export.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/exports/test_graph_export.py
 """
 Tests for the routing graph exporter (graph_export.py).
 
@@ -540,6 +541,8 @@ def _row(
     physical_cost,
     intersection_cost_at_start=0.0,
     intersection_cost_at_end=0.0,
+    elevation_cost_forward=0.0,
+    elevation_cost_backward=0.0,
     crash_cost=0.0,
     length_m=100.0,
     name=None,
@@ -562,6 +565,8 @@ def _row(
         "crash_cost": crash_cost,
         "intersection_cost_at_start": intersection_cost_at_start,
         "intersection_cost_at_end": intersection_cost_at_end,
+        "elevation_cost_forward": elevation_cost_forward,
+        "elevation_cost_backward": elevation_cost_backward,
         "start_is_intersection": start_is_intersection,
         "end_is_intersection": end_is_intersection,
         "highway_class": "local",
@@ -624,11 +629,11 @@ def _decode_graph(path):
         nodes.append({"osm_id": osm_id, "is_intersection": is_intersection})
         pos += 32
 
-    # Edge table (44 bytes each)
+    # Edge table (48 bytes each)
     edge_count = u32()
     edges = []
     for _ in range(edge_count):
-        rec = buf[pos : pos + 44]
+        rec = buf[pos : pos + 48]
         edges.append(
             {
                 "target": struct.unpack_from("<I", rec, 0)[0],
@@ -638,9 +643,10 @@ def _decode_graph(path):
                 "physical_cost": struct.unpack_from("<f", rec, 32)[0],
                 "intersection_cost": struct.unpack_from("<f", rec, 36)[0],
                 "crash_cost": struct.unpack_from("<f", rec, 40)[0],
+                "elevation_cost": struct.unpack_from("<f", rec, 44)[0],
             }
         )
-        pos += 44
+        pos += 48
 
     return {
         "version": version,
@@ -683,6 +689,7 @@ def test_export_end_to_end(tmp_path):
             start_is_intersection=True,
             end_is_intersection=False,
             physical_cost=200.0,
+            elevation_cost_forward=30.0,
         ),
     ]
     engine = _FakeEngine(rows, floor=0.02)
@@ -699,7 +706,7 @@ def test_export_end_to_end(tmp_path):
 
     decoded = _decode_graph(out_path)
 
-    assert decoded["version"] == 2
+    assert decoded["version"] == 3
     # heuristic_floor = raw floor * 0.95 safety margin.
     assert decoded["heuristic_floor"] == pytest.approx(0.02 * 0.95)
 
@@ -725,6 +732,10 @@ def test_export_end_to_end(tmp_path):
 
     assert bwd_ba["intersection_cost"] == pytest.approx(0.0)
     assert bwd_ba["stress_cost"] == pytest.approx(100.0)
+
+    fwd_bc = next(e for e in decoded["edges"] if e["forward"] and e["target"] == idx[30])
+    assert fwd_bc["elevation_cost"] == pytest.approx(30.0)
+    assert fwd_bc["stress_cost"] == pytest.approx(200.0 + 30.0)  # physical + elevation
 
 
 def test_export_falls_back_to_zero_floor_when_query_empty(tmp_path):

--- a/platform/tests/exports/test_graph_format.py
+++ b/platform/tests/exports/test_graph_format.py
@@ -1,3 +1,4 @@
+# /loci_platform/platform/tests/exports/test_graph_format.py
 """
 Tests for the routing graph binary format writer.
 
@@ -32,7 +33,7 @@ from loci.exports.graph_format import (
 # Layout constants from the spec — used to compute offsets in tests.
 HEADER_SIZE = 16
 NODE_RECORD_SIZE = 32
-EDGE_RECORD_SIZE = 44
+EDGE_RECORD_SIZE = 48
 GEOM_COORD_SIZE = 16  # f64 lon + f64 lat
 
 
@@ -63,6 +64,7 @@ def _make_simple_writes():
             physical_cost=250.0,
             intersection_cost=0.0,
             crash_cost=0.0,
+            elevation_cost=0.0,
         ),
         # source 1 → target 2, S1, unnamed, residential, forward
         WriteEdge(
@@ -78,6 +80,7 @@ def _make_simple_writes():
             physical_cost=200.0,
             intersection_cost=0.0,
             crash_cost=0.0,
+            elevation_cost=0.0,
         ),
         # source 1 → target 0, S0 backward sibling
         WriteEdge(
@@ -93,6 +96,7 @@ def _make_simple_writes():
             physical_cost=250.0,
             intersection_cost=0.0,
             crash_cost=0.0,
+            elevation_cost=0.0,
         ),
         # source 2 → target 0, S2 forward
         WriteEdge(
@@ -108,6 +112,7 @@ def _make_simple_writes():
             physical_cost=150.0,
             intersection_cost=0.0,
             crash_cost=0.0,
+            elevation_cost=0.0,
         ),
     ]
     geoms = [
@@ -138,7 +143,7 @@ def test_header_layout():
     # Header is the first 16 bytes:
     assert payload[0:4] == MAGIC
     assert struct.unpack_from("<H", payload, 4)[0] == FORMAT_VERSION
-    assert FORMAT_VERSION == 2  # Reminder: bump triggers reader update
+    assert FORMAT_VERSION == 3  # Reminder: bump triggers reader update
     assert struct.unpack_from("<H", payload, 6)[0] == 0  # flags reserved
     assert struct.unpack_from("<d", payload, 8)[0] == pytest.approx(0.0001)
 
@@ -191,8 +196,8 @@ def test_node_table_layout():
         cursor += NODE_RECORD_SIZE
 
 
-def test_edge_table_records_are_44_bytes():
-    """Edge record shrank to 44 bytes in v2 — the six legacy factor fields were removed."""
+def test_edge_table_records_are_48_bytes():
+    """Edge record shrank to 44 bytes in v2 and grew to 48 in v3."""
     strings, nodes, edges, geoms = _make_simple_writes()
     payload = _write_to_bytes(strings, nodes, edges, geoms)
 
@@ -216,6 +221,7 @@ def test_edge_table_records_are_44_bytes():
         physical = struct.unpack_from("<f", record, 32)[0]
         intersection = struct.unpack_from("<f", record, 36)[0]
         crash = struct.unpack_from("<f", record, 40)[0]
+        elevation = struct.unpack_from("<f", record, 44)[0]
 
         assert padding == b"\x00\x00\x00", "edge padding must be zero"
         assert flags & 0b1111_1110 == 0, "reserved edge flag bits must be zero"
@@ -230,6 +236,7 @@ def test_edge_table_records_are_44_bytes():
         assert physical == pytest.approx(expected.physical_cost, rel=1e-5)
         assert intersection == pytest.approx(expected.intersection_cost, rel=1e-5)
         assert crash == pytest.approx(expected.crash_cost, rel=1e-5)
+        assert elevation == pytest.approx(expected.elevation_cost, rel=1e-5)
         cursor += EDGE_RECORD_SIZE
 
 

--- a/platform/tests/raster/tast_wkb.py
+++ b/platform/tests/raster/tast_wkb.py
@@ -1,0 +1,196 @@
+"""
+Unit tests for loci.raster.wkb.to_hexwkb.
+
+These are pure and offline: we serialize, then decode the bytes back and
+assert the structure and pixels round-trip. The decoder lives only in the
+test — it is deliberately independent of the serializer so a bug in one
+can't hide a bug in the other.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import numpy as np
+import pytest
+from loci.raster.wkb import to_hexwkb
+
+
+def decode(hexwkb: str) -> dict:
+    """Minimal independent decoder for the single-band 32BF layout."""
+    b = bytes.fromhex(hexwkb)
+    off = 0
+    (endian,) = struct.unpack_from("<B", b, off)
+    off += 1
+    (version,) = struct.unpack_from("<H", b, off)
+    off += 2
+    (nbands,) = struct.unpack_from("<H", b, off)
+    off += 2
+    sx, sy, ipx, ipy, skx, sky = struct.unpack_from("<dddddd", b, off)
+    off += 48
+    (srid,) = struct.unpack_from("<i", b, off)
+    off += 4
+    (w,) = struct.unpack_from("<H", b, off)
+    off += 2
+    (h,) = struct.unpack_from("<H", b, off)
+    off += 2
+    (band_header,) = struct.unpack_from("<B", b, off)
+    off += 1
+    (nodata,) = struct.unpack_from("<f", b, off)
+    off += 4
+    pixels = np.frombuffer(b, dtype="<f4", count=w * h, offset=off).reshape(h, w)
+    consumed = off + w * h * 4
+    return dict(
+        endian=endian,
+        version=version,
+        nbands=nbands,
+        scale_x=sx,
+        scale_y=sy,
+        ip_x=ipx,
+        ip_y=ipy,
+        skew_x=skx,
+        skew_y=sky,
+        srid=srid,
+        width=w,
+        height=h,
+        pixtype=band_header & 0x0F,
+        has_nodata=bool(band_header & 0x40),
+        nodata=nodata,
+        pixels=pixels,
+        consumed=consumed,
+        total=len(b),
+    )
+
+
+def _grid(h: int, w: int) -> np.ndarray:
+    return np.arange(h * w, dtype=np.float32).reshape(h, w)
+
+
+def test_header_fields_round_trip():
+    d = decode(
+        to_hexwkb(
+            _grid(3, 5),
+            scale_x=10.0,
+            scale_y=-10.0,
+            ip_x=440000.0,
+            ip_y=4640000.0,
+            srid=4269,
+            nodata=-9999.0,
+        )
+    )
+    assert d["endian"] == 1  # NDR / little-endian
+    assert d["version"] == 0
+    assert d["nbands"] == 1
+    assert d["pixtype"] == 10  # PT_32BF
+    assert (d["width"], d["height"]) == (5, 3)
+    assert (d["scale_x"], d["scale_y"]) == (10.0, -10.0)
+    assert (d["ip_x"], d["ip_y"]) == (440000.0, 4640000.0)
+    assert d["srid"] == 4269
+
+
+def test_pixels_round_trip_exactly():
+    arr = _grid(7, 11)
+    d = decode(
+        to_hexwkb(arr, scale_x=1.0, scale_y=-1.0, ip_x=0.0, ip_y=0.0, srid=4326, nodata=None)
+    )
+    assert np.array_equal(d["pixels"], arr)
+
+
+def test_no_trailing_or_missing_bytes():
+    d = decode(
+        to_hexwkb(
+            _grid(13, 9), scale_x=1.0, scale_y=-1.0, ip_x=0.0, ip_y=0.0, srid=4326, nodata=0.0
+        )
+    )
+    assert d["consumed"] == d["total"]
+
+
+def test_nodata_flag_set_when_given():
+    d = decode(
+        to_hexwkb(
+            _grid(2, 2), scale_x=1.0, scale_y=-1.0, ip_x=0.0, ip_y=0.0, srid=4326, nodata=-9999.0
+        )
+    )
+    assert d["has_nodata"] is True
+    assert d["nodata"] == -9999.0
+
+
+def test_nodata_flag_clear_when_none():
+    d = decode(
+        to_hexwkb(
+            _grid(2, 2), scale_x=1.0, scale_y=-1.0, ip_x=0.0, ip_y=0.0, srid=4326, nodata=None
+        )
+    )
+    assert d["has_nodata"] is False
+
+
+def test_skew_terms_preserved():
+    d = decode(
+        to_hexwkb(
+            _grid(2, 2),
+            scale_x=1.0,
+            scale_y=-1.0,
+            ip_x=0.0,
+            ip_y=0.0,
+            srid=4326,
+            nodata=None,
+            skew_x=0.5,
+            skew_y=-0.25,
+        )
+    )
+    assert d["skew_x"] == 0.5
+    assert d["skew_y"] == -0.25
+
+
+def test_non_square_dims_are_width_then_height():
+    # A 2-row, 4-col tile must decode as width=4, height=2 (not transposed).
+    d = decode(
+        to_hexwkb(
+            _grid(2, 4), scale_x=1.0, scale_y=-1.0, ip_x=0.0, ip_y=0.0, srid=4326, nodata=None
+        )
+    )
+    assert (d["width"], d["height"]) == (4, 2)
+
+
+def test_integer_input_is_cast_to_float32():
+    arr = np.array([[1, 2], [3, 4]], dtype=np.int16)
+    d = decode(
+        to_hexwkb(arr, scale_x=1.0, scale_y=-1.0, ip_x=0.0, ip_y=0.0, srid=4326, nodata=None)
+    )
+    assert np.array_equal(d["pixels"], arr.astype(np.float32))
+
+
+def test_large_elevation_values_keep_float32_precision():
+    # Realistic elevations (and a deep nodata) survive the float32 round-trip.
+    arr = np.array([[4421.0, -86.0], [1609.34, 0.0]], dtype=np.float32)
+    d = decode(
+        to_hexwkb(arr, scale_x=1.0, scale_y=-1.0, ip_x=0.0, ip_y=0.0, srid=4326, nodata=-999999.0)
+    )
+    assert np.array_equal(d["pixels"], arr)
+    assert d["nodata"] == -999999.0
+
+
+def test_rejects_non_2d():
+    with pytest.raises(ValueError, match="2D"):
+        to_hexwkb(
+            np.zeros((2, 2, 1), dtype=np.float32),
+            scale_x=1.0,
+            scale_y=-1.0,
+            ip_x=0.0,
+            ip_y=0.0,
+            srid=4326,
+            nodata=None,
+        )
+
+
+def test_rejects_oversize_dimension():
+    with pytest.raises(ValueError, match="65535"):
+        to_hexwkb(
+            np.zeros((1, 70000), dtype=np.float32),
+            scale_x=1.0,
+            scale_y=-1.0,
+            ip_x=0.0,
+            ip_y=0.0,
+            srid=4326,
+            nodata=None,
+        )

--- a/platform/tests/raster/test_ingest.py
+++ b/platform/tests/raster/test_ingest.py
@@ -1,0 +1,281 @@
+"""
+Unit tests for loci.raster.ingest.
+
+Tiling and row/DDL building are exercised against a synthetic GeoTIFF
+written to a tmp path. The staged_ingest orchestration is exercised with
+a stub engine, so these stay offline — no PostGIS required. The live
+COPY/ST_Value behavior is covered in test_raster_postgis.py.
+"""
+
+from __future__ import annotations
+
+import re
+import struct
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
+import numpy as np
+import pytest
+import rasterio
+from loci.raster.ingest import (
+    HASH_EXCLUDE_COLUMNS,
+    ingest_raster_file,
+    iter_tiles,
+    raster_table_ddl,
+    tile_to_row,
+)
+from rasterio.transform import from_origin
+
+# Synthetic DEM geometry: 600 rows x 500 cols, 10 m, north-up, NAD83.
+WIDTH, HEIGHT = 500, 600
+ORIGIN_X, ORIGIN_Y, RES = 440000.0, 4640000.0, 10.0
+NODATA = -9999.0
+SRID = 4269
+
+
+@pytest.fixture
+def dem_path(tmp_path):
+    arr = np.arange(HEIGHT * WIDTH, dtype=np.float32).reshape(HEIGHT, WIDTH)
+    arr[5, 7] = NODATA
+    path = tmp_path / "synthetic.tif"
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=HEIGHT,
+        width=WIDTH,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4269",
+        transform=from_origin(ORIGIN_X, ORIGIN_Y, RES, RES),
+        nodata=NODATA,
+    ) as dst:
+        dst.write(arr, 1)
+    return str(path), arr
+
+
+def _decode_tile(hexwkb):
+    """Pull (pixels, scale_x, scale_y, ip_x, ip_y, srid) from a tile's WKB."""
+    b = bytes.fromhex(hexwkb)
+    sx, sy, ipx, ipy, _skx, _sky = struct.unpack_from("<dddddd", b, 5)
+    (srid,) = struct.unpack_from("<i", b, 53)
+    (w,) = struct.unpack_from("<H", b, 57)
+    (h,) = struct.unpack_from("<H", b, 59)
+    px = np.frombuffer(b, dtype="<f4", count=w * h, offset=66).reshape(h, w)
+    return px, sx, sy, ipx, ipy, srid
+
+
+def _offsets(tile_id):
+    row_off, col_off = (int(x) for x in tile_id.split("/")[1].split("_"))
+    return row_off, col_off
+
+
+# --------------------------------------------------------------------------
+# Tiling
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tile_size", [64, 128, 256, 512])
+def test_tiles_cover_raster_with_exact_reconstruction(dem_path, tile_size):
+    path, orig = dem_path
+    recon = np.full((HEIGHT, WIDTH), np.nan, dtype=np.float32)
+    for t in iter_tiles(path, source_id="testcity", tile_size=tile_size):
+        px, *_ = _decode_tile(t.rast_hexwkb)
+        r, c = _offsets(t.tile_id)
+        h, w = px.shape
+        # No overlap: this region hasn't been written yet.
+        assert np.isnan(recon[r : r + h, c : c + w]).all()
+        recon[r : r + h, c : c + w] = px
+    assert not np.isnan(recon).any(), "gap in coverage"
+    assert np.array_equal(recon, orig)
+
+
+def test_tile_count_matches_grid(dem_path):
+    path, _ = dem_path
+    n = len(list(iter_tiles(path, source_id="c", tile_size=256)))
+    cols = -(-WIDTH // 256)  # ceil
+    rows = -(-HEIGHT // 256)
+    assert n == cols * rows == 6
+
+
+def test_per_tile_georeference_matches_global_transform(dem_path):
+    path, _ = dem_path
+    for t in iter_tiles(path, source_id="c", tile_size=256):
+        _, sx, sy, ipx, ipy, srid = _decode_tile(t.rast_hexwkb)
+        r, c = _offsets(t.tile_id)
+        assert sx == RES and sy == -RES
+        assert ipx == pytest.approx(ORIGIN_X + c * RES)
+        assert ipy == pytest.approx(ORIGIN_Y - r * RES)
+        assert srid == SRID
+
+
+def test_edge_tiles_are_smaller(dem_path):
+    path, _ = dem_path
+    sizes = {}
+    for t in iter_tiles(path, source_id="c", tile_size=256):
+        px, *_ = _decode_tile(t.rast_hexwkb)
+        sizes[_offsets(t.tile_id)] = px.shape
+    # 500 wide -> last column tile is 500-256-256 = ... cols at 0,256 -> widths 256,244
+    assert sizes[(0, 0)] == (256, 256)
+    assert sizes[(0, 256)] == (256, 244)  # right edge
+    assert sizes[(512, 0)] == (88, 256)  # bottom edge (600-512)
+    assert sizes[(512, 256)] == (88, 244)  # corner
+
+
+def test_tile_bounds_bracket_the_tile(dem_path):
+    path, _ = dem_path
+    for t in iter_tiles(path, source_id="c", tile_size=256):
+        assert t.min_x < t.max_x
+        assert t.min_y < t.max_y
+
+
+# --------------------------------------------------------------------------
+# Checksum (the SCD2 change signal)
+# --------------------------------------------------------------------------
+
+
+def test_checksums_are_stable_across_reads(dem_path):
+    path, _ = dem_path
+    a = [t.checksum for t in iter_tiles(path, source_id="c", tile_size=256)]
+    b = [t.checksum for t in iter_tiles(path, source_id="c", tile_size=256)]
+    assert a == b
+
+
+def test_checksum_changes_when_a_pixel_changes(tmp_path):
+    def write(value):
+        arr = np.zeros((10, 10), dtype=np.float32)
+        arr[0, 0] = value
+        p = tmp_path / f"d{value}.tif"
+        with rasterio.open(
+            p,
+            "w",
+            driver="GTiff",
+            height=10,
+            width=10,
+            count=1,
+            dtype="float32",
+            crs="EPSG:4269",
+            transform=from_origin(0, 100, 10, 10),
+        ) as d:
+            d.write(arr, 1)
+        return next(iter_tiles(str(p), source_id="c")).checksum
+
+    assert write(1.0) != write(2.0)
+
+
+# --------------------------------------------------------------------------
+# Row schema vs DDL  (guards against drift between the two)
+# --------------------------------------------------------------------------
+
+DB_MANAGED = {"record_hash", "valid_from", "valid_to"}
+
+
+def test_row_keys_match_ddl_data_columns(dem_path):
+    path, _ = dem_path
+    tile = next(iter_tiles(path, source_id="c", tile_size=256))
+    row = tile_to_row(tile, ingested_at=datetime.now(UTC))
+
+    ddl = raster_table_ddl("raw_data", "c_elevation", SRID)
+    # Column names are the first quoted token on each definition line.
+    ddl_cols = set(re.findall(r'^\s*"([a-z_]+)"', ddl, flags=re.MULTILINE))
+    data_cols = ddl_cols - DB_MANAGED
+
+    assert set(row.keys()) == data_cols
+
+
+def test_ddl_has_raster_column_and_convex_hull_index():
+    ddl = raster_table_ddl("raw_data", "toronto_elevation", 3979)
+    assert '"rast" raster not null' in ddl
+    assert "using gist (ST_ConvexHull(rast))" in ddl
+    assert 'unique ("tile_id", "record_hash")' in ddl
+    assert 'where "valid_to" is null' in ddl
+
+
+# --------------------------------------------------------------------------
+# Orchestration  (stub engine — verifies SCD2 wiring without a database)
+# --------------------------------------------------------------------------
+
+
+class _StubStager:
+    def __init__(self, **kw):
+        self.kw = kw
+        self.batch_sizes = []
+        self.rows_staged = 0
+        self.rows_merged = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.rows_merged = self.rows_staged
+        return False
+
+    def write_batch(self, rows):
+        self.batch_sizes.append(len(rows))
+        self.rows_staged += len(rows)
+
+
+class _StubEngine:
+    def __init__(self):
+        self.last = None
+
+    @contextmanager
+    def staged_ingest(self, **kw):
+        self.last = _StubStager(**kw)
+        yield self.last
+
+
+def test_ingest_passes_scd2_config(dem_path):
+    path, _ = dem_path
+    eng = _StubEngine()
+    ingest_raster_file(
+        eng,
+        path,
+        source_id="c",
+        target_schema="raw_data",
+        target_table="c_elevation",
+        ingested_at=datetime.now(UTC),
+    )
+    assert eng.last.kw["entity_key"] == ["tile_id"]
+    assert eng.last.kw["hash_exclude_columns"] == HASH_EXCLUDE_COLUMNS
+    assert "rast" in eng.last.kw["hash_exclude_columns"]
+
+
+def test_ingest_batches_and_counts(dem_path):
+    path, _ = dem_path
+    eng = _StubEngine()
+    summary = ingest_raster_file(
+        eng,
+        path,
+        source_id="c",
+        target_schema="raw_data",
+        target_table="c_elevation",
+        ingested_at=datetime.now(UTC),
+        tile_size=256,
+        batch_size=4,
+    )
+    assert summary["tiles_read"] == 6
+    assert summary["rows_staged"] == 6
+    assert eng.last.batch_sizes == [4, 2]  # 6 tiles, batch of 4
+
+
+# --------------------------------------------------------------------------
+# CRS error paths
+# --------------------------------------------------------------------------
+
+
+def test_missing_crs_raises(tmp_path):
+    p = tmp_path / "nocrs.tif"
+    with rasterio.open(
+        p,
+        "w",
+        driver="GTiff",
+        height=4,
+        width=4,
+        count=1,
+        dtype="float32",
+        transform=from_origin(0, 10, 1, 1),
+    ) as d:
+        d.write(np.zeros((4, 4), dtype="float32"), 1)
+    with pytest.raises(ValueError, match="no CRS"):
+        list(iter_tiles(str(p), source_id="c"))

--- a/platform/tests/raster/test_postgis.py
+++ b/platform/tests/raster/test_postgis.py
@@ -1,0 +1,235 @@
+"""
+Integration smoke test for raster ingestion against a real PostGIS.
+
+This is the test that de-risks the two things the offline suite can't:
+  1. that COPY of the hex-WKB into a `raster` column parses cleanly
+     (i.e. StagedIngest can carry a raster the way it carries geometry),
+  2. that the stored tiles answer ST_Value at known coordinates with the
+     right elevations, including NULL at nodata pixels.
+It also checks the SCD2 behavior: a re-run is a no-op, and changing a
+tile creates a new version while closing the old one.
+
+It is SKIPPED unless a database is configured. Point it at a dev/test
+PostGIS that has the postgis and postgis_raster extensions available:
+
+    export DWH_TEST_PGHOST=localhost
+    export DWH_TEST_PGPORT=5432
+    export DWH_TEST_PGDB=loci_test
+    export DWH_TEST_PGUSER=postgres
+    export DWH_TEST_PGPASSWORD=postgres
+    pytest test_raster_postgis.py -v
+
+The test creates and drops its own table, so it won't touch your data.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import numpy as np
+import pytest
+import rasterio
+from loci.raster.ingest import ingest_raster_file, raster_table_ddl
+from rasterio.transform import from_origin
+
+# Small synthetic DEM: 300x300 at 10 m, north-up, NAD83. Pixel (r,c) holds
+# value r*WIDTH + c, so any sampled elevation is predictable. One nodata.
+WIDTH = HEIGHT = 300
+ORIGIN_X, ORIGIN_Y, RES = 440000.0, 4640000.0, 10.0
+NODATA = -9999.0
+SRID = 4269
+NODATA_RC = (40, 70)
+
+SCHEMA = "public"
+TABLE = "_raster_ingest_smoketest"
+
+
+def _env_creds():
+    host = os.environ.get("DWH_TEST_PGHOST")
+    if not host:
+        return None
+
+    @dataclass
+    class Creds:
+        host: str
+        port: int
+        database: str
+        username: str
+        password: str
+
+    return Creds(
+        host=host,
+        port=int(os.environ.get("DWH_TEST_PGPORT", "5432")),
+        database=os.environ.get("DWH_TEST_PGDB", "postgres"),
+        username=os.environ.get("DWH_TEST_PGUSER", "postgres"),
+        password=os.environ.get("DWH_TEST_PGPASSWORD", ""),
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    _env_creds() is None,
+    reason="set DWH_TEST_PGHOST (and friends) to run the PostGIS integration test",
+)
+
+
+def _make_dem(path, *, mutate_pixel=None):
+    arr = np.arange(HEIGHT * WIDTH, dtype=np.float32).reshape(HEIGHT, WIDTH)
+    arr[NODATA_RC] = NODATA
+    if mutate_pixel is not None:
+        (r, c), v = mutate_pixel
+        arr[r, c] = v
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=HEIGHT,
+        width=WIDTH,
+        count=1,
+        dtype="float32",
+        crs=f"EPSG:{SRID}",
+        transform=from_origin(ORIGIN_X, ORIGIN_Y, RES, RES),
+        nodata=NODATA,
+    ) as dst:
+        dst.write(arr, 1)
+    return arr
+
+
+def _pixel_center(r, c):
+    """World (x, y) at the center of pixel (row, col) for a north-up raster."""
+    x = ORIGIN_X + (c + 0.5) * RES
+    y = ORIGIN_Y - (r + 0.5) * RES
+    return x, y
+
+
+def _sample(engine, x, y):
+    """ST_Value at a point, via the convex-hull index join. Returns float|None."""
+    df = engine.query(
+        f"""
+        select ST_Value(r.rast, ST_SetSRID(ST_Point(%(x)s, %(y)s), %(srid)s)) as elev
+        from {SCHEMA}.{TABLE} r
+        where r."valid_to" is null
+          and ST_Intersects(r.rast, ST_SetSRID(ST_Point(%(x)s, %(y)s), %(srid)s))
+        """,
+        {"x": x, "y": y, "srid": SRID},
+    )
+    if df.empty:
+        return None
+    return df.iloc[0]["elev"]
+
+
+@pytest.fixture
+def engine():
+    from loci.db.core import PostgresEngine  # platform import
+
+    eng = PostgresEngine(creds=_env_creds())
+    # eng.execute("create extension if not exists postgis;")
+    # eng.execute("create extension if not exists postgis_raster;")
+    eng.execute(f"drop table if exists {SCHEMA}.{TABLE};")
+    eng.execute(raster_table_ddl(SCHEMA, TABLE, SRID))
+    try:
+        yield eng
+    finally:
+        eng.execute(f"drop table if exists {SCHEMA}.{TABLE};")
+        eng.close()
+
+
+def _current_count(engine):
+    df = engine.query(f'select count(*) as n from {SCHEMA}.{TABLE} where "valid_to" is null')
+    return int(df.iloc[0]["n"])
+
+
+def test_copy_parse_and_value_sampling(engine, tmp_path):
+    """The core smoke test: ingest parses, and ST_Value returns the right values."""
+    path = str(tmp_path / "dem.tif")
+    arr = _make_dem(path)
+
+    summary = ingest_raster_file(
+        engine,
+        path,
+        source_id="smoke",
+        target_schema=SCHEMA,
+        target_table=TABLE,
+        ingested_at=datetime.now(UTC),
+        tile_size=256,
+    )
+    assert summary["rows_merged"] == summary["tiles_read"] > 0
+
+    # Sample several known pixels (including across tile boundaries).
+    for r, c in [(0, 0), (10, 10), (255, 255), (256, 256), (299, 299)]:
+        x, y = _pixel_center(r, c)
+        got = _sample(engine, x, y)
+        assert got == pytest.approx(float(arr[r, c])), f"pixel ({r},{c})"
+
+
+def test_nodata_samples_as_null(engine, tmp_path):
+    path = str(tmp_path / "dem.tif")
+    _make_dem(path)
+    ingest_raster_file(
+        engine,
+        path,
+        source_id="smoke",
+        target_schema=SCHEMA,
+        target_table=TABLE,
+        ingested_at=datetime.now(UTC),
+    )
+    x, y = _pixel_center(*NODATA_RC)
+    assert _sample(engine, x, y) is None
+
+
+def test_reingest_is_a_noop(engine, tmp_path):
+    path = str(tmp_path / "dem.tif")
+    _make_dem(path)
+    first = ingest_raster_file(
+        engine,
+        path,
+        source_id="smoke",
+        target_schema=SCHEMA,
+        target_table=TABLE,
+        ingested_at=datetime.now(UTC),
+    )
+    second = ingest_raster_file(
+        engine,
+        path,
+        source_id="smoke",
+        target_schema=SCHEMA,
+        target_table=TABLE,
+        ingested_at=datetime.now(UTC),
+    )
+    assert first["rows_merged"] > 0
+    assert second["rows_merged"] == 0  # all tiles deduped on unchanged checksum
+    assert _current_count(engine) == first["tiles_read"]
+
+
+def test_changed_tile_creates_new_version(engine, tmp_path):
+    path = str(tmp_path / "dem.tif")
+    _make_dem(path)
+    first = ingest_raster_file(
+        engine,
+        path,
+        source_id="smoke",
+        target_schema=SCHEMA,
+        target_table=TABLE,
+        ingested_at=datetime.now(UTC),
+    )
+
+    # Change one pixel in the top-left tile and re-ingest.
+    _make_dem(path, mutate_pixel=((1, 1), 12345.0))
+    second = ingest_raster_file(
+        engine,
+        path,
+        source_id="smoke",
+        target_schema=SCHEMA,
+        target_table=TABLE,
+        ingested_at=datetime.now(UTC),
+    )
+
+    assert second["rows_merged"] == 1  # exactly the one changed tile
+    assert _current_count(engine) == first["tiles_read"]  # still one current per tile
+
+    # The new value is what ST_Value now returns; total row count grew by one.
+    x, y = _pixel_center(1, 1)
+    assert _sample(engine, x, y) == pytest.approx(12345.0)
+    total = engine.query(f"select count(*) as n from {SCHEMA}.{TABLE}").iloc[0]["n"]
+    assert int(total) == first["tiles_read"] + 1

--- a/platform/tests/tasks/testing/test_route_tests.py
+++ b/platform/tests/tasks/testing/test_route_tests.py
@@ -1,0 +1,424 @@
+"""Behavior tests for the route quality test framework (loci.tasks.testing.route_tests).
+
+Design intent — these tests are written to survive a complete rewrite of the
+framework's internals. They exercise only the stable contract:
+
+  Inputs:
+    - RouteTestCase objects (name, origin, destination, must_use, must_avoid,
+      max_cost, must_cross, must_not_cross).
+    - Gate objects (two (lat, lon) endpoints).
+    - The route geometry/metadata the routing CLI returns.
+
+  Outputs:
+    - run_route_tests(...) returns a list of per-case results (each exposing
+      .case_name and .passed) when every case passes.
+    - run_route_tests(...) raises RuntimeError when any case fails (this is how
+      the Airflow task is made to fail), and the failing case's name appears in
+      the error.
+    - Gate(...) raises ValueError on invalid endpoints.
+
+What these tests deliberately do NOT touch:
+    - The intersection algorithm (parametric, orientation, shapely — doesn't
+      matter). Geometric behavior is asserted only through must_cross /
+      must_not_cross outcomes.
+    - Any private helper name or signature.
+    - Exact wording of failure messages (only that a failure is surfaced and
+      attributed to the right case).
+
+The single external dependency — the routing-cli subprocess — is mocked. The
+mock honors the documented CLI protocol (JSONL in, one JSONL result line per
+case, echoing request.name, with a status and a result object). Tests that
+encode that subprocess protocol specifically are grouped at the bottom and
+labeled; if routing ever moves in-process, only that group needs revisiting.
+
+If the package import path differs in your test setup, adjust the import below.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+from loci.tasks.testing import route_tests
+
+LOG = logging.getLogger("route_tests_under_test")
+
+
+# ---------------------------------------------------------------------------
+# Geometry fixtures for the canonical route
+#
+# The canonical route runs due east along latitude 37.770, from longitude
+# -122.430 to -122.410, as two named segments. Route coordinates are (lon, lat)
+# per the graph format; Gate endpoints are (lat, lon) per RouteTestCase
+# convention. Gates below are positioned so their cross/no-cross outcome is
+# unambiguous and independent of floating-point edge effects.
+# ---------------------------------------------------------------------------
+
+CANONICAL_ROUTE_SEGMENTS = [
+    {"name": "Market Street", "coordinates": [[-122.430, 37.770], [-122.420, 37.770]]},
+    {"name": "Valencia Street", "coordinates": [[-122.420, 37.770], [-122.410, 37.770]]},
+]
+
+# Vertical line at lon -122.415 spanning the route's latitude — clean transversal crossing.
+GATE_CROSSES = ((37.768, -122.415), (37.772, -122.415))
+# Parallel to the route, well to the north — never crossed.
+GATE_PARALLEL_NORTH = ((37.780, -122.430), (37.780, -122.410))
+# Vertical line west of the route's start — never reached.
+GATE_WEST_OF_START = ((37.768, -122.440), (37.772, -122.440))
+# Vertical line exactly through the shared vertex between the two segments —
+# the route only grazes its endpoint, which is NOT a transversal crossing.
+GATE_THROUGH_VERTEX = ((37.768, -122.420), (37.772, -122.420))
+# Collinear with the route line (same latitude, overlapping longitudes).
+GATE_COLLINEAR = ((37.770, -122.425), (37.770, -122.415))
+
+
+# ---------------------------------------------------------------------------
+# CLI mock + harness
+# ---------------------------------------------------------------------------
+
+
+def _ok(segments=None, total_cost=300.0):
+    """A successful CLI payload for one case."""
+    return {
+        "status": "ok",
+        "result": {
+            "segments": segments if segments is not None else CANONICAL_ROUTE_SEGMENTS,
+            "total_cost": total_cost,
+        },
+    }
+
+
+def _no_route():
+    return {"status": "no_route"}
+
+
+def _fake_cli(payloads, returncode=0, stderr=""):
+    """Build a stand-in for subprocess.run that speaks the CLI's JSONL protocol.
+
+    Reads the JSONL request payload from `input`, and for each request emits one
+    result line, echoing request.name and attaching the canned payload for that
+    name. This mirrors the real CLI's 1:1, order-preserving, name-echoing
+    contract without invoking any binary.
+    """
+
+    # def _run(cmd, **kwargs):
+    #     out_lines = []
+    #     for raw in (kwargs.get("input") or "").splitlines():
+    #         raw = raw.strip()
+    #         if not raw:
+    #             continue
+    #         name = json.loads(raw)["name"]
+    #         payload = dict(payloads[name])
+    #         payload["request"] = {"name": name}
+    #         out_lines.append(json.dumps(payload))
+    #     stdout = "\n".join(out_lines) + ("\n" if out_lines else "")
+    #     return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    def _run(cmd, **kwargs):
+        out_lines = []
+        raw_input = kwargs.get("input") or ""
+        for raw in raw_input.splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            name = json.loads(raw)["name"]
+            if name not in payloads:
+                raise AssertionError(
+                    f"fake CLI has no payload for case {name!r}; known: {sorted(payloads)}"
+                )
+            payload = dict(payloads[name])
+            payload["request"] = {"name": name}
+            out_lines.append(json.dumps(payload))
+        stdout = "\n".join(out_lines) + ("\n" if out_lines else "")
+        return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    return _run
+
+
+@pytest.fixture
+def harness(monkeypatch, tmp_path):
+    """Return a `run(cases, payloads, **cli_kwargs)` callable.
+
+    Sets up an existing CLI path and graph file (so existence checks pass) and
+    patches the subprocess boundary. Everything else is the real framework.
+    """
+    cli = tmp_path / "routing-cli"
+    cli.write_text("")  # exists -> is_file() is True
+    graph = tmp_path / "graph.bin.gz"
+    graph.write_text("")
+
+    monkeypatch.setattr(route_tests, "ROUTING_CLI_PATH", cli)
+
+    def run(cases, payloads=None, **cli_kwargs):
+        payloads = payloads if payloads is not None else {c.name: _ok() for c in cases}
+        monkeypatch.setattr(route_tests.subprocess, "run", _fake_cli(payloads, **cli_kwargs))
+        return route_tests.run_route_tests(str(graph), cases, logger=LOG)
+
+    return run
+
+
+def case(
+    name="case",
+    *,
+    must_use=None,
+    must_avoid=None,
+    max_cost=None,
+    must_cross=None,
+    must_not_cross=None,
+):
+    """Build a RouteTestCase with dummy origin/destination (geometry comes from
+    the mocked CLI, so origin/destination are irrelevant to these tests)."""
+    return route_tests.RouteTestCase(
+        name=name,
+        origin=(37.770, -122.430),
+        destination=(37.770, -122.410),
+        must_use=must_use or [],
+        must_avoid=must_avoid or [],
+        max_cost=max_cost,
+        must_cross=must_cross or [],
+        must_not_cross=must_not_cross or [],
+    )
+
+
+def gate(endpoints):
+    return route_tests.Gate(endpoints[0], endpoints[1])
+
+
+def result_for(results, name):
+    return next(r for r in results if r.case_name == name)
+
+
+# ===========================================================================
+# Gate validation (public input type)
+# ===========================================================================
+
+
+def test_gate_accepts_valid_endpoints():
+    g = route_tests.Gate((37.77, -122.42), (37.78, -122.41))
+    assert g is not None
+
+
+def test_gate_rejects_swapped_lat_lon():
+    # (lon, lat) passed where (lat, lon) is expected: -122 is not a valid latitude.
+    with pytest.raises(ValueError):
+        route_tests.Gate((-122.42, 37.77), (-122.41, 37.78))
+
+
+def test_gate_rejects_out_of_range_longitude():
+    with pytest.raises(ValueError):
+        route_tests.Gate((37.77, -200.0), (37.78, -122.41))
+
+
+def test_gate_rejects_zero_length():
+    with pytest.raises(ValueError):
+        route_tests.Gate((37.77, -122.42), (37.77, -122.42))
+
+
+# ===========================================================================
+# Baseline + output contract
+# ===========================================================================
+
+
+def test_case_with_no_assertions_passes(harness):
+    results = harness([case("baseline")])
+    assert result_for(results, "baseline").passed is True
+
+
+def test_all_pass_returns_one_result_per_case(harness):
+    cases = [case("a"), case("b"), case("c")]
+    results = harness(cases)
+    assert {r.case_name for r in results} == {"a", "b", "c"}
+    assert all(r.passed for r in results)
+
+
+def test_empty_test_cases_returns_empty_and_does_not_raise(harness):
+    assert harness([]) == []
+
+
+# ===========================================================================
+# Street-name assertions (must_use / must_avoid)
+# ===========================================================================
+
+
+def test_must_use_passes_when_street_present(harness):
+    results = harness([case("c", must_use=["Valencia"])])
+    assert result_for(results, "c").passed is True
+
+
+def test_must_use_fails_when_street_absent(harness):
+    with pytest.raises(RuntimeError, match="c"):
+        harness([case("c", must_use=["Folsom"])])
+
+
+def test_must_avoid_passes_when_street_absent(harness):
+    results = harness([case("c", must_avoid=["Folsom"])])
+    assert result_for(results, "c").passed is True
+
+
+def test_must_avoid_fails_when_street_present(harness):
+    with pytest.raises(RuntimeError, match="c"):
+        harness([case("c", must_avoid=["Market"])])
+
+
+def test_street_matching_is_case_insensitive_substring(harness):
+    # "valencia" should match "Valencia Street".
+    results = harness([case("c", must_use=["valencia"])])
+    assert result_for(results, "c").passed is True
+
+
+# ===========================================================================
+# max_cost tripwire
+# ===========================================================================
+
+
+def test_max_cost_passes_when_within_bound(harness):
+    results = harness([case("c", max_cost=500.0)], {"c": _ok(total_cost=300.0)})
+    assert result_for(results, "c").passed is True
+
+
+def test_max_cost_fails_when_exceeded(harness):
+    with pytest.raises(RuntimeError, match="c"):
+        harness([case("c", max_cost=100.0)], {"c": _ok(total_cost=300.0)})
+
+
+# ===========================================================================
+# Geometric gate assertions — behavior only, no coupling to the crossing math
+# ===========================================================================
+
+
+def test_must_cross_passes_when_route_crosses_gate(harness):
+    results = harness([case("c", must_cross=[gate(GATE_CROSSES)])])
+    assert result_for(results, "c").passed is True
+
+
+def test_must_cross_fails_when_gate_is_parallel_and_uncrossed(harness):
+    with pytest.raises(RuntimeError, match="c"):
+        harness([case("c", must_cross=[gate(GATE_PARALLEL_NORTH)])])
+
+
+def test_must_cross_fails_when_gate_is_beyond_the_route(harness):
+    with pytest.raises(RuntimeError, match="c"):
+        harness([case("c", must_cross=[gate(GATE_WEST_OF_START)])])
+
+
+def test_must_not_cross_passes_when_route_avoids_gate(harness):
+    results = harness([case("c", must_not_cross=[gate(GATE_PARALLEL_NORTH)])])
+    assert result_for(results, "c").passed is True
+
+
+def test_must_not_cross_fails_when_route_crosses_gate(harness):
+    with pytest.raises(RuntimeError, match="c"):
+        harness([case("c", must_not_cross=[gate(GATE_CROSSES)])])
+
+
+# --- transversal-only semantics (a deliberate design choice, asserted as behavior) ---
+# These encode the decision that a graze (touching an endpoint or running
+# collinear) is NOT a crossing. If that semantic is ever changed on purpose,
+# these are the tests that should change with it.
+
+
+def test_grazing_a_gate_at_a_vertex_is_not_a_crossing(harness):
+    # The route only touches GATE_THROUGH_VERTEX at the shared vertex between
+    # its two segments — not a transversal crossing, so must_cross must fail.
+    with pytest.raises(RuntimeError, match="c"):
+        harness([case("c", must_cross=[gate(GATE_THROUGH_VERTEX)])])
+
+
+def test_running_collinear_with_a_gate_is_not_a_crossing(harness):
+    with pytest.raises(RuntimeError, match="c"):
+        harness([case("c", must_cross=[gate(GATE_COLLINEAR)])])
+
+
+# ===========================================================================
+# Combined / regression-style assertions (the elevation use case)
+# ===========================================================================
+
+
+def test_dodge_pattern_crosses_intended_corridor_and_avoids_the_other(harness):
+    # The shape of a real elevation regression test: require the route to pass
+    # through the intended (flat) corridor AND stay out of the (steep) one.
+    results = harness(
+        [
+            case(
+                "dodge",
+                must_cross=[gate(GATE_CROSSES)],
+                must_not_cross=[gate(GATE_PARALLEL_NORTH)],
+            )
+        ]
+    )
+    assert result_for(results, "dodge").passed is True
+
+
+def test_geometric_and_name_assertions_compose(harness):
+    results = harness(
+        [case("c", must_use=["Valencia"], must_avoid=["Folsom"], must_cross=[gate(GATE_CROSSES)])]
+    )
+    assert result_for(results, "c").passed is True
+
+
+def test_any_failed_assertion_in_a_case_fails_the_case(harness):
+    # must_cross satisfied, but must_avoid violated -> the case fails overall.
+    with pytest.raises(RuntimeError, match="c"):
+        harness([case("c", must_cross=[gate(GATE_CROSSES)], must_avoid=["Market"])])
+
+
+# ===========================================================================
+# Multi-case failure attribution
+# ===========================================================================
+
+
+def test_one_failing_case_among_passing_ones_raises_and_names_the_failure(harness):
+    cases = [
+        case("good_a"),
+        case("bad_one", must_use=["Nonexistent Ave"]),
+        case("good_b"),
+    ]
+    with pytest.raises(RuntimeError) as exc:
+        harness(cases)
+    # Behavior: the failing case is identifiable; we don't assert exact wording.
+    assert "bad_one" in str(exc.value)
+
+
+# ===========================================================================
+# Route-level status handling
+# ===========================================================================
+
+
+def test_no_route_status_is_a_failure(harness):
+    with pytest.raises(RuntimeError, match="c"):
+        harness([case("c")], {"c": _no_route()})
+
+
+# ===========================================================================
+# CLI subprocess-protocol boundary
+#
+# These encode the contract with the external routing-cli process specifically
+# (exit codes, 1:1 line correspondence). They are the only tests tied to the
+# subprocess mechanism; if routing ever moves in-process, revisit just these.
+# ===========================================================================
+
+
+def test_unexpected_cli_exit_code_is_a_runner_error(harness):
+    # Exit codes other than 0 / 5 mean the CLI itself failed, which is a runner
+    # error (RuntimeError), distinct from a route test failing its assertions.
+    with pytest.raises(RuntimeError):
+        harness([case("c")], returncode=2)
+
+
+def test_cli_result_count_mismatch_is_a_runner_error(monkeypatch, tmp_path):
+    cli = tmp_path / "routing-cli"
+    cli.write_text("")
+    graph = tmp_path / "graph.bin.gz"
+    graph.write_text("")
+    monkeypatch.setattr(route_tests, "ROUTING_CLI_PATH", cli)
+
+    # CLI returns zero result lines for one input case -> 1:1 contract violated.
+    def _bad_run(cmd, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(route_tests.subprocess, "run", _bad_run)
+
+    with pytest.raises(RuntimeError):
+        route_tests.run_route_tests(str(graph), [case("c")], logger=LOG)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pendulum>=3.2.0",
     "psycopg2-binary>=2.9.11",
     "pymysql>=1.1.2",
+    "rasterio>=1.5.0",
     "scipy>=1.17.1",
     "shapely>=2.1.2",
     "tenacity>=9.1.4",

--- a/services/routing/docs/graph-format.md
+++ b/services/routing/docs/graph-format.md
@@ -1,9 +1,12 @@
 # Routing graph binary format
 
 This document is the source of truth for the on-disk format consumed by
-`routing-core::format` and produced by the Python `RoutingGraphExporter`
-(chunk 5). Any change to the format requires bumping the version field
-and updating both ends in lockstep.
+`routing-core::format` and produced by the Python `RoutingGraphExporter`.
+Any change to the format requires bumping the version field and updating
+both ends in lockstep: the Rust reader (`services/routing/routing-core/src/format/`)
+and the Python writer (`platform/airflow/dags/loci/exports/graph_format.py`).
+
+The current format version is **3**.
 
 ## File-level conventions
 
@@ -33,7 +36,9 @@ The payload is a strict sequence of sections in this order:
 5. **CSR offsets**
 6. **Segment geometry table**
 
-No padding, no trailers, no index. Sections are read sequentially.
+No padding between sections, no trailers, no index. Sections are read
+sequentially. After the last section the reader confirms there are zero
+bytes remaining and fails if extra trailing data is present.
 
 ### 1. Header — 16 bytes
 
@@ -41,17 +46,23 @@ No padding, no trailers, no index. Sections are read sequentially.
 offset  size  field             value / notes
 ------  ----  ----------------  --------------------------------
    0     4    magic             ASCII "LOCI" (0x4C 0x4F 0x43 0x49)
-   4     2    version           u16 = 1
+   4     2    version           u16 = 3
    6     2    flags             u16 = 0 (reserved)
    8     8    heuristic_floor   f64, cost-per-meter floor for A* heuristic
 ```
 
 The reader MUST verify the magic and version and fail loudly on
-mismatch. `flags` is reserved for future bit flags (e.g. "has CRS
-metadata", "uses extended edge attributes") and MUST be 0 in v1.
+mismatch. A version other than 3 is rejected (the reader understands
+exactly one version). `flags` is reserved for future bit flags and MUST
+be 0; a non-zero value is rejected.
 
 `heuristic_floor` corresponds to `G.graph["heuristic_floor"]` in the
-current Python implementation.
+Python exporter. It is the minimum per-meter edge cost (times a safety
+margin), used to scale the great-circle distance into an admissible A*
+heuristic. It is derived from the per-meter components only
+(`physical_cost + crash_cost`); the per-endpoint intersection cost and
+the elevation cost are deliberately excluded so the heuristic stays a
+true lower bound.
 
 ### 2. String table
 
@@ -60,14 +71,14 @@ elsewhere in the file. Reference values of `u32::MAX` mean "null"
 (no string), not "index into table at position 2^32 - 1".
 
 ```
-offset  size              field            notes
-------  ----------------  ---------------  -----------------------------
-  16     4                count            u32 = N
-  20     variable          entries          N `str` values back to back
+offset  size      field    notes
+------  --------  -------  -----------------------------
+  16     4        count    u32 = N
+  20     variable  entries  N `str` values back to back
 ```
 
 Each entry is a `str`: `[u32 byte_length][UTF-8 bytes]`. No alignment,
-no padding between entries.
+no padding between entries. Invalid UTF-8 is rejected.
 
 Strings stored here include `name`, `highway`, `infra_type`, and
 `segment_id` values for edges and geometries. Empty strings are valid
@@ -77,85 +88,125 @@ the reference, not by a zero-length entry.
 ### 3. Node table
 
 ```
-field           size            notes
---------------  --------------  -----------------------
-count           u32             N = node count
-entries         N × 16 bytes    fixed-size records
+field    size            notes
+-------  --------------  -----------------------
+count    u32             N = node count
+entries  N × 32 bytes    fixed-size records
 ```
 
-Each node record:
+Each node record (32 bytes):
 
 ```
-offset (within record)  size  field      notes
-------                  ----  ---------  --------------------
-   0                    8     osm_id     u64
-   8                    4     lon        f32 (degrees)
-  12                    4     lat        f32 (degrees)
+offset (within record)  size  field             notes
+------                  ----  ----------------  -----------------------------
+   0                    8     osm_id            u64
+   8                    8     lon               f64 (degrees)
+  16                    8     lat               f64 (degrees)
+  24                    1     is_intersection   u8, 0 or 1
+  25                    7     padding           reserved, MUST be zero
 ```
 
 Node order in the file is the canonical `NodeIdx` ordering. The first
 node has `NodeIdx = 0`, the second `NodeIdx = 1`, etc. Edges reference
-nodes by `NodeIdx`, not by `osm_id`. The `osm_id` is stored for
-response composition only.
+nodes by `NodeIdx`, not by `osm_id`. The `osm_id` is stored for response
+composition only.
+
+The record is padded to 32 bytes so each node's f64 fields land at
+8-byte-aligned offsets. The reader rejects an `is_intersection` byte
+other than 0 or 1, and rejects non-zero padding bytes.
+
+`is_intersection` is the authoritative flag for the turn-penalty logic.
+It is set by the data pipeline (a node is a logical intersection iff it
+appears in `<city>_intersection_costs`) and read directly at routing
+time, rather than being re-derived from edge degree. The router uses it
+to decide both whether a left-turn penalty can apply at the node and
+whether to retain turn context in the A* search state.
 
 ### 4. Edge table
 
-Edges are ordered by source `NodeIdx` ascending, then by an
-exporter-internal tiebreak (any stable order is fine). This ordering
-is what makes the CSR offsets section work.
+Edges are ordered by source `NodeIdx` ascending, then by a stable
+exporter-internal tiebreak (parallel edges from the same source keep
+their insertion order). This ordering is what makes the CSR offsets
+section work.
 
 ```
-field           size            notes
---------------  --------------  -----------------------
-count           u32             M = directed edge count
-entries         M × 56 bytes    fixed-size records
+field    size            notes
+-------  --------------  -----------------------
+count    u32             M = directed edge count
+entries  M × 48 bytes    fixed-size records
 ```
 
-Each edge record (56 bytes, aligned to 4):
+Each edge record (48 bytes, aligned to 4):
 
 ```
-offset (within record)  size  field                   notes
-------                  ----  ----------------------  ---------------------------
-   0                    4     target_node_idx         u32
-   4                    4     segment_id_str_idx      u32, never null
-   8                    4     name_str_idx            u32 (null_idx allowed)
-  12                    4     highway_str_idx         u32 (null_idx allowed)
-  16                    4     infra_type_str_idx      u32 (null_idx allowed)
-  20                    1     flags                   u8, bit 0 = forward
-  21                    3     padding                 reserved, MUST be zero
-  24                    4     length_m                f32
-  28                    4     stress_cost             f32
-  32                    4     speed_factor            f32
-  36                    4     road_type_factor        f32
-  40                    4     infrastructure_factor   f32
-  44                    4     tunnel_factor           f32
-  48                    4     surface_factor          f32
-  52                    4     lighting_factor         f32
-  56                    4     physical_cost           f32
-  60                    4     intersection_cost       f32
-  64                    4     crash_cost              f32
+offset (within record)  size  field                notes
+------                  ----  -------------------  ---------------------------
+   0                    4     target_node_idx      u32
+   4                    4     segment_id_str_idx   u32, never null
+   8                    4     name_str_idx         u32 (null_idx allowed)
+  12                    4     highway_str_idx      u32 (null_idx allowed)
+  16                    4     infra_type_str_idx   u32 (null_idx allowed)
+  20                    1     flags                u8, bit 0 = forward
+  21                    3     padding              reserved, MUST be zero
+  24                    4     length_m             f32
+  28                    4     stress_cost          f32
+  32                    4     physical_cost        f32
+  36                    4     intersection_cost    f32
+  40                    4     crash_cost           f32
+  44                    4     elevation_cost       f32
 ```
-
-Wait — that's 68 bytes, not 56. Updating: each edge record is **68 bytes**.
 
 `flags` bit 0 is the `forward` orientation flag (1 = forward, 0 =
-backward), used by the response composer to know whether to reverse
-segment geometry. Bits 1–7 are reserved and MUST be zero in v1.
+backward), used by the response composer to know whether to reverse the
+shared segment geometry. Bits 1–7 are reserved and MUST be zero; the
+reader rejects any reserved bit being set, and rejects non-zero padding
+bytes.
 
-The source node for an edge is implicit in its position; see CSR
-offsets below.
+The source node for an edge is implicit in its position; see CSR offsets
+below.
 
-Nullable f32 fields (`speed_factor`, etc.) where the source value was
-NULL in Postgres are serialized as IEEE 754 NaN (`f32::NAN`). The
-reader exposes these as `Option<f32>` by checking `is_nan()`.
+#### Cost fields
+
+`stress_cost` is the per-direction routing weight A* minimizes. The four
+component fields are its parts, carried for inspection and the
+route-segment popup:
+
+* `physical_cost` — per-segment intrinsic stress (length × base stress
+  plus surface/enclosed/lighting penalties). Direction-independent.
+* `intersection_cost` — the per-endpoint intersection cost that applies
+  for *this edge's traversal direction*: a forward edge carries the cost
+  at its end node, a backward edge the cost at its start node.
+* `crash_cost` — per-segment crash-history cost. Direction-independent.
+  Zero for cities without a crash data source.
+* `elevation_cost` — the directional elevation cost for this edge's
+  traversal direction (uphill or downhill as appropriate). Always
+  present in v3; zero on every edge for cities built without elevation
+  data, and zero for genuinely flat segments.
+
+For a graph produced by the current exporter, `stress_cost` equals
+`physical_cost + intersection_cost + crash_cost + elevation_cost` for
+that edge. The left-turn penalty is applied at routing time (it depends
+on the incoming direction at a junction) and is therefore NOT baked into
+`stress_cost` or stored here; it is reported separately in the route
+response.
+
+A cost `f32` whose source value was NULL is serialized as IEEE 754 NaN.
+In practice the current exporter emits finite values for all six `f32`
+fields: `length_m` and `physical_cost` are guaranteed non-null by the
+exporter's query filter, and `intersection_cost`, `crash_cost`, and
+`elevation_cost` are coalesced to 0 before serialization. The NaN
+convention is retained as the format-level encoding for "missing"; the
+reader reads these fields as raw `f32` and does not special-case NaN, so
+any consumer that could encounter a NaN is responsible for treating it
+as missing.
 
 ### 5. CSR offsets
 
 ```
-field           size            notes
---------------  --------------  -----------------------
-count           u32             K = node_count + 1
-entries         K × 4 bytes     u32 offsets into the edge table
+field    size            notes
+-------  --------------  -----------------------
+count    u32             K = node_count + 1
+entries  K × 4 bytes     u32 offsets into the edge table
 ```
 
 `offsets[i]` is the index of the first edge with `source_node_idx = i`.
@@ -169,55 +220,71 @@ indicates a malformed file.
 ### 6. Segment geometry table
 
 ```
-field           size       notes
---------------  ---------  ----------------------------------
-count           u32        G = number of segments with geometry
-entries         variable   G geometry records
+field    size       notes
+-------  ---------  ----------------------------------
+count    u32        G = number of segments with geometry
+entries  variable   G geometry records
 ```
 
 Each geometry record:
 
 ```
-offset (within record)  size            field                 notes
-------                  ----            -------------------   ------------------
-   0                    4               segment_id_str_idx    u32
-   4                    4               coord_count           u32 = C
-   8                    C × 8           coords                C × [f32 lon, f32 lat]
+offset (within record)  size            field                notes
+------                  ----            -------------------  -----------------------
+   0                    4               segment_id_str_idx   u32, never null
+   4                    4               coord_count          u32 = C
+   8                    C × 16          coords               C × [f64 lon, f64 lat]
 ```
 
-Geometry is keyed by `segment_id_str_idx` matching the same string
-index used on edges. Edges and geometries with the same
-`segment_id_str_idx` share geometry; the edge's `flags.forward` bit
-tells the response composer whether to use the coords as-is or
-reversed.
+Geometry is keyed by `segment_id_str_idx`, matching the same string
+index used on edges. Each coordinate pair is two f64 values (lon, lat),
+16 bytes per coordinate.
 
-Not every segment_id referenced by an edge needs a geometry entry: if
-geometry is missing, the response composer falls back to a straight
-line between the source and target nodes (matching current Python
-behavior in `find_route`).
+Edges and geometries with the same `segment_id_str_idx` share geometry;
+the edge's `flags` forward bit tells the response composer whether to
+use the coords as-is or reversed. Not every segment_id referenced by an
+edge needs a geometry entry: if geometry is missing, the response
+composer falls back to a straight line between the source and target
+nodes.
 
 ## End-of-file
 
-After the last geometry record, the file ends. No trailer, no
-checksum. The reader confirms there are zero bytes remaining and
-fails if extra trailing data is present.
+After the last geometry record, the file ends. No trailer, no checksum.
+The reader confirms there are zero bytes remaining and fails if extra
+trailing data is present.
 
 ## Size estimates
 
-For a Chicago-sized graph (~70k nodes, ~250k directed edges, ~125k
-unique segment geometries with ~5 coords each on average):
+Rough order-of-magnitude figures for a Chicago-sized graph (~70k nodes,
+~250k directed edges, ~125k unique segment geometries with ~5 coords
+each on average). These are estimates from the record sizes, not
+measured values.
 
-| Section          | Bytes        | Notes                              |
-| ---------------- | ------------ | ---------------------------------- |
-| Header           | 16           |                                    |
-| String table     | ~1 MB        | dominated by long unique segment_id values |
-| Node table       | 1.1 MB       | 16 bytes × 70k                     |
-| Edge table       | 17 MB        | 68 bytes × 250k                    |
-| CSR offsets      | 280 KB       | 4 bytes × 70k                      |
-| Segment geometry | 5 MB         | 8 bytes × 5 × 125k                 |
-| **Total raw**    | **~24 MB**   |                                    |
-| Gzipped          | ~7–8 MB      | expected, will measure in chunk 5  |
+| Section          | Bytes        | Notes                                       |
+| ---------------- | ------------ | ------------------------------------------- |
+| Header           | 16           |                                             |
+| String table     | ~1 MB        | dominated by long unique segment_id values  |
+| Node table       | ~2.2 MB      | 32 bytes × 70k                              |
+| Edge table       | ~12 MB       | 48 bytes × 250k                            |
+| CSR offsets      | ~280 KB      | 4 bytes × (70k + 1)                         |
+| Segment geometry | ~11 MB       | (8 + 16 × 5) bytes × 125k                   |
+| **Total raw**    | **~27 MB**   |                                             |
+| Gzipped          | ~8–9 MB      | dominated by string table and coordinates   |
 
 ## Version history
 
-* v1 — initial release.
+* **v1** — initial release. Node coordinates were f32 (16-byte node
+  record). The edge record carried six multiplicative factor fields
+  (speed / road_type / infrastructure / tunnel / surface / lighting)
+  alongside the costs, for a 68-byte record. Segment geometry coords
+  were f32.
+* **v2** — node coordinates promoted to f64, and the node record gained
+  an `is_intersection` u8 flag plus padding to 32 bytes (was 16). The
+  edge record dropped the six legacy multiplicative factor fields in
+  favor of the additive cost model, keeping `physical_cost`,
+  `intersection_cost`, and `crash_cost` — shrinking from 68 to 44 bytes.
+  Segment geometry coordinates promoted from f32 to f64 (8 to 16 bytes
+  per coordinate). Header, string table, and CSR offsets unchanged.
+* **v3** — the edge record gained a fourth cost component,
+  `elevation_cost`, appended after `crash_cost` — growing from 44 to 48
+  bytes. No other section changed.

--- a/services/routing/routing-core/src/astar.rs
+++ b/services/routing/routing-core/src/astar.rs
@@ -191,6 +191,7 @@ mod tests {
             physical_cost: stress,
             intersection_cost: f32::NAN,
             crash_cost: f32::NAN,
+            elevation_cost: f32::NAN,
         }
     }
 

--- a/services/routing/routing-core/src/find_route.rs
+++ b/services/routing/routing-core/src/find_route.rs
@@ -44,6 +44,7 @@ pub struct CostComponents {
     pub physical_cost: f32,
     pub crash_cost: f32,
     pub intersection_cost: f32,
+    pub elevation_cost: f32,
     pub left_turn_penalty: f32,
 }
 
@@ -134,6 +135,7 @@ fn compose_result(g: &IndexedGraph, path: &[u32]) -> Result<RouteResult, FindRou
                 physical_cost: edge.physical_cost,
                 crash_cost: edge.crash_cost,
                 intersection_cost: edge.intersection_cost,
+                elevation_cost: edge.elevation_cost,
                 left_turn_penalty,
             },
         });
@@ -211,6 +213,7 @@ mod tests {
             physical_cost: stress,
             intersection_cost: 0.0,
             crash_cost: 0.0,
+            elevation_cost: 0.0,
         }
     }
 

--- a/services/routing/routing-core/src/format/mod.rs
+++ b/services/routing/routing-core/src/format/mod.rs
@@ -16,9 +16,10 @@ pub use types::{Edge, Graph, GraphFormatError, Node, SegmentGeometry};
 /// Magic bytes at the start of every graph file: b"LOCI".
 pub const MAGIC: [u8; 4] = *b"LOCI";
 
-/// Format version. Bumped to 2 for the f64-coordinate +
+/// Format version. Bumped to 3 to add elevation costs.
+/// Bumped to 2 for the f64-coordinate +
 /// per-node is_intersection layout (was 1 for the f32 layout).
-pub const FORMAT_VERSION: u16 = 2;
+pub const FORMAT_VERSION: u16 = 3;
 
 /// Sentinel string index meaning "no string" (SQL NULL). u32::MAX so it
 /// can never collide with a real index into the string table.

--- a/services/routing/routing-core/src/format/reader/mod.rs
+++ b/services/routing/routing-core/src/format/reader/mod.rs
@@ -193,6 +193,7 @@ fn read_edge(cursor: &mut Cursor<'_>, str_table_len: usize) -> Result<Edge, Grap
         physical_cost: cursor.read_f32("edge.physical_cost")?,
         intersection_cost: cursor.read_f32("edge.intersection_cost")?,
         crash_cost: cursor.read_f32("edge.crash_cost")?,
+        elevation_cost: cursor.read_f32("edge.elevation_cost")?,
     })
 }
 

--- a/services/routing/routing-core/src/format/reader/tests.rs
+++ b/services/routing/routing-core/src/format/reader/tests.rs
@@ -16,7 +16,7 @@ use crate::format::{
 };
 
 const NODE_RECORD_SIZE: usize = 32;
-const EDGE_RECORD_SIZE: usize = 44;
+const EDGE_RECORD_SIZE: usize = 48;
 
 /// Build a minimal valid fixture: 3 nodes, 4 edges, 1 segment geometry.
 ///
@@ -121,6 +121,7 @@ fn build_fixture() -> Vec<u8> {
         b.extend_from_slice(&stress.to_le_bytes()); // physical_cost
         b.extend_from_slice(&0.0f32.to_le_bytes()); // intersection_cost
         b.extend_from_slice(&0.0f32.to_le_bytes()); // crash_cost
+        b.extend_from_slice(&0.0f32.to_le_bytes()); // elevation_cost
     }
 
     // --- CSR offsets ---
@@ -183,6 +184,7 @@ fn reads_valid_fixture() {
     assert_eq!(g.edges[0].length_m, 100.0);
     assert_eq!(g.edges[0].physical_cost, 250.0);
     assert_eq!(g.edges[0].crash_cost, 0.0);
+    assert_eq!(g.edges[0].elevation_cost, 0.0);
 
     // Nullability
     assert_eq!(g.lookup_str(g.edges[0].name_str_idx), Some("Main St"));

--- a/services/routing/routing-core/src/format/types.rs
+++ b/services/routing/routing-core/src/format/types.rs
@@ -41,6 +41,7 @@ pub struct Edge {
     pub physical_cost: f32,
     pub intersection_cost: f32,
     pub crash_cost: f32,
+    pub elevation_cost: f32,
 }
 
 impl Edge {

--- a/services/routing/routing-core/src/kdtree.rs
+++ b/services/routing/routing-core/src/kdtree.rs
@@ -1,3 +1,4 @@
+//! /loci_platform/services/routing/routing-core/src/kdtree.rs
 //! Static 2D KD-tree for nearest-node lookup.
 //!
 //! Built once from a slice of points; queried with `nearest`. Operates

--- a/services/routing/routing-core/src/lib.rs
+++ b/services/routing/routing-core/src/lib.rs
@@ -1,3 +1,4 @@
+//! /loci_platform/services/routing/routing-core/src/lib.rs
 //! routing-core: types and pure routing logic for bike-map.
 //!
 //! Chunks 2-4 added: binary graph format, KD-tree, A*, turn penalties,

--- a/services/routing/routing-core/src/response.rs
+++ b/services/routing/routing-core/src/response.rs
@@ -23,6 +23,7 @@
 //!           "length_m":          f32,
 //!           "physical_cost":     f32,
 //!           "crash_cost":        f32,
+//!           "elevation_cost":    f32,
 //!           "intersection_cost": f32,
 //!           "left_turn_penalty": f32
 //!         }
@@ -73,6 +74,7 @@ fn cost_components_to_json(c: &CostComponents) -> Value {
         "length_m": round_f32(c.length_m, LENGTH_ROUND_DECIMALS),
         "physical_cost": round_f32(c.physical_cost, COST_ROUND_DECIMALS),
         "crash_cost": round_f32(c.crash_cost, COST_ROUND_DECIMALS),
+        "elevation_cost": round_f32(c.elevation_cost, COST_ROUND_DECIMALS),
         "intersection_cost": round_f32(c.intersection_cost, COST_ROUND_DECIMALS),
         "left_turn_penalty": round_f32(c.left_turn_penalty, COST_ROUND_DECIMALS),
     })

--- a/services/routing/routing-core/src/turn_cost.rs
+++ b/services/routing/routing-core/src/turn_cost.rs
@@ -134,6 +134,7 @@ mod tests {
             physical_cost: 100.0,
             intersection_cost: 0.0,
             crash_cost: 0.0,
+            elevation_cost: 0.0,
         }
     }
 

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,15 @@ wheels = [
 ]
 
 [[package]]
+name = "affine"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/98/d2f0bb06385069e799fc7d2870d9e078cfa0fa396dc8a2b81227d0da08b9/affine-2.4.0.tar.gz", hash = "sha256:a24d818d6a836c131976d22f8c27b8d3ca32d0af64c1d8d29deb7bafa4da1eea", size = 17132, upload-time = "2023-01-19T23:44:30.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/f7/85273299ab57117850cc0a936c64151171fac4da49bc6fba0dad984a7c5f/affine-2.4.0-py3-none-any.whl", hash = "sha256:8a3df80e2b2378aef598a83c1392efd47967afec4242021a0b06b4c7cbc61a92", size = 15662, upload-time = "2023-01-19T23:44:28.833Z" },
+]
+
+[[package]]
 name = "agate"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1275,6 +1284,7 @@ dependencies = [
     { name = "pendulum" },
     { name = "psycopg2-binary" },
     { name = "pymysql" },
+    { name = "rasterio" },
     { name = "scipy" },
     { name = "shapely" },
     { name = "tenacity" },
@@ -1300,6 +1310,7 @@ requires-dist = [
     { name = "pendulum", specifier = ">=3.2.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pymysql", specifier = ">=1.1.2" },
+    { name = "rasterio", specifier = ">=1.5.0" },
     { name = "scipy", specifier = ">=1.17.1" },
     { name = "shapely", specifier = ">=2.1.2" },
     { name = "tenacity", specifier = ">=9.1.4" },
@@ -2121,6 +2132,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pyproj"
 version = "3.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2313,6 +2333,47 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/05/10/f42c48fa5153204f42eaa945e8d1fd7c10d6296841dcb2447bf7da1be5c4/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e", size = 810403, upload-time = "2025-06-10T15:32:11.051Z" },
     { url = "https://files.pythonhosted.org/packages/d5/d2/e369064aa51009eb9245399fd8ad2c562bd0bcd392a00be44b2a824ded7c/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3bb4b927929b0cb162fb1605392a321e3333e48ce616cdcfa04a839271373255", size = 835581, upload-time = "2025-06-10T15:32:12.897Z" },
     { url = "https://files.pythonhosted.org/packages/c0/28/26534bed77109632a956977f60d8519049f545abc39215d086e33a61f1f2/pyyaml_ft-8.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793", size = 171579, upload-time = "2025-06-10T15:32:14.34Z" },
+]
+
+[[package]]
+name = "rasterio"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "affine" },
+    { name = "attrs" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "cligj" },
+    { name = "numpy" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/88/edb4b66b6cb2c13f123af5a3896bf70c0cbe73ab3cd4243cb4eb0212a0f6/rasterio-1.5.0.tar.gz", hash = "sha256:1e0ea56b02eea4989b36edf8e58a5a3ef40e1b7edcb04def2603accd5ab3ee7b", size = 452184, upload-time = "2026-01-05T16:06:47.169Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/87/42865a77cebf2e524d27b6afc71db48984799ecd1dbe6a213d4713f42f5f/rasterio-1.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e7b25b0a19975ccd511e507e6de45b0a2d8fb6802abe49bb726cf48588e34833", size = 22776107, upload-time = "2026-01-05T16:05:36.967Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/53/e81683fbbfdf04e019e68b042d9cff8524b0571aa80e4f4d81c373c31a49/rasterio-1.5.0-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:1162c18eaece9f6d2aa1c2ff6b373b99651d93f113f24120a991eaebf28aa4f4", size = 24401477, upload-time = "2026-01-05T16:05:39.702Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/3c/6aa6e0690b18eea02a61739cb362a47c5df66138f0a02cc69e1181b964e5/rasterio-1.5.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:8eb87fd6f843eea109f3df9bef83f741b053b716b0465932276e2c0577dfb929", size = 36018214, upload-time = "2026-01-05T16:05:42.741Z" },
+    { url = "https://files.pythonhosted.org/packages/48/4a/1af9aa9810fb30668568f2c4dd3eec2412c8e9762b69201d971c509b295e/rasterio-1.5.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:08a7580cbb9b3bd320bdf827e10c9b2424d0df066d8eef6f2feb37e154ce0c17", size = 37544972, upload-time = "2026-01-05T16:05:45.815Z" },
+    { url = "https://files.pythonhosted.org/packages/01/62/bfe3408743c9837919ff232474a09ece9eaa88d4ee8c040711fa3dff6dad/rasterio-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:d7d6729c0739b5ec48c33686668a30e27f5bdb361093f180ee7818ff19665547", size = 30140141, upload-time = "2026-01-05T16:05:48.751Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ca/e90e19a6d065a718cc3d468a12b9f015289ad17017656dea8c76f7318d1f/rasterio-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:8af7c368c22f0a99d1259ccc5a5cd96c432c2bde6f132c1ac78508cd7445a745", size = 28498556, upload-time = "2026-01-05T16:05:51.334Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ba/e37462d8c33bbbd6c152a0390ec6911a3d9614ded3d2bc6f6a48e147e833/rasterio-1.5.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:b4ccfcc8ed9400e4f14efdf2005533fcf72048748b727f85ff89b9291ecdf98a", size = 22920107, upload-time = "2026-01-05T16:05:53.773Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/7bfa9cf96ac39b451b2f94dfc584c223ec584c52c148df2e4bab60c3341b/rasterio-1.5.0-cp313-cp313t-macosx_15_0_x86_64.whl", hash = "sha256:2f57c36ca4d3c896f7024226bd71eeb5cd10c8183c2a94508534d78cc05ff9e7", size = 24508993, upload-time = "2026-01-05T16:05:57.062Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/55/7293743f3b69de4b726c67b8dc9da01fc194070b6becc51add4ca8a20a27/rasterio-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cc1395475e4bb7032cd81dda4d5558061c4c7d5a50b1b5e146bdf9716d0b9353", size = 36565784, upload-time = "2026-01-05T16:06:00.019Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ef/5354c47de16c6e289728c3a3d6961ffcf7a9ad6313aef7e8db5d6a40c46e/rasterio-1.5.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:592a485e2057b1aaeab4f843c9897628e60e3ff45e2509325c3e1479116599cb", size = 37686456, upload-time = "2026-01-05T16:06:02.772Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/fc/fe1f034b1acd1900d9fbd616826d001a3d5811f1d0c97c785f88f525853e/rasterio-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:0c739e70a72fb080f039ee1570c5d02b974dde32ded1a3216e1f13fe38ac4844", size = 30355842, upload-time = "2026-01-05T16:06:06.359Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/cb/4dee9697891c9c6474b240d00e27688e03ecd882d3c83cc97eb25c2266ff/rasterio-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:a3539a2f401a7b4b2e94ff2db334878c0e15a2d1c9fe90bb0879c52f89367ae5", size = 28589538, upload-time = "2026-01-05T16:06:09.662Z" },
+    { url = "https://files.pythonhosted.org/packages/77/9f/f84dfa54110c1c82f9f4fd929465d12519569b6f5d015273aa0957013b2e/rasterio-1.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:597be8df418d5ba7b6a927b6b9febfcb42b192882448a8d5b2e2e75a1296631f", size = 22788832, upload-time = "2026-01-05T16:06:12.247Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f1/de55255c918b17afd7292f793a3500c4aea7e9530b2b3f5b3a57836c7d49/rasterio-1.5.0-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:dd292030d39d685c0b35eddef233e7f1cb8b43052578a3ec97a2da57799693be", size = 24405917, upload-time = "2026-01-05T16:06:14.603Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/57/054087a9d5011ad5dfa799277ba8814e41775e1967d37a59ab7b8e2f1876/rasterio-1.5.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:62c3f97a3c72643c74f2d0f310621a09c35c0c412229c327ae6bcc1ee4b9c3bc", size = 35987536, upload-time = "2026-01-05T16:06:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/72/5fbe5f67ae75d7e89ffb718c500d5fecbaa84f6ba354db306de689faf961/rasterio-1.5.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:19577f0f0c5f1158af47b57f73356961cbd1782a5f6ae6f3adf6f2650f4eb369", size = 37408048, upload-time = "2026-01-05T16:06:20.82Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3e/0c4ef19980204bdcbc8f9e084056adebc97916ff4edcc718750ef34e5bf9/rasterio-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:015c1ab6e5453312c5e29692752e7ad73568fe4d13567cbd448d7893128cbd2d", size = 30949590, upload-time = "2026-01-05T16:06:23.425Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d8/2e6b81505408926c00e629d7d3d73fd0454213201bd9907450e0fe82f3dd/rasterio-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:ff677c0a9d3ba667c067227ef2b76872488b37ff29b061bc3e576fad9baa3286", size = 29337287, upload-time = "2026-01-05T16:06:26.599Z" },
+    { url = "https://files.pythonhosted.org/packages/19/49/7b6e6afb28d4e3f69f2229f990ed87dfdc21a3e15ca63b96b2fd9ba17d89/rasterio-1.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:508251b9c746d8d008771a30c2160ff321bfc3b41f6a1aa8e8ef1dd4a00d97ba", size = 22926149, upload-time = "2026-01-05T16:06:29.617Z" },
+    { url = "https://files.pythonhosted.org/packages/24/30/19345d8bc7d2b96c1172594026b9009702e9ab9f0baf07079d3612aaadae/rasterio-1.5.0-cp314-cp314t-macosx_15_0_x86_64.whl", hash = "sha256:742841ed48bc70f6ef517b8fa3521f231780bf408fde0aa6d73770337a36374e", size = 24516040, upload-time = "2026-01-05T16:06:32.964Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/43/dc7a4518fa78904bc41952cbf346c3c2a88a20e61b479154058392914c0b/rasterio-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c9a9eee49ce9410c2f352b34c370bb3a96bb518b6a7f97b3a72ee4c835fd4b5c", size = 36589519, upload-time = "2026-01-05T16:06:35.922Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f2/8f706083c6c163054d12c7ed6d5ac4e4ed02252b761288d74e6158871b34/rasterio-1.5.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b9fd87a0b63ab5c6267dfb0bc96f54fdf49d000651b9ee85ed37798141cff046", size = 37714599, upload-time = "2026-01-05T16:06:38.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/d5/bbca726d5fea5864f7e4bcf3ee893095369e93ad51120495e8c40e2aa1a0/rasterio-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f459db8953ba30ca04fcef2b5e1260eeeff0eae8158bd9c3d6adbe56289765cc", size = 31233931, upload-time = "2026-01-05T16:06:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d1/8b017856e63ccaff3cbd0e82490dbb01363a42f3a462a41b1d8a391e1443/rasterio-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f4b9c2c3b5f10469eb9588f105086e68f0279e62cc9095c4edd245e3f9b88c8a", size = 29418321, upload-time = "2026-01-05T16:06:44.758Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Changes:
* Adds a data collector for elevation data (from the [USGS 3DEP data source](https://www.usgs.gov/3d-elevation-program)). Closes #267
    * Adds `rasterio` dependency and tooling to ingest raster data.
* Integrates elevation into the stress-weighting modeling. Closes #268 
* Implements dbt pipeline generator class to generate elevation-cost pipelines and set tests on the generated dbt models. Closes #269 
* Updates the graph format and exporting tooling as well as the rust routing implementation to factor in the elevation costs in. Closes #270
* Improves the RouteTesting framework to support geometric `must_cross` and `must_not_cross` linestring inputs to indicate required and prohibited routes. Adds route tests for SF and Portland that check for elevation influencing the route. Closes #271
    * Alters frontend to show the elevation cost on hover-over (although I suppose it is misleading to show it in meters; I should make it more clear that the meters are like "meters-of-low-stress-riding-equivalent").


<img width="1532" height="1407" alt="Screenshot from 2026-06-16 19-38-16" src="https://github.com/user-attachments/assets/e74b4fab-dcad-4194-899f-ae9293dc6c79" />

Deployed to dev.


Also added some raster inspection tooling to explore raster data.
<img width="628" height="662" alt="Screenshot from 2026-06-16 19-17-01" src="https://github.com/user-attachments/assets/b8f40fc1-f5ab-45eb-9039-13e7f11529d1" />

<img width="631" height="630" alt="Screenshot from 2026-06-16 19-17-29" src="https://github.com/user-attachments/assets/8611bda4-75d5-48f4-81cb-aaa90de07782" />
