### PR TITLE
Adds nyc bike infra map

### DIFF
--- a/apps/bike-map/config/dev/nyc.json
+++ b/apps/bike-map/config/dev/nyc.json
@@ -1,15 +1,15 @@
 {
-  "city_name": "New Orleans",
+  "city_name": "New York City",
   "log_endpoint": "<log_endpoint>",
   "routing_api_url": "<routing_api_url>",
   "routing_api_key": "<routing_api_key>",
-  "map_center": [-90.08, 29.96],
+  "map_center": [-73.98, 40.70],
   "map_zoom": 11,
   "map_bbox": {
-    "south": 29.79,
-    "west": -90.34,
-    "north": 30.19,
-    "east": -89.60
+    "south": 40.48,
+    "west": -74.26,
+    "north": 40.93,
+    "east": -73.70
   },
   "layers": [
     {
@@ -59,11 +59,11 @@
     }
   ],
   "about_paragraphs": [
-    "New Orleans Bike Map helps you explore cycling conditions around the city.",
+    "Washington DC Bike Map helps you explore cycling conditions around the city.",
     "Routes prefer streets with better bike infrastructure, lower speed limits, and less severe recent crash history, even if that means a slightly longer ride. We recommend always wearing a helmet while riding.",
     "Routes are generated using OpenStreetMap data that may be incomplete or outdated. Route suggestions are informational and are no substitute for your own judgment while riding."
   ],
-  "terms_what_is": "New Orleans Bike Map is a personal project that displays cycling-related data for the New Orleans area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
+  "terms_what_is": "Washington DC Bike Map is a personal project that displays cycling-related data for the Washington DC area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
   "terms_data_sources": "Map data comes from OpenStreetMap contributors and is subject to the <a href=\"https://opendatacommons.org/licenses/odbl/\" target=\"_blank\" rel=\"noopener\">ODbL license</a>. This project does not independently verify the accuracy or completeness of any of these sources.",
-  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of New Orleans Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
+  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of Washington DC Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
 }

--- a/apps/bike-map/config/prod/nola.json
+++ b/apps/bike-map/config/prod/nola.json
@@ -59,11 +59,11 @@
     }
   ],
   "about_paragraphs": [
-    "Washington DC Bike Map helps you explore cycling conditions around the city.",
+    "New Orleans Bike Map helps you explore cycling conditions around the city.",
     "Routes prefer streets with better bike infrastructure, lower speed limits, and less severe recent crash history, even if that means a slightly longer ride. We recommend always wearing a helmet while riding.",
     "Routes are generated using OpenStreetMap data that may be incomplete or outdated. Route suggestions are informational and are no substitute for your own judgment while riding."
   ],
-  "terms_what_is": "Washington DC Bike Map is a personal project that displays cycling-related data for the Washington DC area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
+  "terms_what_is": "New Orleans Bike Map is a personal project that displays cycling-related data for the New Orleans area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
   "terms_data_sources": "Map data comes from OpenStreetMap contributors and is subject to the <a href=\"https://opendatacommons.org/licenses/odbl/\" target=\"_blank\" rel=\"noopener\">ODbL license</a>. This project does not independently verify the accuracy or completeness of any of these sources.",
-  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of Washington DC Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
+  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of New Orleans Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
 }

--- a/apps/bike-map/config/prod/nyc.json
+++ b/apps/bike-map/config/prod/nyc.json
@@ -1,15 +1,15 @@
 {
-  "city_name": "New Orleans",
+  "city_name": "New York City",
   "log_endpoint": "<log_endpoint>",
   "routing_api_url": "<routing_api_url>",
   "routing_api_key": "<routing_api_key>",
-  "map_center": [-90.08, 29.96],
+  "map_center": [-73.98, 40.70],
   "map_zoom": 11,
   "map_bbox": {
-    "south": 29.79,
-    "west": -90.34,
-    "north": 30.19,
-    "east": -89.60
+    "south": 40.48,
+    "west": -74.26,
+    "north": 40.93,
+    "east": -73.70
   },
   "layers": [
     {
@@ -59,11 +59,11 @@
     }
   ],
   "about_paragraphs": [
-    "New Orleans Bike Map helps you explore cycling conditions around the city.",
+    "Washington DC Bike Map helps you explore cycling conditions around the city.",
     "Routes prefer streets with better bike infrastructure, lower speed limits, and less severe recent crash history, even if that means a slightly longer ride. We recommend always wearing a helmet while riding.",
     "Routes are generated using OpenStreetMap data that may be incomplete or outdated. Route suggestions are informational and are no substitute for your own judgment while riding."
   ],
-  "terms_what_is": "New Orleans Bike Map is a personal project that displays cycling-related data for the New Orleans area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
+  "terms_what_is": "Washington DC Bike Map is a personal project that displays cycling-related data for the Washington DC area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
   "terms_data_sources": "Map data comes from OpenStreetMap contributors and is subject to the <a href=\"https://opendatacommons.org/licenses/odbl/\" target=\"_blank\" rel=\"noopener\">ODbL license</a>. This project does not independently verify the accuracy or completeness of any of these sources.",
-  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of New Orleans Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
+  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of Washington DC Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
 }

--- a/apps/bike-map/config/staging/nola.json
+++ b/apps/bike-map/config/staging/nola.json
@@ -59,11 +59,11 @@
     }
   ],
   "about_paragraphs": [
-    "Washington DC Bike Map helps you explore cycling conditions around the city.",
+    "New Orleans Bike Map helps you explore cycling conditions around the city.",
     "Routes prefer streets with better bike infrastructure, lower speed limits, and less severe recent crash history, even if that means a slightly longer ride. We recommend always wearing a helmet while riding.",
     "Routes are generated using OpenStreetMap data that may be incomplete or outdated. Route suggestions are informational and are no substitute for your own judgment while riding."
   ],
-  "terms_what_is": "Washington DC Bike Map is a personal project that displays cycling-related data for the Washington DC area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
+  "terms_what_is": "New Orleans Bike Map is a personal project that displays cycling-related data for the New Orleans area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
   "terms_data_sources": "Map data comes from OpenStreetMap contributors and is subject to the <a href=\"https://opendatacommons.org/licenses/odbl/\" target=\"_blank\" rel=\"noopener\">ODbL license</a>. This project does not independently verify the accuracy or completeness of any of these sources.",
-  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of Washington DC Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
+  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of New Orleans Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
 }

--- a/apps/bike-map/config/staging/nyc.json
+++ b/apps/bike-map/config/staging/nyc.json
@@ -1,15 +1,15 @@
 {
-  "city_name": "New Orleans",
+  "city_name": "New York City",
   "log_endpoint": "<log_endpoint>",
   "routing_api_url": "<routing_api_url>",
   "routing_api_key": "<routing_api_key>",
-  "map_center": [-90.08, 29.96],
+  "map_center": [-73.98, 40.70],
   "map_zoom": 11,
   "map_bbox": {
-    "south": 29.79,
-    "west": -90.34,
-    "north": 30.19,
-    "east": -89.60
+    "south": 40.48,
+    "west": -74.26,
+    "north": 40.93,
+    "east": -73.70
   },
   "layers": [
     {
@@ -59,11 +59,11 @@
     }
   ],
   "about_paragraphs": [
-    "New Orleans Bike Map helps you explore cycling conditions around the city.",
+    "Washington DC Bike Map helps you explore cycling conditions around the city.",
     "Routes prefer streets with better bike infrastructure, lower speed limits, and less severe recent crash history, even if that means a slightly longer ride. We recommend always wearing a helmet while riding.",
     "Routes are generated using OpenStreetMap data that may be incomplete or outdated. Route suggestions are informational and are no substitute for your own judgment while riding."
   ],
-  "terms_what_is": "New Orleans Bike Map is a personal project that displays cycling-related data for the New Orleans area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
+  "terms_what_is": "Washington DC Bike Map is a personal project that displays cycling-related data for the Washington DC area and generates route suggestions based on publicly available data. It is not a commercial product, and it is not offered by a licensed transportation, safety, or engineering professional.",
   "terms_data_sources": "Map data comes from OpenStreetMap contributors and is subject to the <a href=\"https://opendatacommons.org/licenses/odbl/\" target=\"_blank\" rel=\"noopener\">ODbL license</a>. This project does not independently verify the accuracy or completeness of any of these sources.",
-  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of New Orleans Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
+  "terms_liability": "This project is provided \"as is\" without warranties of any kind, express or implied. To the fullest extent permitted by law, the creator of Washington DC Bike Map shall not be liable for any damages arising from your use of or reliance on this application, including but not limited to personal injury, property damage, or data loss."
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -53,6 +53,7 @@ variable "routing_lambda_memory_by_city" {
     detroit  = 1024
     madison  = 512
     nola     = 512
+    nyc      = 1536
     portland = 1024
     sf       = 1536
     toronto  = 1024

--- a/platform/airflow/dags/dag_files/refresh_bike_map_all.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_all.py
@@ -28,6 +28,7 @@ CITIES = [
     "detroit",
     "madison",
     "nola",
+    "nyc",
     "portland",
     "sf",
     "toronto",

--- a/platform/airflow/dags/dag_files/refresh_bike_map_nyc.py
+++ b/platform/airflow/dags/dag_files/refresh_bike_map_nyc.py
@@ -1,0 +1,61 @@
+# loci_platform/platform/airflow/dags/dag_files/refresh_bike_map_nola.py
+"""Refresh the New Orleans bike map: dbt build → export → deploy."""
+
+from datetime import datetime
+
+from airflow.sdk import dag
+from loci.apps.bike_map import data_layers
+from loci.exports.bike_map_layers import LayerDisplayConfig
+from loci.exports.geojson_export import GeoJSONExportConfig
+from loci.sources.dataset_specs import NYC_BBOX
+from loci.tasks.bike_map_tasks import (
+    CityBuildSpec,
+    build_refresh_task_graph,
+    standard_dag_params,
+)
+from loci.tasks.testing.route_tests import RouteTestCase
+
+CITY = "nyc"
+
+CITY_GEOJSON_EXPORTS: list[GeoJSONExportConfig] = [
+    data_layers.bikeindex_bike_theft_geojson_config_factory(CITY),
+    data_layers.osm_bike_parking_geojson_config_factory(CITY),
+]
+
+CITY_LAYER_DISPLAYS: list[LayerDisplayConfig] = [
+    data_layers.BIKEINDEX_BIKE_THEFTS_LAYER_CONFIG,
+    data_layers.OSM_BIKE_PARKING_LAYER_CONFIG,
+]
+
+CITY_ROUTE_TESTS: list[RouteTestCase] = []
+
+ROUTABLE_ORIGIN_DEST_PAIR = ((29.9268, -90.0814), (29.9574, -90.0628))
+
+CITY_SPEC = CityBuildSpec(
+    city=CITY,
+    bbox=NYC_BBOX,
+    pre_export_dbt_selects=[
+        ("--select", f"+{CITY}_bikeindex_bike_thefts"),
+        ("--select", f"+{CITY}_osm_bike_parking"),
+    ],
+    geojson_exports=CITY_GEOJSON_EXPORTS,
+    layer_displays=CITY_LAYER_DISPLAYS,
+    weights_dbt_select=f"+{CITY}_bike_stress_weighted_segments",
+    route_tests=CITY_ROUTE_TESTS,
+    synthetic_check_fixture=ROUTABLE_ORIGIN_DEST_PAIR,
+)
+
+
+@dag(
+    dag_id=f"refresh_bike_map_{CITY}",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["bike-map", "nyc", CITY],
+    params=standard_dag_params(CITY),
+)
+def refresh_bike_map_nyc():
+    build_refresh_task_graph(CITY_SPEC)
+
+
+refresh_bike_map_nyc()

--- a/platform/airflow/dags/dag_files/threedep/update_nyc_3dep_elevation.py
+++ b/platform/airflow/dags/dag_files/threedep/update_nyc_3dep_elevation.py
@@ -1,0 +1,28 @@
+import datetime as dt
+from logging import getLogger
+
+from airflow.sdk import dag
+from loci.collectors.threedep.taskflow import update_threedep_table
+from loci.sources.update_configs import NYC_3DEP_ELEVATION_UC as UPDATE_CONFIG
+
+task_logger = getLogger("airflow.task")
+
+
+CONN_ID = "gis_dwh_db"
+
+
+@dag(
+    schedule=UPDATE_CONFIG.update_cron,
+    start_date=dt.datetime(2022, 11, 1),
+    catchup=False,
+    tags=["nyc", "3dep", "elevation"],
+)
+def update_nyc_3dep_elevation():
+    update_threedep_table(
+        conn_id=CONN_ID,
+        update_config=UPDATE_CONFIG,
+        task_logger=task_logger,
+    )
+
+
+update_nyc_3dep_elevation()

--- a/platform/airflow/dags/loci/environments.py
+++ b/platform/airflow/dags/loci/environments.py
@@ -43,6 +43,7 @@ VALID_CITIES = (
     "detroit",
     "madison",
     "nola",
+    "nyc",
     "portland",
     "sf",
     "toronto",

--- a/platform/airflow/dags/loci/sources/dataset_specs.py
+++ b/platform/airflow/dags/loci/sources/dataset_specs.py
@@ -580,7 +580,7 @@ DETROIT_BBOX = BBox(42.18, -83.40, 42.56, -82.84)
 LOS_ANGELES_BBOX = BBox(33.69, -118.72, 34.38, -118.02)
 MADISON_BBOX = BBox(42.96, -89.60, 43.21, -89.21)
 NEW_ORLEANS_BBOX = BBox(29.79, -90.34, 30.19, -89.60)
-NEW_YORK_CITY_BBOX = BBox(40.48, -74.26, 40.93, -73.70)
+NYC_BBOX = BBox(40.48, -74.26, 40.93, -73.70)
 PORTLAND_BBOX = BBox(45.41, -122.86, 45.66, -122.46)
 SAN_FRANCISCO_BBOX = BBox(37.18, -122.59, 38.00, -121.73)
 SEATTLE_BBOX = BBox(47.47, -122.48, 47.78, -122.04)
@@ -901,10 +901,10 @@ NEW_ORLEANS_OSM_BIKE_NETWORK_NODES_SPEC = generate_osm_bike_network_nodes_spec(
 )
 
 NYC_OSM_BIKE_NETWORK_EDGES_SPEC = generate_osm_bike_network_edges_spec(
-    city="nyc", bbox=NEW_YORK_CITY_BBOX
+    city="nyc", bbox=NYC_BBOX
 )
 NYC_OSM_BIKE_NETWORK_NODES_SPEC = generate_osm_bike_network_nodes_spec(
-    city="nyc", bbox=NEW_YORK_CITY_BBOX
+    city="nyc", bbox=NYC_BBOX
 )
 
 PORTLAND_OSM_BIKE_NETWORK_EDGES_SPEC = generate_osm_bike_network_edges_spec(
@@ -948,7 +948,7 @@ NEW_ORLEANS_OSM_BIKE_PARKING_SPEC = generate_osm_bike_parking_spec(
     city="nola", bbox=NEW_ORLEANS_BBOX
 )
 
-NYC_OSM_BIKE_PARKING_SPEC = generate_osm_bike_parking_spec(city="nyc", bbox=NEW_YORK_CITY_BBOX)
+NYC_OSM_BIKE_PARKING_SPEC = generate_osm_bike_parking_spec(city="nyc", bbox=NYC_BBOX)
 
 PORTLAND_OSM_BIKE_PARKING_SPEC = generate_osm_bike_parking_spec(city="portland", bbox=PORTLAND_BBOX)
 
@@ -1775,5 +1775,6 @@ DENVER_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="denver", bbox=DE
 DETROIT_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="detroit", bbox=DENVER_BBOX)
 MADISON_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="madison", bbox=MADISON_BBOX)
 NOLA_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="nola", bbox=NEW_ORLEANS_BBOX)
+NYC_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="nyc", bbox=NYC_BBOX)
 PORTLAND_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="portland", bbox=PORTLAND_BBOX)
 SF_3DEP_ELEVATION_SPEC = generate_3dep_elevation_spec(city="sf", bbox=SAN_FRANCISCO_BBOX)

--- a/platform/airflow/dags/loci/sources/update_configs.py
+++ b/platform/airflow/dags/loci/sources/update_configs.py
@@ -1064,6 +1064,13 @@ NOLA_3DEP_ELEVATION_UC = DatasetUpdateConfig(
     full_update_day_of_week=6,
 )
 
+NYC_3DEP_ELEVATION_UC = DatasetUpdateConfig(
+    spec=specs.NYC_3DEP_ELEVATION_SPEC,
+    update_cron="30 4 10 1 *",
+    full_update_week_of_month=1,
+    full_update_day_of_week=6,
+)
+
 PORTLAND_3DEP_ELEVATION_UC = DatasetUpdateConfig(
     spec=specs.PORTLAND_3DEP_ELEVATION_SPEC,
     update_cron="10 4 10 1 *",

--- a/platform/dbt/models/_threedep_sources.yml
+++ b/platform/dbt/models/_threedep_sources.yml
@@ -13,5 +13,6 @@ sources:
       - name: detroit_3dep_elevation
       - name: madison_3dep_elevation
       - name: nola_3dep_elevation
+      - name: nyc_3dep_elevation
       - name: portland_3dep_elevation
       - name: sf_3dep_elevation

--- a/platform/dbt/models/marts/cycling/nyc/_marts_nyc_cycling.yml
+++ b/platform/dbt/models/marts/cycling/nyc/_marts_nyc_cycling.yml
@@ -1,0 +1,360 @@
+version: 2
+models:
+  - name: nyc_segment_costs
+    description: "Per-segment intrinsic stress costs from OSM physical attributes.\
+      \ physical_cost = length_m * (base_stress_per_meter + surface_penalty + enclosed_penalty\
+      \ + lighting_penalty), where base_stress_per_meter is at least 1.0 \u2014 so\
+      \ physical_cost is always at least length_m."
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - segment_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: physical_cost >= length_m
+          config:
+            name: nyc_segment_costs_physical_cost_at_least_length
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_nyc_bike_segments')
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: way_id
+        data_tests:
+          - not_null
+      - name: start_node_id
+        data_tests:
+          - not_null
+      - name: end_node_id
+        data_tests:
+          - not_null
+      - name: length_m
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                strictly: true
+      - name: geom
+        data_tests:
+          - not_null
+      - name: highway_class
+        description: Bucketed OSM highway value. Drives base_stress_per_meter.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - quiet
+                  - service
+                  - local
+                  - tertiary
+                  - secondary
+                  - primary
+                  - motorway
+      - name: infra_tier
+        description: Bucketed bike-infra quality. Drives base_stress_per_meter.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - protected
+                  - lane
+                  - shared_path
+                  - sharrow
+                  - none
+      - name: base_stress_per_meter
+        description: Per-meter stress cost from the (highway_class, infra_tier) lookup.
+          Minimum 1.0 (cycleway / quiet path).
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1.0
+      - name: surface_penalty
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0.0
+      - name: enclosed_penalty
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0.0
+      - name: lighting_penalty
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0.0
+      - name: physical_cost
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+      - name: infra_category
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - separated
+                  - on_road
+                  - shared
+                  - path
+              config:
+                where: infra_category is not null
+  - name: nyc_intersection_costs
+    description: Logical bike-network intersections with stress penalties. One row
+      per node where >= 2 distinct OSM ways meet. The cost depends on the top two
+      way classes meeting at the node and the traffic-control tag. Joined into nyc_bike_stress_weighted_segments
+      on BOTH endpoints (start_node_id and end_node_id) so the graph exporter can
+      pick the right one per traversal direction.
+    columns:
+      - name: osmid
+        description: OSM node id (unique).
+        data_tests:
+          - not_null
+          - unique
+          - dbt_utils.relationships_where:
+              arguments:
+                to: source('osm', 'nyc_osm_bike_network_nodes')
+                field: osm_id
+                from_condition: traffic_control is not null
+                to_condition: osm_type = 'node' and valid_to is null
+              config:
+                severity: warn
+      - name: traffic_control
+        description: Raw OSM 'highway' tag value on the node, or NULL for uncontrolled
+          intersections.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - traffic_signals
+                  - stop
+                  - crossing
+                  - mini_roundabout
+                  - give_way
+                  - turning_circle
+                  - turning_loop
+                quote: true
+              config:
+                severity: warn
+      - name: max_class
+        description: Highest stress class among the ways meeting at this node. Drives
+          the base intersection cost lookup.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - motorway
+                  - primary
+                  - secondary
+                  - tertiary
+                  - local
+                  - service
+                  - quiet
+      - name: second_max_class
+        description: Second-highest stress class. Used as a tie-break override for
+          local-and-below intersections (e.g. local x service is cheaper than local
+          x local).
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - motorway
+                  - primary
+                  - secondary
+                  - tertiary
+                  - local
+                  - service
+                  - quiet
+      - name: way_count
+        description: Number of distinct ways meeting at this node.
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 2
+      - name: base_cost
+        description: Base intersection cost from the (max_class, second_max_class)
+          lookup, before applying the traffic-control multiplier.
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+      - name: intersection_cost
+        description: Final intersection cost = base_cost * traffic_control_multiplier.
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+  - name: nyc_bike_stress_weighted_segments
+    description: Stress-weighted segments for bike routing. One row per undirected
+      segment; direction is carried as a column. Exposes physical_cost, crash_cost,
+      and intersection costs at BOTH endpoints. The graph exporter composes per-direction
+      stress when expanding each row into one or two directed edges (forward edges
+      pay intersection_cost_at_end; backward edges pay intersection_cost_at_start).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - start_node_id
+              - end_node_id
+              - way_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: physical_cost >= length_m
+          config:
+            name: nyc_stress_weighted_physical_cost_at_least_length
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: crash_cost >= 0
+          config:
+            name: nyc_crash_cost_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: nyc_stress_weighted_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: nyc_stress_weighted_elevation_cost_backward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: intersection_cost_at_start >= 0
+          config:
+            name: nyc_intersection_cost_at_start_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: intersection_cost_at_end >= 0
+          config:
+            name: nyc_intersection_cost_at_end_non_negative
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_nyc_bike_segments')
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        data_tests:
+          - not_null
+      - name: end_node_id
+        data_tests:
+          - not_null
+      - name: way_id
+        data_tests:
+          - not_null
+      - name: length_m
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                strictly: true
+      - name: geom
+        data_tests:
+          - not_null
+      - name: physical_cost
+        data_tests:
+          - not_null
+      - name: crash_cost
+        data_tests:
+          - not_null
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null
+      - name: intersection_cost_at_start
+        description: Intersection cost at the start of the segment. Paid by backward-direction
+          edges (which approach the start).
+        data_tests:
+          - not_null
+      - name: intersection_cost_at_end
+        description: Intersection cost at the end of the segment. Paid by forward-direction
+          edges (which approach the end).
+        data_tests:
+          - not_null
+      - name: start_is_intersection
+        description: True iff start_node_id appears in nyc_intersection_costs. Propagated
+          through the graph format so the routing service doesn't have to re-derive
+          it from edge degree.
+        data_tests:
+          - not_null
+      - name: end_is_intersection
+        data_tests:
+          - not_null
+      - name: base_stress_per_meter
+        data_tests:
+          - not_null
+      - name: surface_penalty
+        data_tests:
+          - not_null
+      - name: enclosed_penalty
+        data_tests:
+          - not_null
+      - name: lighting_penalty
+        data_tests:
+          - not_null
+  - name: nyc_segment_elevation_costs
+    description: Directional elevation cost per segment from the endpoint elevation
+      delta, quadratic in grade with separate up/down coefficients. One row per segment_id.
+      Costs coalesce to 0 on a coverage gap (treated as flat).
+    data_tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: ref('stg_nyc_bike_segments')
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_forward >= 0
+          config:
+            name: nyc_elevation_cost_forward_non_negative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: elevation_cost_backward >= 0
+          config:
+            name: nyc_elevation_cost_backward_non_negative
+    columns:
+      - name: segment_id
+        data_tests:
+          - not_null
+          - unique
+      - name: start_node_id
+        description: "Completeness check \u2014 every endpoint must resolve in node_elevations."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_nyc_node_elevations')
+                field: node_id
+      - name: end_node_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_nyc_node_elevations')
+                field: node_id
+      - name: elevation_cost_forward
+        data_tests:
+          - not_null
+      - name: elevation_cost_backward
+        data_tests:
+          - not_null

--- a/platform/dbt/models/marts/cycling/nyc/nyc_bike_stress_weighted_segments.sql
+++ b/platform/dbt/models/marts/cycling/nyc/nyc_bike_stress_weighted_segments.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized='table',
+    pre_hook=["SET work_mem = '256MB'"],
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (segment_id)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "RESET work_mem"
+    ]
+) }}
+
+{{ generate_city_bike_stress_weighted_segments_model('nyc', include_crashes=false, include_elevation=true) }}

--- a/platform/dbt/models/marts/cycling/nyc/nyc_bikeindex_bike_thefts.sql
+++ b/platform/dbt/models/marts/cycling/nyc/nyc_bikeindex_bike_thefts.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_bikeindex_bike_thefts_model('nyc', time_zone = 'America/New_York') }}

--- a/platform/dbt/models/marts/cycling/nyc/nyc_intersection_costs.sql
+++ b/platform/dbt/models/marts/cycling/nyc/nyc_intersection_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_intersection_costs_model('nyc') }}

--- a/platform/dbt/models/marts/cycling/nyc/nyc_osm_bike_parking.sql
+++ b/platform/dbt/models/marts/cycling/nyc/nyc_osm_bike_parking.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_osm_bike_parking_model('nyc') }}

--- a/platform/dbt/models/marts/cycling/nyc/nyc_segment_costs.sql
+++ b/platform/dbt/models/marts/cycling/nyc/nyc_segment_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_costs_model('nyc') }}

--- a/platform/dbt/models/marts/cycling/nyc/nyc_segment_elevation_costs.sql
+++ b/platform/dbt/models/marts/cycling/nyc/nyc_segment_elevation_costs.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_city_segment_elevation_costs_model('nyc') }}

--- a/platform/dbt/models/staging/cycling/nyc/_stg_nyc_cycling.yml
+++ b/platform/dbt/models/staging/cycling/nyc/_stg_nyc_cycling.yml
@@ -1,0 +1,116 @@
+version: 2
+models:
+  - name: stg_nyc_bike_ways
+    columns:
+      - name: osm_id
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: node_ids
+        data_tests:
+          - not_null
+      - name: node_count
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 2
+      - name: highway
+        data_tests:
+          - dbt_utils.not_empty_string
+  - name: stg_nyc_way_nodes
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - way_id
+              - position
+    columns:
+      - name: way_id
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_nyc_bike_ways')
+                field: osm_id
+      - name: position
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: node_id
+        data_tests:
+          - not_null
+  - name: stg_nyc_intersection_nodes
+    data_tests:
+      - intersection_node_count_in_range:
+          arguments:
+            way_nodes_model: ref('stg_nyc_way_nodes')
+    columns:
+      - name: node_id
+        data_tests:
+          - not_null
+          - unique
+  - name: stg_nyc_way_segments
+    data_tests:
+      - segment_endpoints_match_node_ids:
+          arguments:
+            ways_model: ref('stg_nyc_bike_ways')
+      - segments_cover_full_ways:
+          arguments:
+            way_nodes_model: ref('stg_nyc_way_nodes')
+            intersection_nodes_model: ref('stg_nyc_intersection_nodes')
+      - segment_geom_endpoints_match_node_positions:
+          arguments:
+            ways_model: ref('stg_nyc_bike_ways')
+  - name: stg_nyc_elevation_tiles
+    description: Precomputed convex-hull footprints for the current 3DEP sub-tiles,
+      used for indexed node-to-tile resolution during elevation sampling. One row
+      per current tile_id.
+    columns:
+      - name: tile_id
+        description: Sub-tile identifier, namespaced by 1-degree tile (<name>/<row>_<col>).
+        data_tests:
+          - not_null
+          - unique
+      - name: hull
+        description: Tile convex hull (geometry, 4269). NULL would silently drop the
+          tile's coverage.
+        data_tests:
+          - not_null
+  - name: stg_nyc_node_elevations
+    description: 'One row per routing-graph node with its bare-earth elevation sampled
+      from the city''s 3DEP DEM. elevation_m is intentionally nullable: a node outside
+      coverage or on a nodata pixel (e.g. open water) is NULL and treated as flat
+      downstream.'
+    columns:
+      - name: node_id
+        description: OSM node id. unique is the regression guard for the one-row-per-node
+          grain the lateral limit-1 resolution guarantees.
+        data_tests:
+          - not_null
+          - unique
+      - name: geom
+        data_tests:
+          - not_null
+      - name: elevation_m
+        description: 'NAVD88 meters, or NULL on a coverage gap. The range bound catches
+          nodata sentinels (-9999, +/-3.4e38) leaking through as numbers and gross
+          unit errors; checked only on non-null rows. Bounds are loose on purpose:
+          they span every target metro (Denver sits near 1600 m), so they flag sentinels,
+          not tight validation.'
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -100
+                max_value: 4500
+              config:
+                where: elevation_m is not null
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.98
+              config:
+                severity: warn

--- a/platform/dbt/models/staging/cycling/nyc/stg_nyc_bike_segments.sql
+++ b/platform/dbt/models/staging/cycling/nyc/stg_nyc_bike_segments.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} (way_id, start_position, end_position)",
+        "CREATE INDEX ON {{ this }} (start_node_id)",
+        "CREATE INDEX ON {{ this }} (end_node_id)",
+        "CREATE INDEX ON {{ this }} USING GIST (geom)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_bike_segments_model('nyc') }}

--- a/platform/dbt/models/staging/cycling/nyc/stg_nyc_bike_ways.sql
+++ b/platform/dbt/models/staging/cycling/nyc/stg_nyc_bike_ways.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_bike_ways_model('nyc', include_all_sidewalks=false) }}

--- a/platform/dbt/models/staging/cycling/nyc/stg_nyc_bikeindex_bike_thefts.sql
+++ b/platform/dbt/models/staging/cycling/nyc/stg_nyc_bikeindex_bike_thefts.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_bikeindex_bike_thefts_model('nyc') }}

--- a/platform/dbt/models/staging/cycling/nyc/stg_nyc_elevation_tiles.sql
+++ b/platform/dbt/models/staging/cycling/nyc/stg_nyc_elevation_tiles.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='table',
+    post_hook=[
+        "CREATE INDEX ON {{ this }} USING GIST (hull)",
+        "ANALYZE {{ this }}"
+    ]
+) }}
+
+{{ generate_stg_city_elevation_tiles_model('nyc') }}

--- a/platform/dbt/models/staging/cycling/nyc/stg_nyc_intersection_nodes.sql
+++ b/platform/dbt/models/staging/cycling/nyc/stg_nyc_intersection_nodes.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_intersection_nodes_model('nyc') }}

--- a/platform/dbt/models/staging/cycling/nyc/stg_nyc_node_elevations.sql
+++ b/platform/dbt/models/staging/cycling/nyc/stg_nyc_node_elevations.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_node_elevations_model('nyc') }}

--- a/platform/dbt/models/staging/cycling/nyc/stg_nyc_osm_bike_infra.sql
+++ b/platform/dbt/models/staging/cycling/nyc/stg_nyc_osm_bike_infra.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_osm_bike_infra_model('nyc', include_all_sidewalks=false) }}

--- a/platform/dbt/models/staging/cycling/nyc/stg_nyc_osm_bike_parking.sql
+++ b/platform/dbt/models/staging/cycling/nyc/stg_nyc_osm_bike_parking.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_osm_bike_parking_model('nyc') }}

--- a/platform/dbt/models/staging/cycling/nyc/stg_nyc_way_nodes.sql
+++ b/platform/dbt/models/staging/cycling/nyc/stg_nyc_way_nodes.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_way_nodes_model('nyc') }}

--- a/platform/dbt/models/staging/cycling/nyc/stg_nyc_way_segments.sql
+++ b/platform/dbt/models/staging/cycling/nyc/stg_nyc_way_segments.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='table') }}
+
+{{ generate_stg_city_way_segments_model('nyc') }}

--- a/platform/migrations/postgres/V58__adds_usgs_3dep_elevation_tables.sql
+++ b/platform/migrations/postgres/V58__adds_usgs_3dep_elevation_tables.sql
@@ -1,0 +1,23 @@
+create table if not exists raw_data.nyc_3dep_elevation (
+    "tile_id" text not null,
+    "rast" raster not null,
+    "checksum" text not null,
+    "srid" integer not null,
+    "min_x" double precision,
+    "min_y" double precision,
+    "max_x" double precision,
+    "max_y" double precision,
+    "ingested_at" timestamptz not null default (now() at time zone 'UTC'),
+    "record_hash" text not null,
+    "valid_from" timestamptz not null default (now() at time zone 'UTC'),
+    "valid_to" timestamptz
+);
+alter table raw_data.nyc_3dep_elevation
+    add constraint uq_nyc_3dep_elevation_entity_hash
+    unique ("tile_id", "record_hash");
+create index if not exists ix_nyc_3dep_elevation_current
+    on raw_data.nyc_3dep_elevation ("tile_id")
+    where "valid_to" is null;
+create index if not exists ix_nyc_3dep_elevation_rast
+    on raw_data.nyc_3dep_elevation using gist (ST_ConvexHull(rast))
+    where "valid_to" is null;


### PR DESCRIPTION
Changes:
* Adds bikeinfra site for NYC (live at [nyc.bikeindex.com](https://nyc.bikeinfra.com/), closes #218)
    * Adds DAGs to collect NYC elevation data, as well as a NYC bike-index deployment DAG.
    * Adds NYC to the landing page.
    * Builds out the standard base pipeline for NYC.
* Corrects the city name used in text on the New Orleans site.


<img width="2288" height="2164" alt="image" src="https://github.com/user-attachments/assets/ed1313fd-a4b8-474b-966e-7c2129de164c" />
